### PR TITLE
Rcc documentation for stm32f2

### DIFF
--- a/devices/common_patches/f2_rcc.yaml
+++ b/devices/common_patches/f2_rcc.yaml
@@ -1,0 +1,15 @@
+RCC:
+  CFGR:
+    _merge:
+      - "MCO1[01]"
+      - "MCO1PRE[012]"
+      - "MCO2PRE[012]"
+      - "MCO2[01]"
+      - "RTCPRE[01234]"
+      - "PPRE2[012]"
+      - "PPRE1[0123]"
+      - "HPRE[0123]"
+  PLLI2SCFGR:
+    _merge:
+      - "PLLI2SR[012]"
+      - "PLLI2SN[012345678]"

--- a/devices/stm32f215.yaml
+++ b/devices/stm32f215.yaml
@@ -25,6 +25,7 @@ CRYP:
 _include:
  - common_patches/dma_fcr_wo.yaml
  - common_patches/merge_I2C_OAR1_ADDx_fields.yaml
+ - common_patches/f2_rcc.yaml
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml
  - ../peripherals/gpio/gpio_v2.yaml

--- a/devices/stm32f215.yaml
+++ b/devices/stm32f215.yaml
@@ -28,6 +28,11 @@ _include:
  - common_patches/f2_rcc.yaml
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml
+ - ../peripherals/rcc/rcc_merge_sw_sws.yaml
+ - ../peripherals/rcc/rcc_v2.yaml
+ - ../peripherals/rcc/rcc_v2_i2s.yaml
+ - ../peripherals/rcc/rcc_v2_i2s_pll.yaml
+ - ../peripherals/rcc/rcc_merge_rtcsel.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml

--- a/devices/stm32f217.yaml
+++ b/devices/stm32f217.yaml
@@ -25,6 +25,7 @@ CRYP:
 _include:
  - common_patches/dma_fcr_wo.yaml
  - common_patches/merge_I2C_OAR1_ADDx_fields.yaml
+ - common_patches/f2_rcc.yaml
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml
  - ../peripherals/gpio/gpio_v2.yaml

--- a/devices/stm32f217.yaml
+++ b/devices/stm32f217.yaml
@@ -28,6 +28,11 @@ _include:
  - common_patches/f2_rcc.yaml
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml
+ - ../peripherals/rcc/rcc_merge_sw_sws.yaml
+ - ../peripherals/rcc/rcc_v2.yaml
+ - ../peripherals/rcc/rcc_v2_i2s.yaml
+ - ../peripherals/rcc/rcc_v2_i2s_pll.yaml
+ - ../peripherals/rcc/rcc_merge_rtcsel.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/wwdg/wwdg.yaml


### PR DESCRIPTION
This is just a very quick pass at stm32f2 RCC. It is probably not exhaustive, and I may have a deeper look at stm32f2 later on. Still I think this quick PR should already be quite useful and I thought it might be worth considering if you want to make a release.