### PR TITLE
Faster Travis Builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,4 @@ install:
 script:
   - cd svd && ./extract.sh && cd ..
   - make -j$(nproc) all
-  - CARGO_INCREMENTAL=0 make -j$(nproc) check
+  - CARGO_INCREMENTAL=0 make check

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ $(1)/src/%/.form: $(1)/src/%/mod.rs
 	touch $$@
 
 $(1)/src/%/.check: $(1)/src/%/mod.rs
-	cd $(1) && cargo check --target-dir ../target/check/$$* --features rt,$$*
+	cd $(1) && cargo check --target-dir ../target/check/ --features rt,$$*
 	touch $$@
 
 endef


### PR DESCRIPTION
Make the `make check` invocation run linearly (`-j1`) but with a common target dir to prevent rebuilding of deps.