### PR TITLE
Makefile: simplify rustfmt call

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ $(1)/src/%/.form: $(1)/src/%/mod.rs
 	form -i $$< -o $$(@D)
 	rm $$<
 	mv $$(@D)/lib.rs $$<
-	find $$(@D) -name "*.rs" -exec rustfmt {} +
+	rustfmt $$<
 	touch $$@
 
 $(1)/src/%/.check: $(1)/src/%/mod.rs


### PR DESCRIPTION
rustfmt will recurse through submodules itself.

This is required with new version of `form` which generate modules as xxx.rs instead of xxx/mod.rs.