### PR TITLE
Documents some USB registers

### DIFF
--- a/devices/common_patches/rename_USB_EPxR_EPTYPE_field.yaml
+++ b/devices/common_patches/rename_USB_EPxR_EPTYPE_field.yaml
@@ -1,0 +1,7 @@
+# Rename EPTYPE to EP_TYPE
+
+USB:
+  "EP*R":
+    _modify:
+      EPTYPE:
+        name: EP_TYPE

--- a/devices/common_patches/rename_USB_FS_peripheral_to_USB.yaml
+++ b/devices/common_patches/rename_USB_FS_peripheral_to_USB.yaml
@@ -1,0 +1,7 @@
+# Rename USB_FS peripheral to USB peripheral
+# Allow all devices with USB to have same peripheral name
+
+_modify:
+  _peripherals:
+    USB_FS:
+      name: USB

--- a/devices/common_patches/rename_USB_SRAM_peripheral_to_USB.yaml
+++ b/devices/common_patches/rename_USB_SRAM_peripheral_to_USB.yaml
@@ -1,0 +1,7 @@
+# Rename USB_SRAM peripheral to USB peripheral
+# Allow all devices with USB to have same peripheral name
+
+_modify:
+  _peripherals:
+    USB_SRAM:
+      name: USB

--- a/devices/common_patches/unprefix_USB_registers.yaml
+++ b/devices/common_patches/unprefix_USB_registers.yaml
@@ -1,0 +1,22 @@
+# Remove USB_ prefix on some USB registers
+
+USB:
+  _modify:
+    USB_EP0R:
+      name: EP0R
+    USB_EP1R:
+      name: EP1R
+    USB_EP2R:
+      name: EP2R
+    USB_EP3R:
+      name: EP3R
+    USB_EP4R:
+      name: EP4R
+    USB_EP5R:
+      name: EP5R
+    USB_EP6R:
+      name: EP6R
+    USB_EP7R:
+      name: EP7R
+    USB_CNTR:
+      name: CNTR

--- a/devices/stm32f0x0.yaml
+++ b/devices/stm32f0x0.yaml
@@ -33,3 +33,4 @@ _include:
  - ../peripherals/dma/dma_v1.yaml
  - ../peripherals/i2c/i2c_v2.yaml
  - ../peripherals/usart/usart_v2B1.yaml
+ - ../peripherals/usb/usb_with_LPM.yaml

--- a/devices/stm32f0x1.yaml
+++ b/devices/stm32f0x1.yaml
@@ -33,3 +33,4 @@ _include:
  - ../peripherals/dma/dma_v1.yaml
  - ../peripherals/i2c/i2c_v2.yaml
  - ../peripherals/usart/usart_v2B1.yaml
+ - ../peripherals/usb/usb_with_LPM.yaml

--- a/devices/stm32f0x2.yaml
+++ b/devices/stm32f0x2.yaml
@@ -41,3 +41,4 @@ _include:
  - ../peripherals/dma/dma_v1.yaml
  - ../peripherals/i2c/i2c_v2.yaml
  - ../peripherals/usart/usart_v2B1.yaml
+ - ../peripherals/usb/usb_with_LPM.yaml

--- a/devices/stm32f0x8.yaml
+++ b/devices/stm32f0x8.yaml
@@ -27,3 +27,4 @@ _include:
  - ../peripherals/dma/dma_v1.yaml
  - ../peripherals/i2c/i2c_v2.yaml
  - ../peripherals/usart/usart_v2B1.yaml
+ - ../peripherals/usb/usb_with_LPM.yaml

--- a/devices/stm32f101.yaml
+++ b/devices/stm32f101.yaml
@@ -41,3 +41,4 @@ _include:
  - ../peripherals/tim/tim2_16bit.yaml
  - ../peripherals/dma/dma_v1.yaml
  - ../peripherals/iwdg/iwdg.yaml
+ - ../peripherals/usb/usb.yaml

--- a/devices/stm32f102.yaml
+++ b/devices/stm32f102.yaml
@@ -32,3 +32,4 @@ _include:
  - ../peripherals/tim/tim2_16bit.yaml
  - ../peripherals/dma/dma_v1.yaml
  - ../peripherals/iwdg/iwdg.yaml
+ - ../peripherals/usb/usb.yaml

--- a/devices/stm32f103.yaml
+++ b/devices/stm32f103.yaml
@@ -31,17 +31,6 @@ RCC:
         name: USBPRE
         description: USB prescaler
 
-USB:
-  # This register is later transformed into EP%sR for the array
-  EP0R:
-    EA: [0, 15]
-    EP_TYPE:
-      BULK: [0, "This endpoint is a bulk endpoint"]
-      CONTROL: [1, "This endpoint is a control endpoint"]
-      ISO: [2, "This endpoint is an isochronous endpoint"]
-      INTERRUPT: [3, "This endpoint is an interrupt endpoint"]
-
-
 WWDG:
   # EWIF is named incorrectly in the SVD compared to its name in RM0008
   SR:

--- a/devices/stm32f103.yaml
+++ b/devices/stm32f103.yaml
@@ -68,3 +68,4 @@ _include:
  - ../peripherals/bkp/bkp.yaml
  - ../peripherals/adc/adc_array.yaml
  - ../peripherals/can/can.yaml
+ - ../peripherals/usb/usb.yaml

--- a/devices/stm32f107.yaml
+++ b/devices/stm32f107.yaml
@@ -41,3 +41,4 @@ _include:
  - ../peripherals/tim/tim2_16bit.yaml
  - ../peripherals/dma/dma_v1.yaml
  - ../peripherals/iwdg/iwdg.yaml
+ - ../peripherals/usb/usb.yaml

--- a/devices/stm32f301.yaml
+++ b/devices/stm32f301.yaml
@@ -26,6 +26,7 @@ _include:
  - ./common_patches/merge_I2C_OAR1_OA1x_fields.yaml
  - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
  - ./common_patches/merge_USART_BRR_fields.yaml
+ - ./common_patches/unprefix_USB_registers.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/spi/spi_v2.yaml
  - ../peripherals/spi/spi_common.yaml

--- a/devices/stm32f301.yaml
+++ b/devices/stm32f301.yaml
@@ -41,3 +41,4 @@ _include:
  - ../peripherals/iwdg/iwdg_with_WINR.yaml
  - ../peripherals/i2c/i2c_v2.yaml
  - ../peripherals/usart/usart_v2B.yaml
+ - ../peripherals/usb/usb.yaml

--- a/devices/stm32f302.yaml
+++ b/devices/stm32f302.yaml
@@ -14,6 +14,7 @@ _include:
  - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
  - ./common_patches/merge_USART_BRR_fields.yaml
  - ./common_patches/rename_USB_FS_peripheral_to_USB.yaml
+ - ./common_patches/unprefix_USB_registers.yaml
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml
  - ../peripherals/gpio/gpio_v2.yaml

--- a/devices/stm32f302.yaml
+++ b/devices/stm32f302.yaml
@@ -13,6 +13,7 @@ _include:
  - ./common_patches/merge_I2C_OAR1_OA1x_fields.yaml
  - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
  - ./common_patches/merge_USART_BRR_fields.yaml
+ - ./common_patches/rename_USB_FS_peripheral_to_USB.yaml
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml
  - ../peripherals/gpio/gpio_v2.yaml

--- a/devices/stm32f302.yaml
+++ b/devices/stm32f302.yaml
@@ -30,3 +30,4 @@ _include:
  - ../peripherals/iwdg/iwdg_with_WINR.yaml
  - ../peripherals/i2c/i2c_v2.yaml
  - ../peripherals/usart/usart_v2B.yaml
+ - ../peripherals/usb/usb.yaml

--- a/devices/stm32f303.yaml
+++ b/devices/stm32f303.yaml
@@ -14,6 +14,7 @@ _include:
  - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
  - ./common_patches/merge_USART_BRR_fields.yaml
  - ./common_patches/rename_USB_FS_peripheral_to_USB.yaml
+ - ./common_patches/unprefix_USB_registers.yaml
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml
  - ../peripherals/gpio/gpio_v2.yaml

--- a/devices/stm32f303.yaml
+++ b/devices/stm32f303.yaml
@@ -13,6 +13,7 @@ _include:
  - ./common_patches/merge_I2C_OAR1_OA1x_fields.yaml
  - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
  - ./common_patches/merge_USART_BRR_fields.yaml
+ - ./common_patches/rename_USB_FS_peripheral_to_USB.yaml
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml
  - ../peripherals/gpio/gpio_v2.yaml

--- a/devices/stm32f303.yaml
+++ b/devices/stm32f303.yaml
@@ -30,3 +30,4 @@ _include:
  - ../peripherals/iwdg/iwdg_with_WINR.yaml
  - ../peripherals/i2c/i2c_v2.yaml
  - ../peripherals/usart/usart_v2B.yaml
+ - ../peripherals/usb/usb.yaml

--- a/devices/stm32f373.yaml
+++ b/devices/stm32f373.yaml
@@ -6,6 +6,7 @@ _include:
  - ./common_patches/merge_I2C_OAR1_OA1x_fields.yaml
  - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
  - ./common_patches/merge_USART_BRR_fields.yaml
+ - ./common_patches/unprefix_USB_registers.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/gpio/gpio_with_brr.yaml

--- a/devices/stm32f373.yaml
+++ b/devices/stm32f373.yaml
@@ -18,3 +18,4 @@ _include:
  - ../peripherals/iwdg/iwdg_with_WINR.yaml
  - ../peripherals/i2c/i2c_v2.yaml
  - ../peripherals/usart/usart_v2B.yaml
+ - ../peripherals/usb/usb.yaml

--- a/devices/stm32f3x8.yaml
+++ b/devices/stm32f3x8.yaml
@@ -19,3 +19,4 @@ _include:
  - ../peripherals/iwdg/iwdg_with_WINR.yaml
  - ../peripherals/i2c/i2c_v2.yaml
  - ../peripherals/usart/usart_v2B.yaml
+ - ../peripherals/usb/usb.yaml

--- a/devices/stm32f3x8.yaml
+++ b/devices/stm32f3x8.yaml
@@ -6,6 +6,7 @@ _include:
  - ./common_patches/merge_I2C_OAR1_OA1x_fields.yaml
  - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
  - ./common_patches/merge_USART_BRR_fields.yaml
+ - ./common_patches/unprefix_USB_registers.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml

--- a/devices/stm32l0x2.yaml
+++ b/devices/stm32l0x2.yaml
@@ -18,6 +18,7 @@ _include:
  - ./common_patches/merge_USART_BRR_fields.yaml
  - ./common_patches/rename_USB_FS_peripheral_to_USB.yaml
  - ./common_patches/unprefix_USB_registers.yaml
+ - ./common_patches/rename_USB_EPxR_EPTYPE_field.yaml
  - ../peripherals/dac/dac_common_1ch.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml

--- a/devices/stm32l0x2.yaml
+++ b/devices/stm32l0x2.yaml
@@ -17,6 +17,7 @@ _include:
  - ./common_patches/rename_USART_CR2_DATAINV_field.yaml
  - ./common_patches/merge_USART_BRR_fields.yaml
  - ./common_patches/rename_USB_FS_peripheral_to_USB.yaml
+ - ./common_patches/unprefix_USB_registers.yaml
  - ../peripherals/dac/dac_common_1ch.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml

--- a/devices/stm32l0x2.yaml
+++ b/devices/stm32l0x2.yaml
@@ -16,6 +16,7 @@ _include:
  - ./common_patches/merge_LPUART_CR2_ADDx_fields.yaml
  - ./common_patches/rename_USART_CR2_DATAINV_field.yaml
  - ./common_patches/merge_USART_BRR_fields.yaml
+ - ./common_patches/rename_USB_FS_peripheral_to_USB.yaml
  - ../peripherals/dac/dac_common_1ch.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml

--- a/devices/stm32l0x2.yaml
+++ b/devices/stm32l0x2.yaml
@@ -31,3 +31,4 @@ _include:
  - ../peripherals/i2c/i2c_v2.yaml
  - ../peripherals/usart/lpuart_v2A.yaml
  - ../peripherals/usart/usart_v2B1.yaml
+ - ../peripherals/usb/usb_with_LPM.yaml

--- a/devices/stm32l0x3.yaml
+++ b/devices/stm32l0x3.yaml
@@ -18,6 +18,7 @@ _include:
  - ./common_patches/merge_USART_BRR_fields.yaml
  - ./common_patches/rename_USB_FS_peripheral_to_USB.yaml
  - ./common_patches/unprefix_USB_registers.yaml
+ - ./common_patches/rename_USB_EPxR_EPTYPE_field.yaml
  - ../peripherals/dac/dac_common_1ch.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml

--- a/devices/stm32l0x3.yaml
+++ b/devices/stm32l0x3.yaml
@@ -17,6 +17,7 @@ _include:
  - ./common_patches/rename_USART_CR2_DATAINV_field.yaml
  - ./common_patches/merge_USART_BRR_fields.yaml
  - ./common_patches/rename_USB_FS_peripheral_to_USB.yaml
+ - ./common_patches/unprefix_USB_registers.yaml
  - ../peripherals/dac/dac_common_1ch.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml

--- a/devices/stm32l0x3.yaml
+++ b/devices/stm32l0x3.yaml
@@ -16,6 +16,7 @@ _include:
  - ./common_patches/merge_LPUART_CR2_ADDx_fields.yaml
  - ./common_patches/rename_USART_CR2_DATAINV_field.yaml
  - ./common_patches/merge_USART_BRR_fields.yaml
+ - ./common_patches/rename_USB_FS_peripheral_to_USB.yaml
  - ../peripherals/dac/dac_common_1ch.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml

--- a/devices/stm32l0x3.yaml
+++ b/devices/stm32l0x3.yaml
@@ -31,3 +31,4 @@ _include:
  - ../peripherals/i2c/i2c_v2.yaml
  - ../peripherals/usart/lpuart_v2A.yaml
  - ../peripherals/usart/usart_v2B1.yaml
+ - ../peripherals/usb/usb_with_LPM.yaml

--- a/devices/stm32l100.yaml
+++ b/devices/stm32l100.yaml
@@ -92,3 +92,4 @@ _include:
  - ../peripherals/exti/exti_v1.yaml
  - ../peripherals/rcc/rcc_l1.yaml
  - ../peripherals/i2c/i2c_v1.yaml
+ - ../peripherals/usb/usb.yaml

--- a/devices/stm32l100.yaml
+++ b/devices/stm32l100.yaml
@@ -77,6 +77,7 @@ _include:
  - ./common_patches/rcc_LSECSSC_LSECSSF.yaml
  - ./common_patches/gpio_with_OSPEEDER.yaml
  - ./common_patches/merge_I2C_OAR1_ADDx_fields.yaml
+ - ./common_patches/unprefix_USB_registers.yaml
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml
  - ../peripherals/crc/crc_basic.yaml

--- a/devices/stm32l151.yaml
+++ b/devices/stm32l151.yaml
@@ -28,3 +28,4 @@ _include:
  - ../peripherals/tim/tim2_16bit.yaml
  - ../peripherals/iwdg/iwdg.yaml
  - ../peripherals/i2c/i2c_v1.yaml
+ - ../peripherals/usb/usb.yaml

--- a/devices/stm32l151.yaml
+++ b/devices/stm32l151.yaml
@@ -15,6 +15,7 @@ CRC:
 _include:
  - ./common_patches/rename_TIM2_CCR3_CCR3.yaml
  - ./common_patches/merge_I2C_OAR1_ADDx_fields.yaml
+ - ./common_patches/unprefix_USB_registers.yaml
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml
  - ../peripherals/crc/crc_basic.yaml

--- a/devices/stm32l162.yaml
+++ b/devices/stm32l162.yaml
@@ -28,3 +28,4 @@ _include:
  - ../peripherals/tim/tim2_16bit.yaml
  - ../peripherals/iwdg/iwdg.yaml
  - ../peripherals/i2c/i2c_v1.yaml
+ - ../peripherals/usb/usb.yaml

--- a/devices/stm32l162.yaml
+++ b/devices/stm32l162.yaml
@@ -15,6 +15,7 @@ CRC:
 _include:
  - ./common_patches/rename_TIM2_CCR3_CCR3.yaml
  - ./common_patches/merge_I2C_OAR1_ADDx_fields.yaml
+ - ./common_patches/unprefix_USB_registers.yaml
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml
  - ../peripherals/crc/crc_basic.yaml

--- a/devices/stm32l4x1.yaml
+++ b/devices/stm32l4x1.yaml
@@ -32,6 +32,7 @@ _include:
  - ./common_patches/rename_LPUART_CR2_DATAINV_field.yaml
  - ./common_patches/merge_LPUART_CR2_ADDx_fields.yaml
  - ./common_patches/merge_USART_BRR_fields.yaml
+ - common_patches/rename_USB_SRAM_peripheral_to_USB.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml

--- a/devices/stm32l4x2.yaml
+++ b/devices/stm32l4x2.yaml
@@ -57,6 +57,7 @@ _include:
  - ./common_patches/rename_LPUART_CR2_DATAINV_field.yaml
  - ./common_patches/merge_LPUART_CR2_ADDx_fields.yaml
  - ./common_patches/merge_USART_BRR_fields.yaml
+ - common_patches/rename_USB_SRAM_peripheral_to_USB.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml

--- a/peripherals/usb/usb.yaml
+++ b/peripherals/usb/usb.yaml
@@ -75,3 +75,5 @@ USB:
       Disabled: [0, "USB device disabled"]
       Enabled: [1, "USB device enabled"]
     ADD: [0, 0b1111111]
+  BTABLE:
+    BTABLE: [0, 0b1111111111111]

--- a/peripherals/usb/usb.yaml
+++ b/peripherals/usb/usb.yaml
@@ -70,3 +70,8 @@ USB:
       Locked: [1, "the frame timer remains in this state until an USB reset or USB suspend event occurs"]
     LSOF: [0, 0b11]
     FN: [0, 0b11111111111]
+  DADDR:
+    EF:
+      Disabled: [0, "USB device disabled"]
+      Enabled: [1, "USB device enabled"]
+    ADD: [0, 0b1111111]

--- a/peripherals/usb/usb.yaml
+++ b/peripherals/usb/usb.yaml
@@ -1,0 +1,42 @@
+# USB peripheral and associated SRAM
+
+USB:
+  CNTR:
+    CTRM:
+      Disabled: [0, "Correct Transfer (CTR) Interrupt disabled"]
+      Enabled: [1, "CTR Interrupt enabled, an interrupt request is generated when the corresponding bit in the USB_ISTR register is set"]
+    PMAOVRM:
+      Disabled: [0, "PMAOVR Interrupt disabled"]
+      Enabled: [1, "PMAOVR Interrupt enabled, an interrupt request is generated when the corresponding bit in the USB_ISTR register is set"]
+    ERRM:
+      Disabled: [0, "ERR Interrupt disabled"]
+      Enabled: [1, "ERR Interrupt enabled, an interrupt request is generated when the corresponding bit in the USB_ISTR register is set"]
+    WKUPM:
+      Disabled: [0, "WKUP Interrupt disabled"]
+      Enabled: [1, "WKUP Interrupt enabled, an interrupt request is generated when the corresponding bit in the USB_ISTR register is set"]
+    SUSPM:
+      Disabled: [0, "Suspend Mode Request SUSP Interrupt disabled"]
+      Enabled: [1, "SUSP Interrupt enabled, an interrupt request is generated when the corresponding bit in the USB_ISTR register is set"]
+    RESETM:
+      Disabled: [0, "RESET Interrupt disabled"]
+      Enabled: [1, "RESET Interrupt enabled, an interrupt request is generated when the corresponding bit in the USB_ISTR register is set"]
+    SOFM:
+      Disabled: [0, "SOF Interrupt disabled"]
+      Enabled: [1, "SOF Interrupt enabled, an interrupt request is generated when the corresponding bit in the USB_ISTR register is set"]
+    ESOFM:
+      Disabled: [0, "ESOF Interrupt disabled"]
+      Enabled: [1, "ESOF Interrupt enabled, an interrupt request is generated when the corresponding bit in the USB_ISTR register is set"]
+    RESUME:
+      Requested: [1, "Resume requested"]
+    FSUSP:
+      NoEffect: [0, "No effect"]
+      Suspend: [1, "Enter suspend mode. Clocks and static power dissipation in the analog transceiver are left unaffected"]
+    LPMODE:
+      Disabled: [0, "No low-power mode"]
+      Enabled: [1, "Enter low-power mode"]
+    PDWN:
+      Disabled: [0, "No power down"]
+      Enabled: [1, "Enter power down mode"]
+    FRES:
+      NoReset: [0, "Clear USB reset"]
+      Reset: [1, "Force a reset of the USB peripheral, exactly like a RESET signaling on the USB"]

--- a/peripherals/usb/usb.yaml
+++ b/peripherals/usb/usb.yaml
@@ -61,3 +61,12 @@ USB:
       To: [0, "data transmitted by the USB peripheral to the host PC"]
       From: [1, "data received by the USB peripheral from the host PC"]
     EP_ID: [0, 0b1111]
+  FNR:
+    RXDP:
+      Received: [1, "received data plus upstream port data line"]
+    RXDM:
+      Received: [1, "received data minus upstream port data line"]
+    LCK:
+      Locked: [1, "the frame timer remains in this state until an USB reset or USB suspend event occurs"]
+    LSOF: [0, 0b11]
+    FN: [0, 0b11111111111]

--- a/peripherals/usb/usb.yaml
+++ b/peripherals/usb/usb.yaml
@@ -40,3 +40,24 @@ USB:
     FRES:
       NoReset: [0, "Clear USB reset"]
       Reset: [1, "Force a reset of the USB peripheral, exactly like a RESET signaling on the USB"]
+  ISTR:
+    CTR:
+      Completed: [1, "endpoint has successfully completed a transaction"]
+    PMAOVR:
+      Overrun: [1, "microcontroller has not been able to respond in time to an USB memory request"]
+    ERR:
+      Error: [1, "One of No ANSwer, Cyclic Redundancy Check, Bit Stuffing or Framing format Violation error occurred"]
+    WKUP:
+      Wakeup: [1, "activity is detected that wakes up the USB peripheral"]
+    SUSP:
+      Suspend: [1, "no traffic has been received for 3 ms, indicating a suspend mode request from the USB bus"]
+    RESET:
+      Reset: [1, "peripheral detects an active USB RESET signal at its inputs"]
+    SOF:
+      StartOfFrame: [1, "beginning of a new USB frame and it is set when a SOF packet arrives through the USB bus"]
+    ESOF:
+      ExpectedStartOfFrame: [1, "an SOF packet is expected but not received"]
+    DIR:
+      To: [0, "data transmitted by the USB peripheral to the host PC"]
+      From: [1, "data received by the USB peripheral from the host PC"]
+    EP_ID: [0, 0b1111]

--- a/peripherals/usb/usb.yaml
+++ b/peripherals/usb/usb.yaml
@@ -77,3 +77,28 @@ USB:
     ADD: [0, 0b1111111]
   BTABLE:
     BTABLE: [0, 0b1111111111111]
+  "EP*R":
+    CTR_RX:
+    DTOG_RX:
+    STAT_RX:
+      Disabled: [0, "all reception requests addressed to this endpoint are ignored"]
+      Stall: [1, "the endpoint is stalled and all reception requests result in a STALL handshake"]
+      Nak: [2, "the endpoint is naked and all reception requests result in a NAK handshake"]
+      Valid: [3, "this endpoint is enabled for reception"]
+    SETUP:
+      #"the last completed transaction is a SETUP"]
+    EP_TYPE:
+      Bulk: [0, "Bulk endpoint"]
+      Control: [1, "Control endpoint"]
+      Iso: [2, "Iso endpoint"]
+      Interrupt: [3, "Interrupt endpoint"]
+    EP_KIND: 
+      #"DBL_BUF if EP_TYPE=Bulk or STATUS_OUT if EP_TYPE=Control"]
+    CTR_TX:
+    DTOG_TX:
+    STAT_TX:
+      Disabled: [0, "all transmission requests addressed to this endpoint are ignored"]
+      Stall: [1, "the endpoint is stalled and all transmission requests result in a STALL handshake"]
+      Nak: [2, "the endpoint is naked and all transmission requests result in a NAK handshake"]
+      Valid: [3, "this endpoint is enabled for transmission"]
+    EA: [0, 0b1111]

--- a/peripherals/usb/usb_with_LPM.yaml
+++ b/peripherals/usb/usb_with_LPM.yaml
@@ -1,0 +1,15 @@
+# Extends USB peripheral with Low-Power Mode
+
+_include:
+ - usb.yaml
+
+USB:
+  CNTR:
+    L1REQM:
+      Disabled: [0, "L1REQ Interrupt disabled"]
+      Enabled: [1, "L1REQ Interrupt enabled, an interrupt request is generated when the corresponding bit in the USB_ISTR register is set"]
+    L1RESUME:
+      Requested: [1, "LPM L1 request requested"]
+  ISTR:
+    L1REQ:
+      Received: [1, "LPM command to enter the L1 state is successfully received and acknowledged"] 

--- a/peripherals/usb/usb_with_LPM.yaml
+++ b/peripherals/usb/usb_with_LPM.yaml
@@ -22,3 +22,31 @@ USB:
     LPMEN:
       Disabled: [0, "enable the LPM support within the USB device"]
       Enabled: [1, "no LPM transactions are handled"]
+  BCDR:
+    DPPU:
+      Disabled: [0, "signalize disconnect to the host when needed by the user software"]
+      Enabled: [1, "enable the embedded pull-up on the DP line"]
+    PS2DET:
+      Normal: [0, "Normal port detected"]
+      PS2: [1, "PS2 port or proprietary charger detected"]
+    SDET:
+      CDP: [0, "CDP detected"]
+      DCP: [1, "DCP detected"]
+    PDET:
+      NoBCD: [0, "no BCD support detected"]
+      BCD: [1, "BCD support detected"]
+    DCDET:
+      NotDetected: [0, "data lines contact not detected"]
+      Detected: [1, "data lines contact detected"]
+    SDEN:
+      Disabled: [0, "Secondary detection (SD) mode disabled"]
+      Enabled: [1, "Secondary detection (SD) mode enabled"]
+    PDEN:
+      Disabled: [0, "Primary detection (PD) mode disabled"]
+      Enabled: [1, "Primary detection (PD) mode enabled"]
+    DCDEN:
+      Disabled: [0, "Data contact detection (DCD) mode disabled"]
+      Enabled: [1, "Data contact detection (DCD) mode enabled"]
+    BCDEN:
+      Disabled: [0, "disable the BCD support"]
+      Enabled: [1, "enable the BCD support within the USB device"]

--- a/peripherals/usb/usb_with_LPM.yaml
+++ b/peripherals/usb/usb_with_LPM.yaml
@@ -13,3 +13,12 @@ USB:
   ISTR:
     L1REQ:
       Received: [1, "LPM command to enter the L1 state is successfully received and acknowledged"] 
+  LPMCSR:
+    BESL: [0, 0b1111]
+    REMWAKE:
+    LPMACK:
+      Nyet: [0, "the valid LPM Token will be NYET"]
+      Ack: [1, "the valid LPM Token will be ACK"]
+    LPMEN:
+      Disabled: [0, "enable the LPM support within the USB device"]
+      Enabled: [1, "no LPM transactions are handled"]


### PR DESCRIPTION
Documents the USB peripheral on F0, F1, F3, L0 and L1 families.

- Unprefix USB peripherals
- Documents registers.
- Rename some fields.
- Partial revert a commit that document USB field for stm32f103 device.

I write those some time ago. Perhaps they are good enough to be merged in or perhaps not.