### PR TITLE
Fix handling of UART stop bit on STM32F4

### DIFF
--- a/peripherals/usart/uart_uart.yaml
+++ b/peripherals/usart/uart_uart.yaml
@@ -3,4 +3,4 @@
   CR2:
     STOP:
       Stop1: [0, "1 stop bit"]
-      Stop2: [1, "2 stop bits"]
+      Stop2: [2, "2 stop bits"]


### PR DESCRIPTION
On UART (contrary to USART), the 2 bits stop field of CR2 only accept values 0b00 (1 stop bit) or 0b10 (2 stop bits). So basically, this is actually a 1 bit field.

The currently defined value for Stop2 is incorrect for a 2 bits fields, it should be 2 instead of 1.

This patch actually changes the stop field to only 1 bit, making the value of Stop2 correct, and changing the unsafe .bits() method to a safe .bit() method.