### PR TITLE
stm32l0xy: fix wakeup pin bits in the PWR_CSR register

### DIFF
--- a/devices/common_patches/l0_pwr_wakeup.yaml
+++ b/devices/common_patches/l0_pwr_wakeup.yaml
@@ -1,0 +1,18 @@
+# Fix wakeup bits in PWR_CSR, and rename one more flag
+PWR:
+  CSR:
+    _modify:
+      EWUP:
+        name: EWUP1
+        description: Enable WKUP pin 1
+      BRE:
+        name: EWUP2
+        description: Enable WKUP pin 2
+      BRR:
+        name: VREFINTRDYF
+        description: Internal voltage reference ready flag
+    _add:
+      EWUP3:
+        description: Enable WKUP pin 3
+        bitOffset: 10
+        bitWidth: 1

--- a/devices/stm32l0x1.yaml
+++ b/devices/stm32l0x1.yaml
@@ -1,6 +1,7 @@
 _svd: ../svd/stm32l0x1.svd
 
 _include:
+ - ./common_patches/l0_pwr_wakeup.yaml
  - ./common_patches/merge_USART_CR1_DEATx_fields.yaml
  - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
  - ./common_patches/merge_USART_CR2_ABRMODx_fields.yaml

--- a/devices/stm32l0x2.yaml
+++ b/devices/stm32l0x2.yaml
@@ -6,6 +6,7 @@ _modify:
     name: LPUART1
 
 _include:
+ - ./common_patches/l0_pwr_wakeup.yaml
  - ./common_patches/merge_USART_CR1_DEATx_fields.yaml
  - ./common_patches/merge_USART_CR1_DEDTx_fields.yaml
  - ./common_patches/merge_USART_CR2_ADDx_fields.yaml

--- a/devices/stm32l0x3.yaml
+++ b/devices/stm32l0x3.yaml
@@ -5,7 +5,9 @@ _modify:
   LPUSART1:
     name: LPUART1
 
+
 _include:
+ - ./common_patches/l0_pwr_wakeup.yaml
  - ./common_patches/merge_USART_CR1_DEATx_fields.yaml
  - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
  - ./common_patches/merge_USART_CR2_ABRMODx_fields.yaml


### PR DESCRIPTION
Now behaves according to the reference manuals.