### PR TITLE
Splitted the patch for merging RTCSEL in an individual file

### DIFF
--- a/devices/stm32f401.yaml
+++ b/devices/stm32f401.yaml
@@ -16,6 +16,7 @@ CRC:
 
 _include:
  - ../peripherals/rcc/rcc_v2.yaml
+ - ../peripherals/rcc/rcc_merge_rtcsel.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/adc/adc_v2.yaml

--- a/devices/stm32f405.yaml
+++ b/devices/stm32f405.yaml
@@ -56,6 +56,7 @@ _include:
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml
  - ../peripherals/rcc/rcc_v2.yaml
+ - ../peripherals/rcc/rcc_merge_rtcsel.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/adc/adc_v2_smpr.yaml

--- a/devices/stm32f407.yaml
+++ b/devices/stm32f407.yaml
@@ -87,6 +87,7 @@ _include:
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml
  - ../peripherals/rcc/rcc_v2.yaml
+ - ../peripherals/rcc/rcc_merge_rtcsel.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/adc/adc_v2_smpr.yaml

--- a/devices/stm32f411.yaml
+++ b/devices/stm32f411.yaml
@@ -16,6 +16,7 @@ CRC:
 
 _include:
  - ../peripherals/rcc/rcc_v2.yaml
+ - ../peripherals/rcc/rcc_merge_rtcsel.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/adc/adc_v2.yaml

--- a/devices/stm32f412.yaml
+++ b/devices/stm32f412.yaml
@@ -33,6 +33,7 @@ CRC:
 
 _include:
  - ../peripherals/rcc/rcc_v2.yaml
+ - ../peripherals/rcc/rcc_merge_rtcsel.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/adc/adc_v2.yaml

--- a/devices/stm32f427.yaml
+++ b/devices/stm32f427.yaml
@@ -46,6 +46,7 @@ _include:
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml
  - ../peripherals/rcc/rcc_v2.yaml
+ - ../peripherals/rcc/rcc_merge_rtcsel.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/adc/adc_v2_smpr.yaml

--- a/devices/stm32f429.yaml
+++ b/devices/stm32f429.yaml
@@ -46,6 +46,7 @@ _include:
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml
  - ../peripherals/rcc/rcc_v2.yaml
+ - ../peripherals/rcc/rcc_merge_rtcsel.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/adc/adc_v2_smpr.yaml

--- a/devices/stm32f446.yaml
+++ b/devices/stm32f446.yaml
@@ -39,6 +39,7 @@ _include:
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml
  - ../peripherals/gpio/gpio_v2.yaml
+ - ../peripherals/rcc/rcc_v2.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/adc/adc_v2_smpr.yaml
  - ../peripherals/adc/adc_v2_multi.yaml

--- a/devices/stm32f7x2.yaml
+++ b/devices/stm32f7x2.yaml
@@ -10,6 +10,7 @@ _include:
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml
  - ../peripherals/rcc/rcc_v2.yaml
+ - ../peripherals/rcc/rcc_merge_rtcsel.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/spi/spi_v2.yaml

--- a/devices/stm32f7x3.yaml
+++ b/devices/stm32f7x3.yaml
@@ -10,6 +10,7 @@ _include:
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml
  - ../peripherals/rcc/rcc_v2.yaml
+ - ../peripherals/rcc/rcc_merge_rtcsel.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/spi/spi_v2.yaml

--- a/devices/stm32f7x5.yaml
+++ b/devices/stm32f7x5.yaml
@@ -114,6 +114,7 @@ _include:
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml
  - ../peripherals/rcc/rcc_v2.yaml
+ - ../peripherals/rcc/rcc_merge_rtcsel.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/adc/adc_v2_multi.yaml

--- a/devices/stm32f7x6.yaml
+++ b/devices/stm32f7x6.yaml
@@ -105,6 +105,7 @@ _include:
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml
  - ../peripherals/rcc/rcc_v2.yaml
+ - ../peripherals/rcc/rcc_merge_rtcsel.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/spi/spi_v2.yaml

--- a/devices/stm32f7x7.yaml
+++ b/devices/stm32f7x7.yaml
@@ -257,6 +257,7 @@ _include:
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml
  - ../peripherals/rcc/rcc_v2.yaml
+ - ../peripherals/rcc/rcc_merge_rtcsel.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/spi/spi_v2.yaml

--- a/devices/stm32f7x9.yaml
+++ b/devices/stm32f7x9.yaml
@@ -246,6 +246,7 @@ _include:
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml
  - ../peripherals/rcc/rcc_v2.yaml
+ - ../peripherals/rcc/rcc_merge_rtcsel.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/spi/spi_v2.yaml

--- a/peripherals/rcc/rcc_merge_rtcsel.yaml
+++ b/peripherals/rcc/rcc_merge_rtcsel.yaml
@@ -1,0 +1,5 @@
+# Applicable at least to STM32F4 and STM32F7.
+
+RCC:
+ BDCR:
+    _merge: ["RTCSEL[01]"]

--- a/peripherals/rcc/rcc_v2.yaml
+++ b/peripherals/rcc/rcc_v2.yaml
@@ -73,7 +73,6 @@ RCC:
       DisabledInSleep: [0, "Selected module is disabled during Sleep mode"]
       EnabledInSleep: [1, "Selected module is enabled during Sleep mode"]
   BDCR:
-    _merge: ["RTCSEL[01]"]
     BDRST:
       Reset: [1, "Resets the entire Backup domain"]
     RTCEN:


### PR DESCRIPTION
See [Missing patch for `stm32f446`](https://github.com/adamgreig/stm32-rs/pull/17) (#17).
I think this is correct but I can't get to generate the rs files : `make svd2rust -j8; ls stm32f4/src` outputs :
```
.rw-rw-r--  1,4k 24 mai   14:11 lib.rs
.rw-rw-r--     0  24 mai   14:17 stm32f401.rs
.rw-rw-r--     0  24 mai   14:17 stm32f405.rs
.rw-rw-r--     0  24 mai   14:17 stm32f407.rs
.rw-rw-r--     0  24 mai   14:17 stm32f410.rs
.rw-rw-r--     0  24 mai   14:17 stm32f411.rs
.rw-rw-r--     0  24 mai   14:17 stm32f412.rs
.rw-rw-r--     0  24 mai   14:17 stm32f413.rs
.rw-rw-r--     0  24 mai   14:17 stm32f427.rs
.rw-rw-r--     0  24 mai   14:17 stm32f429.rs
.rw-rw-r--     0  24 mai   14:17 stm32f446.rs
.rw-rw-r--     0  24 mai   14:17 stm32f469.rs
```