### PR TITLE
STM32F103 USB patches

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ devices should be supported to some level.
 
 * Install `svd2rust`: `cargo install svd2rust`
 * Install `form`: `cargo install form`
-* Install latest rustfmt: `cargo uninstall rustfmt; rustup component add rustfmt-preview`
-* Install PyYAML: `pip install pyyaml`
+* Install rustfmt: `rustup component add rustfmt`
+* Install PyYAML: `pip install --user pyyaml`
 * Unzip bundled SVD zip files: `cd svd; ./extract.sh`
 * Generate patched SVD files: `cd ..; make patch`
 * Generate svd2rust device crates: `make svd2rust` (you probably want `-j` for this)

--- a/devices/stm32f103.yaml
+++ b/devices/stm32f103.yaml
@@ -22,7 +22,27 @@ _modify:
     name: Ethernet_MMC
   ETHERNET_PTP:
     name: Ethernet_PTP
-WWDG:  
+
+RCC:
+  CFGR:
+    _modify:
+      # Incorrect compared to RM0008; F103 has USB not OTG_FS
+      OTGFSPRE:
+        name: USBPRE
+        description: USB prescaler
+
+USB:
+  # This register is later transformed into EP%sR for the array
+  EP0R:
+    EA: [0, 15]
+    EP_TYPE:
+      BULK: [0, "This endpoint is a bulk endpoint"]
+      CONTROL: [1, "This endpoint is a control endpoint"]
+      ISO: [2, "This endpoint is an isochronous endpoint"]
+      INTERRUPT: [3, "This endpoint is an interrupt endpoint"]
+
+
+WWDG:
   # EWIF is named incorrectly in the SVD compared to its name in RM0008
   SR:
     _modify:


### PR DESCRIPTION
This is actually all I could find in the stm32f103xx patch file related to USB; I'm not sure if it will be enough to fix the issues you were having @therealprof? I think `USBPRE` was the main one?

If this is enough I'd like to get 0.5 released ASAP with svd2rust 0.14 support; we can always add more of the stm32f103xx patches later too. I think combined with the new array support from #107 we should be good for USB on STM32F103 at least, which will hopefully enable stm32f103xx-usb to work too. @mvirkkunen?