### PR TITLE
Cleanup and document STM32F0 SYSCFG and COMP registers

### DIFF
--- a/devices/common_patches/f0_syscfg.yaml
+++ b/devices/common_patches/f0_syscfg.yaml
@@ -1,0 +1,16 @@
+SYSCFG:
+  CFGR1:
+    _delete:
+      - I2C2_FM_plus
+      - SPI2_DMA_RMP
+      - USART2_DMA_RMP
+      - I2C1_DMA_RMP
+      - TIM1_DMA_RMP
+      - TIM2_DMA_RMP
+      - TIM3_DMA_RMP
+  CFGR2:
+    _delete:
+      - PVD_LOCK
+
+_include:
+ - ./f0_syscfg_common.yaml

--- a/devices/common_patches/f0_syscfg_common.yaml
+++ b/devices/common_patches/f0_syscfg_common.yaml
@@ -1,0 +1,30 @@
+SYSCFG:
+  CFGR1:
+    _add:
+      PA11_PA12_RMP:
+        description: "PA11 and PA12 remapping bit for small packages (28 and 20 pins)"
+        bitOffset: 4
+        bitWidth: 1
+      I2C_PA9_FMP:
+        description: "Fast Mode Plus (FM+) driving capability activation bits"
+        bitOffset: 22
+        bitWidth: 1
+      I2C_PA10_FMP:
+        description: "Fast Mode Plus (FM+) driving capability activation bits"
+        bitOffset: 23
+        bitWidth: 1
+    _modify:
+      I2C_PB6_FM:
+        name: I2C_PB6_FMP
+      I2C_PB7_FM:
+        name: I2C_PB7_FMP
+      I2C_PB8_FM:
+        name: I2C_PB8_FMP
+      I2C_PB9_FM:
+        name: I2C_PB9_FMP
+      I2C1_FM_plus:
+        name: I2C1_FMP
+  CFGR2:
+    _modify:
+      LOCUP_LOCK:
+        name: LOCKUP_LOCK

--- a/devices/common_patches/f0_syscfg_comp.yaml
+++ b/devices/common_patches/f0_syscfg_comp.yaml
@@ -1,0 +1,150 @@
+_modify:
+  SYSCFG_COMP:
+    name: SYSCFG
+
+SYSCFG:
+  _modify:
+    SYSCFG_CFGR1:
+      name: CFGR1
+      displayName: CFGR1
+    SYSCFG_CFGR2:
+      name: CFGR2
+      displayName: CFGR2
+    SYSCFG_EXTICR1:
+      name: EXTICR1
+      displayName: EXTICR1
+    SYSCFG_EXTICR2:
+      name: EXTICR2
+      displayName: EXTICR2
+    SYSCFG_EXTICR3:
+      name: EXTICR3
+      displayName: EXTICR3
+    SYSCFG_EXTICR4:
+      name: EXTICR4
+      displayName: EXTICR4
+  _delete:
+    - COMP_CSR
+  CFGR1:
+    _add:
+      IR_MOD:
+        description: "IR Modulation Envelope signal selection"
+        bitOffset: 6
+        bitWidth: 2
+      TIM16_DMA_RMP2:
+        description: "TIM16 alternate DMA request remapping bit"
+        bitOffset: 13
+        bitWidth: 1
+      TIM17_DMA_RMP2:
+        description: "TIM17 alternate DMA request remapping bit"
+        bitOffset: 14
+        bitWidth: 1
+    _modify:
+      I2C2_FM_plus:
+        name: I2C2_FMP
+
+_include:
+ - ./f0_syscfg_common.yaml
+
+_add:
+  COMP:
+    description: "General purpose comparators"
+    baseAddress: 0x40010000
+    addressBlock:
+      offset: 0
+    registers:
+      CSR:
+        description: control and status register
+        addressOffset: 0x1C
+        size: 0x20
+        resetValue: 0x00000000
+        fields:
+          COMP1EN:
+            description: Comparator 1 enable
+            bitOffset: 0
+            bitWidth: 1
+            access: read-write
+          COMP1SW1:
+            description: Comparator 1 non inverting input DAC switch
+            bitOffset: 1
+            bitWidth: 1
+            access: read-write
+          COMP1MODE:
+            description: Comparator 1 mode
+            bitOffset: 2
+            bitWidth: 2
+            access: read-write
+          COMP1INSEL:
+            description: Comparator 1 inverting input selection
+            bitOffset: 4
+            bitWidth: 3
+            access: read-write
+          COMP1OUTSEL:
+            description: Comparator 1 output selection
+            bitOffset: 8
+            bitWidth: 3
+            access: read-write
+          COMP1POL:
+            description: Comparator 1 output polarity
+            bitOffset: 11
+            bitWidth: 1
+            access: read-write
+          COMP1HYST:
+            description: Comparator 1 hysteresis
+            bitOffset: 12
+            bitWidth: 2
+            access: read-write
+          COMP1OUT:
+            description: Comparator 1 output
+            bitOffset: 14
+            bitWidth: 1
+            access: read-only
+          COMP1LOCK:
+            description: Comparator 1 lock
+            bitOffset: 15
+            bitWidth: 1
+            access: read-write
+          COMP2EN:
+            description: Comparator 2 enable
+            bitOffset: 16
+            bitWidth: 1
+            access: read-write
+          COMP2MODE:
+            description: Comparator 2 mode
+            bitOffset: 18
+            bitWidth: 2
+            access: read-write
+          COMP2INSEL:
+            description: Comparator 2 inverting input selection
+            bitOffset: 20
+            bitWidth: 3
+            access: read-write
+          WNDWEN:
+            description: Window mode enable
+            bitOffset: 23
+            bitWidth: 1
+            access: read-write
+          COMP2OUTSEL:
+            description: Comparator 2 output selection
+            bitOffset: 24
+            bitWidth: 3
+            access: read-write
+          COMP2POL:
+            description: Comparator 2 output polarity
+            bitOffset: 27
+            bitWidth: 1
+            access: read-write
+          COMP2HYST:
+            description: Comparator 2 hysteresis
+            bitOffset: 28
+            bitWidth: 2
+            access: read-write
+          COMP2OUT:
+            description: Comparator 2 output
+            bitOffset: 30
+            bitWidth: 1
+            access: read-only
+          COMP2LOCK:
+            description: Comparator 2 lock
+            bitOffset: 31
+            bitWidth: 1
+            access: read-write

--- a/devices/stm32f0x0.yaml
+++ b/devices/stm32f0x0.yaml
@@ -34,3 +34,4 @@ _include:
  - ../peripherals/dma/dma_v1.yaml
  - ../peripherals/i2c/i2c_v2.yaml
  - ../peripherals/usart/usart_v2B1.yaml
+ - ../peripherals/syscfg/syscfg_f0.yaml

--- a/devices/stm32f0x0.yaml
+++ b/devices/stm32f0x0.yaml
@@ -15,6 +15,7 @@ _include:
  - ./common_patches/f0_adc_cfgr2_ckmode.yaml
  - ./common_patches/f0_usart6.yaml
  - ./common_patches/f0_dmaen.yaml
+ - ./common_patches/f0_syscfg.yaml
  - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
  - ./common_patches/rename_USART_CR1_M0_field.yaml
  - ./common_patches/merge_USART_BRR_fields.yaml

--- a/devices/stm32f0x1.yaml
+++ b/devices/stm32f0x1.yaml
@@ -34,3 +34,4 @@ _include:
  - ../peripherals/dma/dma_v1.yaml
  - ../peripherals/i2c/i2c_v2.yaml
  - ../peripherals/usart/usart_v2B1.yaml
+ - ../peripherals/syscfg/syscfg_f0x128.yaml

--- a/devices/stm32f0x1.yaml
+++ b/devices/stm32f0x1.yaml
@@ -35,3 +35,4 @@ _include:
  - ../peripherals/i2c/i2c_v2.yaml
  - ../peripherals/usart/usart_v2B1.yaml
  - ../peripherals/syscfg/syscfg_f0x128.yaml
+ - ../peripherals/comp/comp_f0.yaml

--- a/devices/stm32f0x1.yaml
+++ b/devices/stm32f0x1.yaml
@@ -13,6 +13,7 @@ _include:
  - ./common_patches/merge_I2C_OAR1_OA1x_fields.yaml
  - ./common_patches/f0_adc_cfgr2_ckmode.yaml
  - ./common_patches/f0_dmaen.yaml
+ - ./common_patches/f0_syscfg_comp.yaml
  - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
  - ./common_patches/rename_USART_CR1_M0_field.yaml
  - ./common_patches/merge_USART_BRR_fields.yaml

--- a/devices/stm32f0x2.yaml
+++ b/devices/stm32f0x2.yaml
@@ -42,3 +42,4 @@ _include:
  - ../peripherals/dma/dma_v1.yaml
  - ../peripherals/i2c/i2c_v2.yaml
  - ../peripherals/usart/usart_v2B1.yaml
+ - ../peripherals/syscfg/syscfg_f0x128.yaml

--- a/devices/stm32f0x2.yaml
+++ b/devices/stm32f0x2.yaml
@@ -21,6 +21,7 @@ _include:
  - ./common_patches/f0_adc_cfgr2_ckmode.yaml
  - ./common_patches/f0_usart6.yaml
  - ./common_patches/f0_dmaen.yaml
+ - ./common_patches/f0_syscfg_comp.yaml
  - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
  - ./common_patches/rename_USART_CR1_M0_field.yaml
  - ./common_patches/merge_USART_BRR_fields.yaml

--- a/devices/stm32f0x2.yaml
+++ b/devices/stm32f0x2.yaml
@@ -43,3 +43,4 @@ _include:
  - ../peripherals/i2c/i2c_v2.yaml
  - ../peripherals/usart/usart_v2B1.yaml
  - ../peripherals/syscfg/syscfg_f0x128.yaml
+ - ../peripherals/comp/comp_f0.yaml

--- a/devices/stm32f0x8.yaml
+++ b/devices/stm32f0x8.yaml
@@ -28,3 +28,4 @@ _include:
  - ../peripherals/dma/dma_v1.yaml
  - ../peripherals/i2c/i2c_v2.yaml
  - ../peripherals/usart/usart_v2B1.yaml
+ - ../peripherals/syscfg/syscfg_f0x128.yaml

--- a/devices/stm32f0x8.yaml
+++ b/devices/stm32f0x8.yaml
@@ -7,6 +7,7 @@ _include:
  - ./common_patches/f0_adc_cfgr2_ckmode.yaml
  - ./common_patches/f0_usart6.yaml
  - ./common_patches/f0_dmaen.yaml
+ - ./common_patches/f0_syscfg_comp.yaml
  - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
  - ./common_patches/rename_USART_CR1_M0_field.yaml
  - ./common_patches/merge_USART_BRR_fields.yaml

--- a/devices/stm32f0x8.yaml
+++ b/devices/stm32f0x8.yaml
@@ -29,3 +29,4 @@ _include:
  - ../peripherals/i2c/i2c_v2.yaml
  - ../peripherals/usart/usart_v2B1.yaml
  - ../peripherals/syscfg/syscfg_f0x128.yaml
+ - ../peripherals/comp/comp_f0.yaml

--- a/peripherals/comp/comp_f0.yaml
+++ b/peripherals/comp/comp_f0.yaml
@@ -1,0 +1,86 @@
+COMP:
+  CSR:
+    COMP1EN:
+      Disabled: [0, "Comparator 1 disabled"]
+      Enabled: [1, "Comparator 1 enabled"]
+    COMP1SW1:
+      Open: [0, "Switch open"]
+      Closed: [1, "Switch closed"]
+    COMP1MODE:
+      HighSpeed: [0, "High speed / full power"]
+      MediumSpeed: [1, "Medium speed / medium power"]
+      LowSpeed: [2, "Low speed / low power"]
+      VeryLowSpeed: [3, "Very-low speed / ultra-low power"]
+    COMP1INSEL:
+      OneQuarterVRef: [0, "1/4 of VRefint"]
+      OneHalfVRef: [1, "1/2 of VRefint"]
+      ThreeQuarterVRef: [2, "3/4 of VRefint"]
+      VRef: [3, "VRefint"]
+      Comp1_INM4: [4, "COMP1_INM4 (PA4 with DAC_OUT1 if enabled)"]
+      Comp1_INM5: [5, "COMP1_INM5 (PA5 with DAC_OUT2 if present and enabled)"]
+      Comp1_INM6: [6, "COMP1_INM6 (PA0)"]
+    COMP1OUTSEL:
+      NoSelection: [0, "No selection"]
+      Timer1BreakInput: [1, "Timer 1 break input"]
+      Timer1InputCapture1: [2, "Timer 1 Input capture 1"]
+      Timer1OCRefClearInput: [3, "Timer 1 OCrefclear input"]
+      Timer2InputCapture4: [4, "Timer 2 input capture 4"]
+      Timer2OCRefClearInput: [5, "Timer 2 OCrefclear input"]
+      Timer3InputCapture1: [6, "Timer 3 input capture 1"]
+      Timer3OCRefClearInput: [7, "Timer 3 OCrefclear input"]
+    COMP1POL:
+      NotInverted: [0, "Output is not inverted"]
+      Inverted: [1, "Output is inverted"]
+    COMP1HYST:
+      NoHysteresis: [0, "No hysteresis"]
+      LowHysteresis: [1, "Low hysteresis"]
+      MediumHysteresis: [2, "Medium hysteresis"]
+      HighHysteresis: [3, "High hysteresis"]
+    COMP1OUT:
+      Low: [0, "Non-inverting input below inverting input"]
+      High: [1, "Non-inverting input above inverting input"]
+    COMP1LOCK:
+      Unlocked: [0, "Comparator 1 CSR bits (CSR[15:0]) are read-write"]
+      Locked: [1, "Comparator 1 CSR bits (CSR[15:0]) are read-only"]
+    COMP2EN:
+      Disabled: [0, "Comparator 2 disabled"]
+      Enabled: [1, "Comparator 2 enabled"]
+    COMP2MODE:
+      HighSpeed: [0, "High speed / full power"]
+      MediumSpeed: [1, "Medium speed / medium power"]
+      LowSpeed: [2, "Low speed / low power"]
+      VeryLowSpeed: [3, "Very-low speed / ultra-low power"]
+    COMP2INSEL:
+      OneQuarterVRef: [0, "1/4 of VRefint"]
+      OneHalfVRef: [1, "1/2 of VRefint"]
+      ThreeQuarterVRef: [2, "3/4 of VRefint"]
+      VRef: [3, "VRefint"]
+      Comp2_INM4: [4, "COMP1_INM4 (PA4 with DAC_OUT1 if enabled)"]
+      Comp2_INM5: [5, "COMP1_INM5 (PA5 with DAC_OUT2 if present and enabled)"]
+      Comp2_INM6: [6, "COMP1_INM6 (PA2)"]
+    WNDWEN:
+      Disabled: [0, "Window mode disabled"]
+      Enabled: [1, "Window mode enabled"]
+    COMP2OUTSEL:
+      NoSelection: [0, "No selection"]
+      Timer1BreakInput: [1, "Timer 1 break input"]
+      Timer1InputCapture1: [2, "Timer 1 Input capture 1"]
+      Timer1OCRefClearInput: [3, "Timer 1 OCrefclear input"]
+      Timer2InputCapture4: [4, "Timer 2 input capture 4"]
+      Timer2OCRefClearInput: [5, "Timer 2 OCrefclear input"]
+      Timer3InputCapture1: [6, "Timer 3 input capture 1"]
+      Timer3OCRefClearInput: [7, "Timer 3 OCrefclear input"]
+    COMP2POL:
+      NotInverted: [0, "Output is not inverted"]
+      Inverted: [1, "Output is inverted"]
+    COMP2HYST:
+      NoHysteresis: [0, "No hysteresis"]
+      LowHysteresis: [1, "Low hysteresis"]
+      MediumHysteresis: [2, "Medium hysteresis"]
+      HighHysteresis: [3, "High hysteresis"]
+    COMP2OUT:
+      Low: [0, "Non-inverting input below inverting input"]
+      High: [1, "Non-inverting input above inverting input"]
+    COMP2LOCK:
+      Unlocked: [0, "Comparator 2 CSR bits (CSR[31:16]) are read-write"]
+      Locked: [1, "Comparator 2 CSR bits (CSR[31:16]) are read-only"]

--- a/peripherals/syscfg/syscfg_f0.yaml
+++ b/peripherals/syscfg/syscfg_f0.yaml
@@ -1,0 +1,159 @@
+SYSCFG:
+  CFGR1:
+    MEM_MODE:
+      MainFlash: [0, "Main Flash memory mapped at 0x0000_0000"]
+      SystemFlash: [1, "System Flash memory mapped at 0x0000_0000"]
+      MainFlash2: [2, "Main Flash memory mapped at 0x0000_0000"]
+      SRAM: [3, "Embedded SRAM mapped at 0x0000_0000"]
+    PA11_PA12_RMP:
+      NotRemapped: [0, "Pin pair PA9/PA10 mapped on the pins"]
+      Remapped: [1, "Pin pair PA11/PA12 mapped instead of PA9/PA10"]
+    ADC_DMA_RMP:
+      NotRemapped: [0, "ADC DMA request mapped on DMA channel 1"]
+      Remapped: [1, "ADC DMA request mapped on DMA channel 2"]
+    USART1_TX_DMA_RMP:
+      NotRemapped: [0, "USART1_TX DMA request mapped on DMA channel 2"]
+      Remapped: [1, "USART1_TX DMA request mapped on DMA channel 4"]
+    USART1_RX_DMA_RMP:
+      NotRemapped: [0, "USART1_RX DMA request mapped on DMA channel 3"]
+      Remapped: [1, "USART1_RX DMA request mapped on DMA channel 5"]
+    TIM16_DMA_RMP:
+      NotRemapped: [0, "TIM16_CH1 and TIM16_UP DMA request mapped on DMA channel 3"]
+      Remapped: [1, "TIM16_CH1 and TIM16_UP DMA request mapped on DMA channel 4"]
+    TIM17_DMA_RMP:
+      NotRemapped: [0, "TIM17_CH1 and TIM17_UP DMA request mapped on DMA channel 1"]
+      Remapped: [1, "TIM17_CH1 and TIM17_UP DMA request mapped on DMA channel 2"]
+    I2C_PB6_FMP:
+      Standard: [0, "PB6 pin operate in standard mode"]
+      FMP: [1, "I2C FM+ mode enabled on PB6 and the Speed control is bypassed"]
+    I2C_PB7_FMP:
+      Standard: [0, "PB7 pin operate in standard mode"]
+      FMP: [1, "I2C FM+ mode enabled on PB7 and the Speed control is bypassed"]
+    I2C_PB8_FMP:
+      Standard: [0, "PB8 pin operate in standard mode"]
+      FMP: [1, "I2C FM+ mode enabled on PB8 and the Speed control is bypassed"]
+    I2C_PB9_FMP:
+      Standard: [0, "PB9 pin operate in standard mode"]
+      FMP: [1, "I2C FM+ mode enabled on PB9 and the Speed control is bypassed"]
+    I2C1_FMP:
+      Standard: [0, "FM+ mode is controlled by I2C_Pxx_FMP bits only"]
+      FMP: [1, "FM+ mode is enabled on all I2C1 pins selected through selection bits in GPIOx_AFR registers"]
+    I2C_PA9_FMP:
+      Standard: [0, "PA9 pin operate in standard mode"]
+      FMP: [1, "I2C FM+ mode enabled on PA9 and the Speed control is bypassed"]
+    I2C_PA10_FMP:
+      Standard: [0, "PA10 pin operate in standard mode"]
+      FMP: [1, "I2C FM+ mode enabled on PA10 and the Speed control is bypassed"]
+    USART3_DMA_RMP:
+      NotRemapped: [0, "USART3_RX and USART3_TX DMA requests mapped on DMA channel 6 and 7 respectively (or simply disabled on STM32F0x0)"]
+      Remapped: [1, "USART3_RX and USART3_TX DMA requests mapped on DMA channel 3 and 2 respectively"]
+  CFGR2:
+    LOCKUP_LOCK:
+      Disconnected: [0, "Cortex-M0 LOCKUP output disconnected from TIM1/15/16/17 Break input"]
+      Connected: [1, "Cortex-M0 LOCKUP output connected to TIM1/15/16/17 Break input"]
+    SRAM_PARITY_LOCK:
+      Disconnected: [0, "SRAM parity error disconnected from TIM1/15/16/17 Break input"]
+      Connected: [1, "SRAM parity error connected to TIM1/15/16/17 Break input"]
+    SRAM_PEF:
+      NoParityError: [0, "No SRAM parity error detected"]
+      ParityErrorDetected: [1, "SRAM parity error detected"]
+  EXTICR1:
+    EXTI0:
+      PA0: [0, "Select PA0 as the source input for the EXTI0 external interrupt"]
+      PB0: [1, "Select PB0 as the source input for the EXTI0 external interrupt"]
+      PC0: [2, "Select PC0 as the source input for the EXTI0 external interrupt"]
+      PD0: [3, "Select PD0 as the source input for the EXTI0 external interrupt"]
+      PF0: [5, "Select PF0 as the source input for the EXTI0 external interrupt"]
+    EXTI1:
+      PA1: [0, "Select PA1 as the source input for the EXTI1 external interrupt"]
+      PB1: [1, "Select PB1 as the source input for the EXTI1 external interrupt"]
+      PC1: [2, "Select PC1 as the source input for the EXTI1 external interrupt"]
+      PD1: [3, "Select PD1 as the source input for the EXTI1 external interrupt"]
+      PF1: [5, "Select PF1 as the source input for the EXTI1 external interrupt"]
+    EXTI2:
+      PA2: [0, "Select PA2 as the source input for the EXTI2 external interrupt"]
+      PB2: [1, "Select PB2 as the source input for the EXTI2 external interrupt"]
+      PC2: [2, "Select PC2 as the source input for the EXTI2 external interrupt"]
+      PD2: [3, "Select PD2 as the source input for the EXTI2 external interrupt"]
+      PF2: [5, "Select PF2 as the source input for the EXTI2 external interrupt"]
+    EXTI3:
+      PA3: [0, "Select PA3 as the source input for the EXTI3 external interrupt"]
+      PB3: [1, "Select PB3 as the source input for the EXTI3 external interrupt"]
+      PC3: [2, "Select PC3 as the source input for the EXTI3 external interrupt"]
+      PD3: [3, "Select PD3 as the source input for the EXTI3 external interrupt"]
+      PF3: [5, "Select PF3 as the source input for the EXTI3 external interrupt"]
+  EXTICR2:
+    EXTI4:
+      PA4: [0, "Select PA4 as the source input for the EXTI4 external interrupt"]
+      PB4: [1, "Select PB4 as the source input for the EXTI4 external interrupt"]
+      PC4: [2, "Select PC4 as the source input for the EXTI4 external interrupt"]
+      PD4: [3, "Select PD4 as the source input for the EXTI4 external interrupt"]
+      PF4: [5, "Select PF4 as the source input for the EXTI4 external interrupt"]
+    EXTI5:
+      PA5: [0, "Select PA5 as the source input for the EXTI5 external interrupt"]
+      PB5: [1, "Select PB5 as the source input for the EXTI5 external interrupt"]
+      PC5: [2, "Select PC5 as the source input for the EXTI5 external interrupt"]
+      PD5: [3, "Select PD5 as the source input for the EXTI5 external interrupt"]
+      PF5: [5, "Select PF5 as the source input for the EXTI5 external interrupt"]
+    EXTI6:
+      PA6: [0, "Select PA6 as the source input for the EXTI6 external interrupt"]
+      PB6: [1, "Select PB6 as the source input for the EXTI6 external interrupt"]
+      PC6: [2, "Select PC6 as the source input for the EXTI6 external interrupt"]
+      PD6: [3, "Select PD6 as the source input for the EXTI6 external interrupt"]
+      PF6: [5, "Select PF6 as the source input for the EXTI6 external interrupt"]
+    EXTI7:
+      PA7: [0, "Select PA7 as the source input for the EXTI7 external interrupt"]
+      PB7: [1, "Select PB7 as the source input for the EXTI7 external interrupt"]
+      PC7: [2, "Select PC7 as the source input for the EXTI7 external interrupt"]
+      PD7: [3, "Select PD7 as the source input for the EXTI7 external interrupt"]
+      PF7: [5, "Select PF7 as the source input for the EXTI7 external interrupt"]
+  EXTICR3:
+    EXTI8:
+      PA8: [0, "Select PA8 as the source input for the EXTI8 external interrupt"]
+      PB8: [1, "Select PB8 as the source input for the EXTI8 external interrupt"]
+      PC8: [2, "Select PC8 as the source input for the EXTI8 external interrupt"]
+      PD8: [3, "Select PD8 as the source input for the EXTI8 external interrupt"]
+      PF8: [5, "Select PF8 as the source input for the EXTI8 external interrupt"]
+    EXTI9:
+      PA9: [0, "Select PA9 as the source input for the EXTI9 external interrupt"]
+      PB9: [1, "Select PB9 as the source input for the EXTI9 external interrupt"]
+      PC9: [2, "Select PC9 as the source input for the EXTI9 external interrupt"]
+      PD9: [3, "Select PD9 as the source input for the EXTI9 external interrupt"]
+      PF9: [5, "Select PF9 as the source input for the EXTI9 external interrupt"]
+    EXTI10:
+      PA10: [0, "Select PA10 as the source input for the EXTI10 external interrupt"]
+      PB10: [1, "Select PB10 as the source input for the EXTI10 external interrupt"]
+      PC10: [2, "Select PC10 as the source input for the EXTI10 external interrupt"]
+      PD10: [3, "Select PD10 as the source input for the EXTI10 external interrupt"]
+      PF10: [5, "Select PF10 as the source input for the EXTI10 external interrupt"]
+    EXTI11:
+      PA11: [0, "Select PA11 as the source input for the EXTI11 external interrupt"]
+      PB11: [1, "Select PB11 as the source input for the EXTI11 external interrupt"]
+      PC11: [2, "Select PC11 as the source input for the EXTI11 external interrupt"]
+      PD11: [3, "Select PD11 as the source input for the EXTI11 external interrupt"]
+      PF11: [5, "Select PF11 as the source input for the EXTI11 external interrupt"]
+  EXTICR4:
+    EXTI12:
+      PA12: [0, "Select PA12 as the source input for the EXTI12 external interrupt"]
+      PB12: [1, "Select PB12 as the source input for the EXTI12 external interrupt"]
+      PC12: [2, "Select PC12 as the source input for the EXTI12 external interrupt"]
+      PD12: [3, "Select PD12 as the source input for the EXTI12 external interrupt"]
+      PF12: [5, "Select PF12 as the source input for the EXTI12 external interrupt"]
+    EXTI13:
+      PA13: [0, "Select PA13 as the source input for the EXTI13 external interrupt"]
+      PB13: [1, "Select PB13 as the source input for the EXTI13 external interrupt"]
+      PC13: [2, "Select PC13 as the source input for the EXTI13 external interrupt"]
+      PD13: [3, "Select PD13 as the source input for the EXTI13 external interrupt"]
+      PF13: [5, "Select PF13 as the source input for the EXTI13 external interrupt"]
+    EXTI14:
+      PA14: [0, "Select PA14 as the source input for the EXTI14 external interrupt"]
+      PB14: [1, "Select PB14 as the source input for the EXTI14 external interrupt"]
+      PC14: [2, "Select PC14 as the source input for the EXTI14 external interrupt"]
+      PD14: [3, "Select PD14 as the source input for the EXTI14 external interrupt"]
+      PF14: [5, "Select PF14 as the source input for the EXTI14 external interrupt"]
+    EXTI15:
+      PA15: [0, "Select PA15 as the source input for the EXTI15 external interrupt"]
+      PB15: [1, "Select PB15 as the source input for the EXTI15 external interrupt"]
+      PC15: [2, "Select PC15 as the source input for the EXTI15 external interrupt"]
+      PD15: [3, "Select PD15 as the source input for the EXTI15 external interrupt"]
+      PF15: [5, "Select PF15 as the source input for the EXTI15 external interrupt"]

--- a/peripherals/syscfg/syscfg_f0x128.yaml
+++ b/peripherals/syscfg/syscfg_f0x128.yaml
@@ -1,0 +1,76 @@
+_include:
+ - ./syscfg_f0.yaml
+
+SYSCFG:
+  CFGR1:
+    IR_MOD:
+      TIM16: [0, "TIM16 selected"]
+      USART1: [1, "USART1 selected"]
+      USART4: [2, "USART4 selected"]
+    TIM16_DMA_RMP2:
+      NotAlternateRemapped: [0, "TIM16 DMA request mapped according to TIM16_DMA_RMP bit"]
+      AlternateRemapped: [1, "TIM16_CH1 and TIM16_UP DMA request mapped on DMA channel 6"]
+    TIM17_DMA_RMP2:
+      NotAlternateRemapped: [0, "TIM17 DMA request mapped according to TIM16_DMA_RMP bit"]
+      AlternateRemapped: [1, "TIM17_CH1 and TIM17_UP DMA request mapped on DMA channel 7"]
+    I2C2_FMP:
+      Standard: [0, "FM+ mode is controlled by I2C_Pxx_FMP bits only"]
+      FMP: [1, "FM+ mode is enabled on all I2C2 pins selected through selection bits in GPIOx_AFR registers"]
+    SPI2_DMA_RMP:
+      NotRemapped: [0, "SPI2_RX and SPI2_TX DMA requests mapped on DMA channel 4 and 5 respectively"]
+      Remapped: [1, "SPI2_RX and SPI2_TX DMA requests mapped on DMA channel 6 and 7 respectively"]
+    USART2_DMA_RMP:
+      NotRemapped: [0, "USART2_RX and USART2_TX DMA requests mapped on DMA channel 5 and 4 respectively"]
+      Remapped: [1, "USART2_RX and USART2_TX DMA requests mapped on DMA channel 6 and 7 respectively"]
+    I2C1_DMA_RMP:
+      NotRemapped: [0, "I2C1_RX and I2C1_TX DMA requests mapped on DMA channel 3 and 2 respectively"]
+      Remapped: [1, "I2C1_RX and I2C1_TX DMA requests mapped on DMA channel 7 and 6 respectively"]
+    TIM1_DMA_RMP:
+      NotRemapped: [0, "TIM1_CH1, TIM1_CH2 and TIM1_CH3 DMA requests mapped on DMA channel 2, 3 and 4 respectively"]
+      Remapped: [1, "TIM1_CH1, TIM1_CH2 and TIM1_CH3 DMA requests mapped on DMA channel 6"]
+    TIM2_DMA_RMP:
+      NotRemapped: [0, "TIM2_CH2 and TIM2_CH4 DMA requests mapped on DMA channel 3 and 4 respectively"]
+      Remapped: [1, "TIM2_CH2 and TIM2_CH4 DMA requests mapped on DMA channel 7"]
+    TIM3_DMA_RMP:
+      NotRemapped: [0, "TIM3_CH1 and TIM3_TRIG DMA requests mapped on DMA channel 4"]
+      Remapped: [1, "TIM3_CH1 and TIM3_TRIG DMA requests mapped on DMA channel 6"]
+  CFGR2:
+    PVD_LOCK:
+      Disconnected: [0, "PVD interrupt disconnected from TIM1/15/16/17 Break input"]
+      Connected: [1, "PVD interrupt connected to TIM1/15/16/17 Break input"]
+  EXTICR1:
+    EXTI0:
+      PE0: [4, "Select PE0 as the source input for the EXTI0 external interrupt"]
+    EXTI1:
+      PE1: [4, "Select PE1 as the source input for the EXTI1 external interrupt"]
+    EXTI2:
+      PE2: [4, "Select PE2 as the source input for the EXTI2 external interrupt"]
+    EXTI3:
+      PE3: [4, "Select PE3 as the source input for the EXTI3 external interrupt"]
+  EXTICR2:
+    EXTI4:
+      PE4: [4, "Select PE4 as the source input for the EXTI4 external interrupt"]
+    EXTI5:
+      PE5: [4, "Select PE5 as the source input for the EXTI5 external interrupt"]
+    EXTI6:
+      PE6: [4, "Select PE6 as the source input for the EXTI6 external interrupt"]
+    EXTI7:
+      PE7: [4, "Select PE7 as the source input for the EXTI7 external interrupt"]
+  EXTICR3:
+    EXTI8:
+      PE8: [4, "Select PE8 as the source input for the EXTI8 external interrupt"]
+    EXTI9:
+      PE9: [4, "Select PE9 as the source input for the EXTI9 external interrupt"]
+    EXTI10:
+      PE10: [4, "Select PE10 as the source input for the EXTI10 external interrupt"]
+    EXTI11:
+      PE11: [4, "Select PE11 as the source input for the EXTI11 external interrupt"]
+  EXTICR4:
+    EXTI12:
+      PE12: [4, "Select PE12 as the source input for the EXTI12 external interrupt"]
+    EXTI13:
+      PE13: [4, "Select PE13 as the source input for the EXTI13 external interrupt"]
+    EXTI14:
+      PE14: [4, "Select PE14 as the source input for the EXTI14 external interrupt"]
+    EXTI15:
+      PE15: [4, "Select PE15 as the source input for the EXTI15 external interrupt"]


### PR DESCRIPTION
- remove fields that are not present on stm32f0x0
- rename fields that don't match the Reference Manual
- split SYSCFG_COMP into SYSCFG and COMP to match Reference Manual
- document all fields

Fix #122