### PR TITLE
Add cargo build support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@
 **/Cargo.lock
 .deps/
 */src/stm32*/
+src/lib.rs
 html/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,81 @@
+[package]
+name = "stm32"
+version = "0.6.0"
+authors = ["Adam Greig <adam@adamgreig.com>"]
+description = "Device support crates for STM32 devices"
+repository = "https://github.com/stm32-rs/stm32-rs"
+readme = "README.md"
+keywords = ["stm32", "svd2rust", "no_std", "embedded"]
+categories = ["embedded", "no-std"]
+license = "MIT/Apache-2.0"
+
+[lib]
+path = "src/lib.rs"
+
+[build-dependencies]
+svd2rust = { git = "https://github.com/rust-embedded/svd2rust", rev = "77da805eb1afc4dcb5fd04ec992cde71b32d3832" }
+zip = "0.3"
+
+[dependencies]
+bare-metal = "0.2.4"
+vcell = "0.1.0"
+cortex-m = "0.5.8"
+
+[dependencies.cortex-m-rt]
+optional = true
+version = "0.6.7"
+
+[features]
+default = ["patch"]
+fmt = []
+nightly = []
+patch = []
+rt = ["cortex-m-rt/device"]
+stm32f0x0 = []
+stm32f0x1 = []
+stm32f0x2 = []
+stm32f0x8 = []
+stm32f100 = []
+stm32f101 = []
+stm32f102 = []
+stm32f103 = []
+stm32f107 = []
+stm32f215 = []
+stm32f217 = []
+stm32f301 = []
+stm32f302 = []
+stm32f303 = []
+stm32f373 = []
+stm32f3x4 = []
+stm32f3x8 = []
+stm32f401 = []
+stm32f405 = []
+stm32f407 = []
+stm32f410 = []
+stm32f411 = []
+stm32f412 = []
+stm32f413 = []
+stm32f427 = []
+stm32f429 = []
+stm32f446 = []
+stm32f469 = []
+stm32f7x2 = []
+stm32f7x3 = []
+stm32f7x5 = []
+stm32f7x6 = []
+stm32f7x7 = []
+stm32f7x9 = []
+stm32g0x0 = []
+stm32g0x1 = []
+stm32h7x3 = []
+stm32l0x1 = []
+stm32l0x2 = []
+stm32l0x3 = []
+stm32l100 = []
+stm32l151 = []
+stm32l162 = []
+stm32l4x1 = []
+stm32l4x2 = []
+stm32l4x3 = []
+stm32l4x5 = []
+stm32l4x6 = []

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ CHECK_SRCS := $(foreach crate, $(CRATES), \
 
 # Turn a devices/device.yaml and svd/device.svd into svd/device.svd.patched
 svd/%.svd.patched: devices/%.yaml svd/%.svd
-	python3 scripts/svdpatch.py $<
+	python3 scripts/svdpatch.py < $(word 2,$^) $< > $@
 
 define crate_template
 $(1)/src/%/mod.rs: svd/%.svd.patched

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,130 @@
+extern crate svd2rust;
+extern crate zip;
+
+use std::env;
+use std::fs::File;
+use std::io::{self, Read, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+fn main() {
+    let mut features: std::collections::HashSet<_> = std::env::vars()
+        .filter_map(|var| {
+            const FEATURE_PREFIX: &str = "CARGO_FEATURE_";
+            match var {
+                (ref key, _) if key.starts_with(FEATURE_PREFIX) => {
+                    Some(String::from(&key[FEATURE_PREFIX.len()..]))
+                }
+                _ => None,
+            }
+        })
+        .collect();
+    let _feat_default = features.remove("DEFAULT");
+    let feat_patch = features.remove("PATCH");
+
+    let feat_fmt = features.remove("FMT");
+    let feat_nightly = features.remove("NIGHTLY");
+
+    let _feat_rt = features.remove("RT");
+    let _feat_cmrt = features.remove("CORTEX_M_RT");
+
+    match features.len() {
+        0 => panic!("A device feature must be specified. example: --features stm32f303"),
+        1 => (),
+
+        // Note: The compilation will fail due to multiply defined
+        // static variables (ex: DEVICE_PERIPHERALS) if more then
+        // one device feature is specified.
+        _ => panic!("Only one device feature can be specified"),
+    }
+
+    for feature in features.iter().take(1) {
+        let svd_filename = format!("{}.svd", feature);
+        let mut svd = get_svd(&svd_filename).expect(&format!("Unable to find {}", svd_filename));
+
+        if feat_patch {
+            let feat_lower = feature.to_lowercase();
+            let cfg_path = Path::new("devices").join(format!("{}.yaml", feat_lower));
+            svd = patch_svd(cfg_path.to_str().unwrap(), &svd)
+                .expect(&format!("Unable to patch {}", svd_filename));
+        }
+
+        let mod_path = Path::new("src").join("lib.rs");
+        std::fs::DirBuilder::new()
+            .recursive(true)
+            .create(mod_path.parent().unwrap())
+            .expect("Unable to create src dir");
+
+        let svd2rust::Generation {
+            lib_rs,
+            device_specific,
+            ..
+        } = svd2rust::generate(&svd, &svd2rust::Target::CortexM, feat_nightly)
+            .expect("Failed to generate rust library");
+
+        File::create(&mod_path)
+            .unwrap()
+            .write_all(lib_rs.as_bytes())
+            .expect("Unable to write module");
+
+        let mut out = &PathBuf::from(env::var("OUT_DIR").unwrap());
+        println!("cargo:rustc-link-search={}", out.display());
+        File::create(out.join("device.x"))
+            .unwrap()
+            .write_all(device_specific.unwrap().device_x.as_bytes())
+            .expect("Unable to write device.x");
+
+        if feat_fmt {
+            Command::new("rustfmt")
+                .args(&["--write-mode", "overwrite"])
+                .arg(&mod_path)
+                .output()
+                .expect("Unable to format module");
+        }
+    }
+}
+
+fn get_svd(filename: &str) -> io::Result<String> {
+    for entry in std::fs::read_dir(Path::new("svd").join("vendor"))? {
+        let path = entry?.path();
+
+        if let Ok(file) = File::open(path) {
+            if let Ok(mut archive) = zip::ZipArchive::new(file) {
+                for i in 0..archive.len() {
+                    if let Ok(mut file) = archive.by_index(i) {
+                        if file.name().ends_with(filename) {
+                            let mut buf = String::new();
+                            file.read_to_string(&mut buf)?;
+                            return Ok(buf);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    Err(io::Error::new(io::ErrorKind::NotFound, ""))
+}
+
+fn patch_svd(filename: &str, svd_data: &str) -> io::Result<String> {
+    let patch_path = Path::new("scripts").join("svdpatch.py");
+    let mut python = Command::new("python3")
+        .arg(patch_path.to_str().unwrap())
+        .arg(filename)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()?;
+    {
+        let stdin = python.stdin.as_mut().expect("Unable to open stdin");
+        stdin
+            .write_all(svd_data.as_bytes())
+            .expect("Unable to write to stdin");
+    }
+
+    Ok(String::from_utf8(
+        python
+            .wait_with_output()
+            .expect("Unable to read from stdout")
+            .stdout,
+    )
+    .expect("Unable to convert to string"))
+}

--- a/cortex_m/Makefile
+++ b/cortex_m/Makefile
@@ -4,7 +4,7 @@ YAMLS := $(wildcard *.yaml)
 PATCHED_SVDS := $(patsubst %.yaml, %.svd.patched, $(YAMLS))
 
 %.svd.patched: %.yaml %.svd
-	python3 ../scripts/svdpatch.py $<
+	python3 ../scripts/svdpatch.py < $(word 2,$^) $< > $@
 
 patch: $(PATCHED_SVDS)
 

--- a/scripts/svdpatch.py
+++ b/scripts/svdpatch.py
@@ -8,6 +8,7 @@ Licensed under the MIT and Apache 2.0 licenses. See LICENSE files for details.
 import copy
 import yaml
 import os.path
+import sys
 import argparse
 import xml.etree.ElementTree as ET
 from fnmatch import fnmatch
@@ -705,10 +706,8 @@ def main():
         root["_path"] = args.yaml
 
     # Load the specified SVD file
-    if "_svd" not in root:
-        raise RuntimeError("You must have an svd key in the root YAML file")
-    svdpath = abspath(args.yaml, root["_svd"])
-    svdpath_out = svdpath + ".patched"
+    svdpath = sys.stdin
+    svdpath_out = sys.stdout.buffer
     svd = ET.parse(svdpath)
 
     # Load all included YAML files


### PR DESCRIPTION
This change adds a cargo build script to allow dependent crates to specify stm32 as a Cargo.toml dependency.  Cargo can also be used to build within the repository with something like...
cargo build --features 'rt stm32f303'

It does depend on a svd2rust PR
https://github.com/japaric/svd2rust/pull/202

This support only allows one device feature to be specified (otherwise duplicate statics prevent compilation).  The build.rs script will panic if it detects too many devices.
