### PR TITLE
USART6 common patch for STM32F0, move DMAEN from device to rcc_f0.yaml peripheral file

### DIFF
--- a/devices/common_patches/f0_usart6.yaml
+++ b/devices/common_patches/f0_usart6.yaml
@@ -1,0 +1,13 @@
+RCC:
+  APB2RSTR:
+    _add:
+      USART6RST:
+        description: "USART6 reset"
+        bitOffset: 5
+        bitWidth: 1
+  APB2ENR:
+    _add:
+      USART6EN:
+        description: "USART6 clock enable"
+        bitOffset: 5
+        bitWidth: 1

--- a/devices/stm32f0x0.yaml
+++ b/devices/stm32f0x0.yaml
@@ -1,23 +1,11 @@
 _svd: ../svd/stm32f0x0.svd
 
 RCC:
-  APB2RSTR:
-    _add:
-      USART6RST:
-        description: "USART6 reset"
-        bitOffset: 5
-        bitWidth: 1
   AHBENR:
     _add:
       IOPDEN:
         description: "I/O port D clock enable"
         bitOffset: 20
-        bitWidth: 1
-  APB2ENR:
-    _add:
-      USART6EN:
-        description: "USART6 clock enable"
-        bitOffset: 5
         bitWidth: 1
 
 _include:
@@ -25,9 +13,10 @@ _include:
  - ./common_patches/merge_I2C_CR2_SADDx_fields.yaml
  - ./common_patches/merge_I2C_OAR1_OA1x_fields.yaml
  - ./common_patches/f0_adc_cfgr2_ckmode.yaml
+ - ./common_patches/f0_usart6.yaml
  - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
  - ./common_patches/rename_USART_CR1_M0_field.yaml
- - common_patches/merge_USART_BRR_fields.yaml
+ - ./common_patches/merge_USART_BRR_fields.yaml
  - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/tim/tim2_32bit.yaml
  - ../peripherals/gpio/gpio_v2.yaml

--- a/devices/stm32f0x0.yaml
+++ b/devices/stm32f0x0.yaml
@@ -13,10 +13,6 @@ RCC:
         description: "I/O port D clock enable"
         bitOffset: 20
         bitWidth: 1
-      DMAEN:
-        description: "DMA clock enable"
-        bitOffset: 0
-        bitWidth: 1
   APB2ENR:
     _add:
       USART6EN:

--- a/devices/stm32f0x1.yaml
+++ b/devices/stm32f0x1.yaml
@@ -7,14 +7,6 @@ Flash:
       RAM_PARITY_CHECK:
         bitWidth: 1
 
-RCC:
-  AHBENR:
-    _add:
-      DMAEN:
-        description: "DMA clock enable"
-        bitOffset: 0
-        bitWidth: 1
-
 _include:
  - ./common_patches/rename_RCC_CIR_HSI14RDYIE_field.yaml
  - ./common_patches/merge_I2C_CR2_SADDx_fields.yaml
@@ -22,7 +14,7 @@ _include:
  - ./common_patches/f0_adc_cfgr2_ckmode.yaml
  - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
  - ./common_patches/rename_USART_CR1_M0_field.yaml
- - common_patches/merge_USART_BRR_fields.yaml
+ - ./common_patches/merge_USART_BRR_fields.yaml
  - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml

--- a/devices/stm32f0x2.yaml
+++ b/devices/stm32f0x2.yaml
@@ -13,12 +13,6 @@ RCC:
         description: "USART5 reset"
         bitOffset: 20
         bitWidth: 1
-  AHBENR:
-    _add:
-      DMAEN:
-        description: "DMA clock enable"
-        bitOffset: 0
-        bitWidth: 1
   APB2ENR:
     _add:
       USART6EN:

--- a/devices/stm32f0x2.yaml
+++ b/devices/stm32f0x2.yaml
@@ -1,23 +1,11 @@
 _svd: ../svd/stm32f0x2.svd
 
 RCC:
-  APB2RSTR:
-    _add:
-      USART6RST:
-        description: "USART6 reset"
-        bitOffset: 5
-        bitWidth: 1
   APB1RSTR:
     _add:
       USART5RST:
         description: "USART5 reset"
         bitOffset: 20
-        bitWidth: 1
-  APB2ENR:
-    _add:
-      USART6EN:
-        description: "USART6 clock enable"
-        bitOffset: 5
         bitWidth: 1
   APB1ENR:
     _add:
@@ -31,9 +19,10 @@ _include:
  - ./common_patches/merge_I2C_CR2_SADDx_fields.yaml
  - ./common_patches/merge_I2C_OAR1_OA1x_fields.yaml
  - ./common_patches/f0_adc_cfgr2_ckmode.yaml
+ - ./common_patches/f0_usart6.yaml
  - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
  - ./common_patches/rename_USART_CR1_M0_field.yaml
- - common_patches/merge_USART_BRR_fields.yaml
+ - ./common_patches/merge_USART_BRR_fields.yaml
  - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml

--- a/devices/stm32f0x8.yaml
+++ b/devices/stm32f0x8.yaml
@@ -7,12 +7,6 @@ RCC:
         description: "USART6 reset"
         bitOffset: 5
         bitWidth: 1
-  AHBENR:
-    _add:
-      DMAEN:
-        description: "DMA clock enable"
-        bitOffset: 0
-        bitWidth: 1
   APB2ENR:
     _add:
       USART6EN:

--- a/devices/stm32f0x8.yaml
+++ b/devices/stm32f0x8.yaml
@@ -1,27 +1,14 @@
 _svd: ../svd/stm32f0x8.svd
 
-RCC:
-  APB2RSTR:
-    _add:
-      USART6RST:
-        description: "USART6 reset"
-        bitOffset: 5
-        bitWidth: 1
-  APB2ENR:
-    _add:
-      USART6EN:
-        description: "USART6 clock enable"
-        bitOffset: 5
-        bitWidth: 1
-
 _include:
  - ./common_patches/rename_RCC_CIR_HSI14RDYIE_field.yaml
  - ./common_patches/merge_I2C_CR2_SADDx_fields.yaml
  - ./common_patches/merge_I2C_OAR1_OA1x_fields.yaml
  - ./common_patches/f0_adc_cfgr2_ckmode.yaml
+ - ./common_patches/f0_usart6.yaml
  - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
  - ./common_patches/rename_USART_CR1_M0_field.yaml
- - common_patches/merge_USART_BRR_fields.yaml
+ - ./common_patches/merge_USART_BRR_fields.yaml
  - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml

--- a/peripherals/rcc/rcc_f0.yaml
+++ b/peripherals/rcc/rcc_f0.yaml
@@ -238,6 +238,11 @@ RCC:
     TIM3RST:
       Reset: [1, "Reset TIM3"]
   AHBENR:
+    _add:
+      DMAEN:
+        description: "DMA clock enable"
+        bitOffset: 0
+        bitWidth: 1
     IOPFEN:
       Disabled: [0, "I/O port F clock disabled"]
       Enabled: [1, "I/O port F clock enabled"]


### PR DESCRIPTION
This is mostly just cleaning up the changes I made in #99 

`DMAEN` was moved into the common `rcc_f0.yaml` file rather than being repeated in each individual device file, and I created a common patch for the `USART6` peripheral on F0-series devices.