### PR TITLE
Updated L0 family to include all available perpherials

### DIFF
--- a/devices/common_patches/l0_flash.yaml
+++ b/devices/common_patches/l0_flash.yaml
@@ -1,0 +1,27 @@
+# Fix Write Protection for L0 Flash
+"FLASH":
+  _delete:
+    - WRPR
+  _add:
+    WRPROT1:
+      description: Write Protection Register 1
+      addressOffset: 0x20
+      size: 32
+      access: read-only
+      resetValue: 0x00000000
+      fields:
+        WRPROT1:
+          description: Write Protection
+          bitOffset: 0
+          bitWidth: 16
+    WRPROT2:
+      description: Write Protection Register 2
+      addressOffset: 0x80
+      size: 32
+      access: read-only
+      resetValue: 0x00000000
+      fields:
+        WRPROT2:
+          description: Write Protection
+          bitOffset: 16
+          bitWidth: 16

--- a/devices/common_patches/l0_pwr_mode.yaml
+++ b/devices/common_patches/l0_pwr_mode.yaml
@@ -1,0 +1,14 @@
+# Fix low power mode bits for L0
+
+PWR:
+  CR:
+    _modify:
+      LPDS:
+        description: Regulator in Low-power deepsleep mode
+        bitWidth: 1
+        bitOffset: 16
+    _add:
+      LPSDSR:
+        description: Low-power deepsleep/Sleep/Low-power run
+        bitWidth: 1
+        bitOffset: 0

--- a/devices/common_patches/l0_rtc.yaml
+++ b/devices/common_patches/l0_rtc.yaml
@@ -1,0 +1,28 @@
+# Fix RTC bits for L0
+
+RTC:
+  TAMPCR:
+    _modify:
+      TAMP2_TRG:
+        name: TAMP2TRG
+    _add:
+      TAMP3MF:
+        description: Tamper 3 mask flag
+        bitWidth: 1
+        bitOffset: 24
+      TAMP3NOERASE:
+        description: Tamper 3 no erase
+        bitWidth: 1
+        bitOffset: 23
+      TAMP3IE:
+        description: Tamper 3 interrupt enable
+        bitWidth: 1
+        bitOffset: 22
+      TAMP3TRG:
+        description: Active level for RTC_TAMP3 input
+        bitWidth: 1
+        bitOffset: 6
+      TAMP3E:
+        description: RTC_TAMP3 detection enable
+        bitWidth: 1
+        bitOffset: 5

--- a/devices/common_patches/l0_syscfg_cfgr.yaml
+++ b/devices/common_patches/l0_syscfg_cfgr.yaml
@@ -1,0 +1,49 @@
+# Add SYSCFG registers
+SYSCFG:
+  _modify:
+    COMP1_CTRL:
+      name: COMP1_CSR
+    COMP2_CTRL:
+      name: COMP2_CSR
+  CFGR1:
+    _add:
+      UFB:
+        description: "User bank swapping"
+        bitOffset: 3
+        bitWidth: 1
+  CFGR2:
+    _add:
+      I2C3_FMP:
+        description: I2C3 Fm+ drive capability enable bit
+        bitOffset: 14
+        bitWidth: 1
+      FWDIS:
+        description: Firewall disable bit
+        bitOffset: 0
+        bitWidth: 1
+    _delete:
+      - CAPA
+      - FWDISEN
+  CFGR3:
+    _delete:
+      - VREFINT_COMP_RDYF
+      - VREFINT_ADC_RDYF
+      - SENSOR_ADC_RDYF
+      - REF_RC48MHz_RDYF
+      - ENREF_RC48MHz
+      - ENBUF_VREFINT_COMP
+      - ENBUF_BGAP_ADC
+      - EN_BGAP
+    _add:
+      ENBUF_VREFINT_COMP2:
+        description: VREFINT reference for COMP2 scaler enable bit
+        bitOffset: 12
+        bitWidth: 1
+      ENBUF_VREFINT_ADC:
+        description: VREFINT reference for ADC enable bit
+        bitOffset: 8
+        bitWidth: 1
+      EN_VREFINT:
+        description: VREFINT enable and scaler control for COMP2 enable bit
+        bitOffset: 0
+        bitWidth: 1

--- a/devices/common_patches/remove_l0_mpu.yaml
+++ b/devices/common_patches/remove_l0_mpu.yaml
@@ -1,0 +1,3 @@
+# Remove MPU from L0 Family
+_delete:
+  - MPU

--- a/devices/common_patches/remove_l0_scb.yaml
+++ b/devices/common_patches/remove_l0_scb.yaml
@@ -1,0 +1,3 @@
+# Delete STK from L0 Family
+_delete:
+  - STK

--- a/devices/common_patches/remove_l0_stk.yaml
+++ b/devices/common_patches/remove_l0_stk.yaml
@@ -1,0 +1,3 @@
+# Delete SCB from L0 Family
+_delete:
+  - SCB

--- a/devices/stm32l0x1.yaml
+++ b/devices/stm32l0x1.yaml
@@ -1,7 +1,153 @@
 _svd: ../svd/stm32l0x1.svd
 
+_modify:
+  Flash:
+    name: FLASH
+  Firewall:
+    name: FW
+  SYSCFG_COMP:
+    name: SYSCFG
+
+ADC:
+  CFGR1:
+    _modify:
+      AUTDLY:
+        name: WAIT
+  SMPR:
+    _modify:
+      SMPR:
+        name: SMP
+
+AES:
+  DINR:
+    _modify:
+      AES_DINR:
+        name: DIN
+  DOUTR:
+    _modify:
+      AES_DOUTR:
+        name: DOUT
+  KEYR0:
+    _modify:
+      AES_KEYR0:
+        name: KEY0
+  KEYR1:
+    _modify:
+      AES_KEYR1:
+        name: KEY1
+  KEYR2:
+    _modify:
+      AES_KEYR2:
+        name: KEY2
+  KEYR3:
+    _modify:
+      AES_KEYR3:
+        name: KEY3
+  IVR0:
+    _modify:
+      AES_IVR0:
+        name: IV0
+  IVR1:
+    _modify:
+      AES_IVR1:
+        name: IV1
+  IVR2:
+    _modify:
+      AES_IVR2:
+        name: IV2
+  IVR3:
+    _modify:
+      AES_IVR3:
+        name: IV3
+CRC:
+  POL:
+    _modify:
+      Polynomialcoefficients:
+        name: POL
+
+FLASH:
+  _modify:
+    OBR:
+      name: OPTR
+  ACR:
+    _modify:
+      DESAB_BUF:
+        name: DISAB_BUF
+  PECR:
+    _modify:
+      FTDW:
+        name: FIX
+  OPTR:
+    _modify:
+      SPRMOD:
+        name: WPRMOD
+      RDPRT:
+        name: RDPROT
+
+FW:
+  _modify:
+    FIREWALL_CSSA:
+      name: CSSA
+    FIREWALL_CSL:
+      name: CSL
+    FIREWALL_NVDSSA:
+      name: NVDSSA
+    FIREWALL_NVDSL:
+      name: NVDSL
+    FIREWALL_VDSSA:
+      name: VDSSA
+    FIREWALL_VDSL:
+      name: VDSL
+    FIREWALL_CR:
+      name: CR
+
+"SPI*,I2S*":
+  SR:
+    _modify:
+      TIFRFE:
+        name: FRE
+
+RCC:
+  CR:
+    _modify:
+      CSSLSEON:
+        name: CSSHSEON
+  AHBRSTR:
+    _modify:
+      CRYPRST:
+        name: CRYPTRST
+  APB1RSTR:
+    _modify:
+      I2C3:
+        name: I2C3RST
+  CCIPR:
+    _merge: 
+      - "LPTIM1SEL*"
+      - "I2C3SEL*"
+      - "I2C1SEL*"
+      - "LPUART1SEL*"
+      - "USART2SEL*"
+      - "USART1SEL*"
+  CSR:
+    _modify:
+      LPWRSTF:
+        name: LPWRRSTF
+
+WWDG:
+  _modify:
+    WWDG_CR:
+      name: CR
+    WWDG_CFR:
+      name: CFR
+    WWDG_SR:
+      name: SR
+
 _include:
+ - ./common_patches/l0_flash.yaml
+ - ./common_patches/l0_pwr_mode.yaml
  - ./common_patches/l0_pwr_wakeup.yaml
+ - ./common_patches/l0_rtc.yaml
+ - ./common_patches/l0_syscfg_cfgr.yaml
  - ./common_patches/merge_USART_CR1_DEATx_fields.yaml
  - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
  - ./common_patches/merge_USART_CR2_ABRMODx_fields.yaml
@@ -12,14 +158,33 @@ _include:
  - ./common_patches/merge_LPUART_CR2_ADDx_fields.yaml
  - ./common_patches/rename_USART_CR2_DATAINV_field.yaml
  - ./common_patches/merge_USART_BRR_fields.yaml
- - ../peripherals/crc/crc_basic.yaml
- - ../peripherals/wwdg/wwdg.yaml
- - ../peripherals/pwr/pwr_v1.yaml
- - ../peripherals/tim/tim_basic.yaml
- - ../peripherals/tim/tim6.yaml
- - ../peripherals/tim/tim2_32bit.yaml
+ - ./common_patches/remove_l0_mpu.yaml
+ - ./common_patches/remove_l0_scb.yaml
+ - ./common_patches/remove_l0_stk.yaml
+ - ../peripherals/adc/adc_l0.yaml
+ - ../peripherals/aes/aes_l0.yaml
+ - ../peripherals/crc/crc_l0.yaml
  - ../peripherals/dma/dma_v1_with_remapping.yaml
- - ../peripherals/iwdg/iwdg_with_WINR.yaml
+ - ../peripherals/exti/exti_l0.yaml
+ - ../peripherals/flash/flash_l0.yaml
+ - ../peripherals/fw/fw_l0.yaml
+ - ../peripherals/gpio/gpio_l0.yaml
  - ../peripherals/i2c/i2c_v2.yaml
+ - ../peripherals/iwdg/iwdg_with_WINR.yaml
+ - ../peripherals/lptim/lptim_l0.yaml
+ - ../peripherals/nvic/nvic_v1.yaml
+ - ../peripherals/pwr/pwr_l0.yaml
+ - ../peripherals/tim/tim_basic.yaml
+ - ../peripherals/tim/tim_gp1.yaml
+ - ../peripherals/tim/tim6.yaml
+ - ../peripherals/tim/tim21.yaml
+ - ../peripherals/tim/tim2_32bit.yaml
+ - ../peripherals/tim/tim_l0.yaml
+ - ../peripherals/rcc/rcc_l0_l1_common.yaml
+ - ../peripherals/rcc/rcc_l0.yaml
+ - ../peripherals/rtc/rtc_l0.yaml
+ - ../peripherals/spi/spi_l0.yaml
+ - ../peripherals/syscfg/syscfg_l0.yaml
+ - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/usart/lpuart_v2A.yaml
  - ../peripherals/usart/usart_v2B1.yaml

--- a/devices/stm32l100.yaml
+++ b/devices/stm32l100.yaml
@@ -89,5 +89,6 @@ _include:
  - ../peripherals/tim/tim2_16bit.yaml
  - ../peripherals/iwdg/iwdg.yaml
  - ../peripherals/exti/exti_v1.yaml
+ - ../peripherals/rcc/rcc_l0_l1_common.yaml
  - ../peripherals/rcc/rcc_l1.yaml
  - ../peripherals/i2c/i2c_v1.yaml

--- a/peripherals/adc/adc_l0.yaml
+++ b/peripherals/adc/adc_l0.yaml
@@ -1,0 +1,226 @@
+# ADC as used on L0
+
+ADC:
+  ISR:
+    EOCAL:
+      _read:
+        NotComplete: [0, "Calibration is not complete"]
+        Complete: [1, "Calibration complete"]
+      _write:
+        Clear: [1, "Clear the calibration flag"]
+    AWD:
+      _read:
+        NoEvent: [0, "No analog watchdog event occurred"]
+        Event: [1, "Analog watchdog event occurred"]
+      _write:
+        Clear: [1, "Clear the analog watchdog event flag"]
+    OVR:
+      _read:
+        NoOverrun: [0, "No overrun occurred"]
+        Overrun: [1, "Overrun occurred"]
+      _write:
+        Clear: [1, "Clear the overrun flag"]
+    EOS:
+      _read:
+        NotComplete: [0, "Conversion sequence is not complete"]
+        Complete: [1, "Conversion sequence complete"]
+      _write:
+        Clear: [1, "Clear the conversion sequence flag"]
+    EOC:
+      _read:
+        NotComplete: [0, "Channel conversion is not complete"]
+        Complete: [1, "Channel conversion complete"]
+      _write:
+        Clear: [1, "Clear the channel conversion flag"]
+    EOSMP:
+      _read:
+        NotAtEnd: [0, "Not at the end of the samplings phase"]
+        AtEnd: [1, "End of sampling phase reached"]
+      _write:
+        Clear: [1, "Clear the sampling phase flag"]
+    ADRDY:
+      _read:
+        NotReady: [0, "ADC not yet ready to start conversion"]
+        Ready: [1, "ADC ready to start conversion"]
+      _write:
+        Clear: [1, "Clear the ADC ready flag"]
+  IER:
+    EOCALIE:
+      Disabled: [0, "End of calibration interrupt disabled"]
+      Enabled: [1, "End of calibration interrupt enabled"]
+    AWDIE:
+      Disabled: [0, "Analog watchdog interrupt disabled"]
+      Enabled: [1, "Analog watchdog interrupt enabled"]
+    OVRIE:
+      Disabled: [0, "Overrun interrupt disabled"]
+      Enabled: [1, "Overrun interrupt enabled. An interrupt is generated when the OVR bit is set."]
+    EOSIE:
+      Disabled: [0, "EOS interrupt disabled"]
+      Enabled: [1, "EOS interrupt enabled. An interrupt is generated when the EOS bit is set."]
+    EOCIE:
+      Disabled: [0, "EOC interrupt disabled"]
+      Enabled: [1, "EOC interrupt enabled. An interrupt is generated when the EOC bit is set."]
+    EOSMPIE:
+      Disabled: [0, "EOSMP interrupt disabled"]
+      Enabled: [1, "EOSMP interrupt enabled. An interrupt is generated when the EOSMP bit is set."]
+    ADRDYIE:
+      Disabled: [0, "ADRDY interrupt disabled"]
+      Enabled: [1, "ADRDY interrupt enabled. An interrupt is generated when the ADRDY bit is set."]
+  CR:
+    ADCAL:
+      _read:
+        NotCalibrating: [0, "ADC calibration either not yet performed or completed"]
+        Calibrating: [1, "ADC calibration in progress"]
+      _write:
+        StartCalibration: [1, "Start the ADC calibration sequence"]
+    ADVREGEN:
+      Disabled: [0, "ADC voltage regulator disabled"]
+      Enabled: [1, "ADC voltage regulator enabled"]
+    ADSTP:
+      _read:
+        NotStopping: [0, "No stop command active"]
+        Stopping: [1, "ADC stopping conversion"]
+      _write:
+        StopConversion: [1, "Stop the active conversion"]
+    ADSTART:
+      _read:
+        NotActive: [0, "No conversion ongoing"]
+        Active: [1, "ADC operating and may be converting"]
+      _write:
+        StartConversion: [1, "Start the ADC conversion (may be delayed for hardware triggers)"]
+    ADDIS:
+      _read:
+        NotDisabling: [0, "No disable command active"]
+        Disabling: [1, "ADC disabling"]
+      _write:
+        Disable: [1, "Disable the ADC"]
+    ADEN:
+      _read:
+        Disabled: [0, "ADC disabled"]
+        Enabled: [1, "ADC enabled"]
+      _write:
+        Enabled: [1, "Enable the ADC"]
+  CFGR1:
+    AWDCH: [0, 18]
+    AWDEN:
+      Disabled: [0, "Analog watchdog disabled"]
+      Enabled: [1, "Analog watchdog enabled"]
+    AWDSGL:
+      AllChannels: [0, "Analog watchdog enabled on all channels"]
+      SingleChannel: [1, "Analog watchdog enabled on a single channel"]
+    DISCEN:
+      Disabled: [0, "Discontinuous mode disabled"]
+      Enabled: [1, "Discontinuous mode enabled"]
+    AUTOFF:
+      Disabled: [0, "Auto-off mode disabled"]
+      Enabled: [1, "Auto-off mode enabled"]
+    WAIT:
+      Disabled: [0, "Wait conversion mode off"]
+      Enabled: [1, "Wait conversion mode on"]
+    CONT:
+      Single: [0, "Single conversion mode"]
+      Continuous: [1, "Continuous conversion mode"]
+    OVRMOD:
+      Preserve: [0, "ADC_DR register is preserved with the old data when an overrun is detected"]
+      Overwrite: [1, "ADC_DR register is overwritten with the last conversion result when an overrun is detected"]
+    EXTEN:
+      Disabled: [0, "Hardware trigger detection disabled"]
+      RisingEdge: [1, "Hardware trigger detection on the rising edge"]
+      FallingEdge: [2, "Hardware trigger detection on the falling edge"]
+      BothEdges: [3, "Hardware trigger detection on both the rising and falling edges"]
+    EXTSEL:
+      TIM6_TRGO: [0, "Timer 6 TRGO event"]
+      TIM21_CH2: [1, "Timer 21 CH2 event"]
+      TIM2_TRGO: [2, "Timer 2 TRGO event"]
+      TIM2_CH4: [3, "Timer 2 CH4 event"]
+      TIM22_TRGO: [4, "Timer 22 TRGO, Timer 21 TRGO event"]
+      TIM2_CH3: [5, "Timer 2 CH3 event"]
+      TIM3_TRGO: [6, "Timer 3 TRGO event"]
+      EXTI_LINE11: [7, "EXTI line 11 event"]
+    ALIGN:
+      Right: [0, "Right alignment"]
+      Left: [1, "Left alignment"]
+    RES:
+      TwelveBit: [0, "12 bits"]
+      TenBit: [1, "10 bits"]
+      EightBit: [2, "8 bits"]
+      SixBit: [3, "6 bits"]
+    SCANDIR:
+      Upward: [0, "Upward scan (from CHSEL0 to CHSEL18)"]
+      Backward: [1, "Backward scan (from CHSEL18 to CHSEL0)"]
+    DMACFG:
+      OneShot: [0, "DMA one shot mode selected"]
+      Circular: [1, "DMA circular mode selected"]
+    DMAEN:
+      Disabled: [0, "DMA disabled"]
+      Enabled: [1, "DMA enabled"]
+  CFGR2:
+    CKMODE:
+      ADCLK: [0, "ADCCLK (Asynchronous clock mode)"]
+      PCLK_Div2: [1, "PCLK/2 (Synchronous clock mode)"]
+      PCLK_Div4: [2, "PCLK/4 (Synchronous clock mode)"]
+      PCLK: [3, "PCLK (Synchronous clock mode)"]
+    TOVS:
+      TriggerAll: [0, "All oversampled conversions for a channel are done consecutively after a trigger"]
+      TriggerEach: [1, "Each oversampled conversion for a channel needs a trigger"]
+    OVSS: [0, 8]
+    OVSR:
+      Mul2: [0, "2x"]
+      Mul4: [1, "4x"]
+      Mul8: [2, "8x"]
+      Mul16: [3, "16x"]
+      Mul32: [4, "32x"]
+      Mul64: [5, "64x"]
+      Mul128: [6, "128x"]
+      Mul256: [7, "256x"]
+    OVSE:
+      Disabled: [0, "Oversampler disabled"]
+      Enabled: [1, "Oversampler enabled"]
+  SMPR:
+    SMP:
+      Cycles1_5: [0, "1.5 ADC clock cycles"]
+      Cycles3_5: [1, "3.5 ADC clock cycles"]
+      Cycles7_5: [2, "7.5 ADC clock cycles"]
+      Cycles12_5: [3, "12.5 ADC clock cycles"]
+      Cycles19_5: [4, "19.5 ADC clock cycles"]
+      Cycles39_5: [5, "39.5 ADC clock cycles"]
+      Cycles79_5: [6, "79.5 ADC clock cycles"]
+      Cycles160_5: [7, "160.5 ADC clock cycles"]
+  TR:
+    HT: [0, 2047]
+    LT: [0, 2047]
+  CHSELR:
+    "CHSEL*":
+      NotSelected: [0, "Input Channel is not selected for conversion"]
+      Selected: [1, "Input Channel is selected for conversion"]
+  DR:
+    DATA: [0, 65535]
+  CALFACT:
+    CALFACT: [0, 127]
+  CCR:
+    LFMEN:
+      Disabled: [0, "Low Frequency Mode disabled"]
+      Enabled: [1, "Low Frequency Mode enabled"]
+    VLCDEN:
+      Disabled: [0, "VLCD reading circuitry disabled"]
+      Enabled: [1, "VLCD reading circuitry enabled"]
+    TSEN:
+      Disabled: [0, "Temperature sensor disabled"]
+      Enabled: [1, "Temperature sensor enabled"]
+    VREFEN:
+      Disabled: [0, "VREFINT disabled"]
+      Enabled: [1, "VREFINT enabled"]
+    PRESC:
+      Div1: [0, "Input ADC clock not divided"]
+      Div2: [1, "Input ADC clock divided by 2"]
+      Div4: [2, "Input ADC clock divided by 4"]
+      Div6: [3, "Input ADC clock divided by 6"]
+      Div8: [4, "Input ADC clock divided by 8"]
+      Div10: [5, "Input ADC clock divided by 10"]
+      Div12: [6, "Input ADC clock divided by 12"]
+      Div16: [7, "Input ADC clock divided by 16"]
+      Div32: [8, "Input ADC clock divided by 32"]
+      Div64: [9, "Input ADC clock divided by 64"]
+      Div128: [10, "Input ADC clock divided by 128"]
+      Div256: [11, "Input ADC clock divided by 256"]
+

--- a/peripherals/aes/aes_l0.yaml
+++ b/peripherals/aes/aes_l0.yaml
@@ -1,0 +1,55 @@
+AES:
+  CR:
+    DMAOUTEN:
+      Disabled: [0, "Disable DMA Output"]
+      Enabled: [1, "Enabled DMA Output"]
+    DMAINEN:
+      Disabled: [0, "Disable DMA Input"]
+      Enabled: [1, "Enable DMA Input"]
+    ERRIE:
+      Disabled: [0, "Disable (mask) error interrupt"]
+      Enabled: [1, "Enable error interrupt"]
+    CCFIE:
+      Disabled: [0, "Disable (mask) CCF interrupt"]
+      Enabled: [1, "Enable CCF interrupt"]
+    ERRC:
+      _write:
+          Clear: [1, "Clear RDERR and WRERR flags"]
+    CCFC:
+      _write:
+        Clear: [1, "Clear computation complete flag"]
+    CHMOD:
+      ECB: [0, "Electronic codebook (ECB)"]
+      CBC: [1, "Cipher-Block Chaining (CBC)"]
+      CTR: [2, "Counter Mode (CTR)"]
+    MODE:
+      Mode1: [0, "Mode 1: encryption"]
+      Mode2: [1, "Mode 2: key derivation (or key preparation for ECB/CBC decryption)"]
+      Mode3: [2, "Mode 3: decryption"]
+      Mode4: [3, "Mode 4: key derivation then single decryption"]
+    DATATYPE:
+      None: [0, "Word"]
+      HalfWord: [1, "Half-word (16-bit)"]
+      Byte: [2, "Byte (8-bit)"]
+      Bit: [3, "Bit"]
+    EN:
+      Disabled: [0, "Disable AES"]
+      Enabled: [1, "Enable AES"]
+  SR:
+    WRERR:
+      NoError: [0, "Write error not detected"]
+      Error: [1, "Write error detected"]
+    RDERR:
+      NoError: [0, "Read error not detected"]
+      Error: [1, "Read error detected"]
+    CCF:
+      Complete: [0, "Computation complete"]
+      NotComplete: [1, "Computation not complete"]
+  DINR: 
+    DIN: [0, 0xFFFFFFFF]
+  DOUTR: 
+    DOUT: [0, 0xFFFFFFFF]
+  "KEYR[0123]": 
+    "KEY*": [0, 0xFFFFFFFF]
+  "IVR[0123]": 
+    "IV*": [0, 0xFFFFFFFF]

--- a/peripherals/crc/crc_l0.yaml
+++ b/peripherals/crc/crc_l0.yaml
@@ -1,0 +1,27 @@
+# CRC for L0
+
+_include:
+  - "crc_basic.yaml"
+
+CRC:
+  CR:
+    REV_OUT:
+      Forward: [0, "Bit order not affected"]
+      Reverse: [1, "Bit-reversed output format"]
+    REV_IN:
+      Forward: [0, "Bit order not affected"]
+      ReverseByte: [1, "Bit reversal done by byte"]
+      ReverseHalfWord: [2, "Bit reversal done by half-word"]
+      ReverseWord: [3, "Bit reversal done by word"]
+    POLYSIZE:
+      Polysize32: [0, "32 bit polynomial"]
+      Polysize16: [1, "16 bit polynomial"]
+      Polysize8: [2, "8 bit polynomial"]
+      Polysize7: [3, "7 bit polynomial"]
+    RESET:
+      NoReset: [0, "No Reset"]
+      Reset: [1, "Reset CRC calculation"]
+  INIT:
+    CRC_INIT: [0, 0xFFFFFFFF]
+  POL:
+    POL: [0, 0xFFFFFFFF]

--- a/peripherals/exti/exti_l0.yaml
+++ b/peripherals/exti/exti_l0.yaml
@@ -1,0 +1,28 @@
+EXTI:
+  IMR:
+    "IM*":
+      Masked: [0, "Interrupt request line is masked"]
+      Unmasked: [1, "Interrupt request line is unmasked"]
+  EMR:
+    "EM*":
+      Masked: [0, "Interrupt request line is masked"]
+      Unmasked: [1, "Interrupt request line is unmasked"]
+  RTSR:
+    "RT*":
+      Disabled: [0, "Rising edge trigger is disabled"]
+      Enabled: [1, "Rising edge trigger is enabled"]
+  FTSR:
+    "FT*":
+      Disabled: [0, "Falling edge trigger is disabled"]
+      Enabled: [1, "Falling edge trigger is enabled"]
+  SWIER:
+    "SWI*":
+      _write:
+        Pend: [1, "Generates an interrupt request"]
+  PR:
+    "PIF*":
+      _write:
+        Clear: [1, "Clears pending bit"]
+      _read:
+        NotPending: [0, "No trigger request occurred"]
+        Pending: [1, "Selected trigger request occurred"]

--- a/peripherals/flash/flash_l0.yaml
+++ b/peripherals/flash/flash_l0.yaml
@@ -1,0 +1,144 @@
+# This FLASH is used on the STM32L0 families.
+
+"FLASH":
+  ACR:
+    PRE_READ:
+      Disabled: [0, "The pre-read is disabled"]
+      Enabled: [1, "The pre-read is enabled"]
+    DISAB_BUF:
+      Enabled: [0, "The buffers are enabled"]
+      Disabled: [1, "The buffers are disabled"]
+    RUN_PD:
+      NVMIdleMode: [0, "When the device is in Run mode, the NVM is in Idle mode"]
+      NVMPwrDownMode: [1, "When the device is in Run mode, the NVM is in power-down mode"]
+    SLEEP_PD:
+      NVMIdleMode: [0, "When the device is in Sleep mode, the NVM is in Idle mode"]
+      NVMPwrDownMode: [1, "When the device is in Sleep mode, the NVM is in power-down mode"]
+    PRFTEN:
+      Disabled: [0, "Prefetch is disabled"]
+      Enabled: [1, "Prefetch is enabled"]
+    LATENCY: 
+      WS0: [0, "Zero wait state is used to read a word in the NVM"]
+      WS1: [1, "One wait state is used to read a word in the NVM"]
+  PECR:
+    OBL_LAUNCH:
+      _read:
+        Complete: [0, "Option byte loaded"]
+        NotComplete: [1, "Option byte loading to be done"]
+      _write:
+        Reload: [1, "Reload option byte"]
+    ERRIE:
+      Disabled: [0, "Error interrupt disable"]
+      Enabled: [1, "Error interrupt enable"]
+    EOPIE:
+      Disabled: [0, "End of program interrupt disable"]
+      Enabled: [1, "End of program interrupt enable"]
+    PARALLELBANK:
+      Disabled: [0, "Parallel bank mode disabled"]
+      Enabled: [1, "Parallel bank mode enabled"]
+    FPRG:
+      Disabled: [0, "Half Page programming disabled"]
+      Enabled: [1, "Half Page programming enabled"]
+    ERASE:
+      NoErase: [0, "No erase operation requested"]
+      Erase: [1, "Erase operation requested"]
+    FIX:
+      AutoErase: [0, "An erase phase is automatically performed"]
+      PrelimErase: [1, "The program operation is always performed with a preliminary erase"]
+    DATA:
+      NotSelected: [0, "Data EEPROM not selected"]
+      Selected: [1, "Data memory selected"]
+    PROG:
+      NotSelected: [0, "The Flash program memory is not selected"]
+      Selected: [1, "The Flash program memory is selected"]
+    OPTLOCK:
+      Unlocked: [0, "The write and erase operations in the Option bytes area are disabled"]
+      Locked: [1, "The write and erase operations in the Option bytes area are enabled"]
+    PRGLOCK:
+      Unlocked: [0, "The write and erase operations in the Flash program memory are disabled"]
+      Locked: [1, "The write and erase operations in the Flash program memory are enabled"]
+    PELOCK:
+      Unlocked: [0, "The FLASH_PECR register is unlocked"]
+      Locked: [1, "The FLASH_PECR register is locked and no write/erase operation can start"]
+  PDKEYR:
+    PDKEYR: [0, 0xFFFFFFFF]
+  PEKEYR:
+    PEKEYR: [0, 0xFFFFFFFF]
+  PRGKEYR:
+    PRGKEYR: [0, 0xFFFFFFFF]
+  OPTKEYR:
+    OPTKEYR: [0, 0xFFFFFFFF]
+  SR:
+    FWWERR:
+      _read:
+        NoError: [0, "No write/erase operation aborted to perform a fetch"]
+        Error: [1, "A write/erase operation aborted to perform a fetch"]
+      _write:
+        Clear: [1, "Clear the flag"]
+    NOTZEROERR:
+      _read:
+        NoEvent: [0, "The write operation is done in an erased region or the memory interface can apply an erase before a write"]
+        Event: [1, "The write operation is attempting to write to a not-erased region and the memory interface cannot apply an erase before a write"]
+      _write:
+        Clear: [1, "Clear the flag"]
+    RDERR:
+      _read:
+        NoError: [0, "No read protection error happened."]
+        Error: [1, "One read protection error happened"]
+      _write:
+        Clear: [1, "Clear the flag"]
+    OPTVERR:
+      _read:
+        NoError: [0, "No error happened during the Option bytes loading"]
+        Error: [1, "One or more errors happened during the Option bytes loading"]
+      _write:
+        Clear: [1, "Clear the flag"]
+    SIZERR:
+      _read:
+        NoError: [0, "No size error happened"]
+        Error: [1, "One size error happened"]
+      _write:
+        Clear: [1, "Clear the flag"]
+    PGAERR:
+      _read:
+        NoError: [0, "No alignment error happened"]
+        Error: [1, "One alignment error happened"]
+      _write:
+        Clear: [1, "Clear the flag"]
+    WRPERR:
+      _read:
+        NoError: [0, "No protection error happened"]
+        Error: [1, "One protection error happened"]
+      _write:
+        Clear: [1, "Clear the flag"]
+    READY:
+      NotReady: [0, "The NVM is not ready"]
+      Ready: [1, "The NVM is ready"]
+    ENDHV:
+      Active: [0, "High voltage is executing a write/erase operation in the NVM"]
+      Inactive: [1, "High voltage is off, no write/erase operation is ongoing"]
+    EOP:
+      NoEvent: [0, "No EOP operation occurred"]
+      Event: [1, "An EOP event occurred"]
+    BSY:
+      Inactive: [0, "No write/erase operation is in progress"]
+      Active: [1, "No write/erase operation is in progress"]
+  "OPTR":
+    BOR_LEV:
+      BOR_Off: [0, "This is the reset threshold level for the 1.45 V - 1.55 V voltage range (power-down only)"]
+      BOR_Level1: [1, "Reset threshold level for VBOR0 (around 1.8 V)"]
+      BOR_Level2: [2, "Reset threshold level for VBOR1 (around 2.0 V)"]
+      BOR_Level3: [3, "Reset threshold level for VBOR2 (around 2.5 V)"]
+      BOR_Level4: [4, "Reset threshold level for VBOR3 (around 2.7 V)"]
+      BOR_Level5: [5, "Reset threshold level for VBOR4 (around 3.0 V)"]
+    WPRMOD:
+      Disabled: [0, "PCROP disabled. The WRPROT bits are used as a write protection on a sector."]
+      Enabled: [1, "PCROP enabled. The WRPROT bits are used as a read protection on a sector."]
+    RDPROT:
+      Level0: [0xAA, "Level 0"]
+      Level1: [0, "Level 1"]
+      Level2: [0xCC, "Level 2"]
+  WRPROT1:
+    WRPROT1: [0, 0xFFFFFFFF]
+  WRPROT2:
+    WRPROT2: [0, 0xFFFF]

--- a/peripherals/fw/fw_l0.yaml
+++ b/peripherals/fw/fw_l0.yaml
@@ -1,0 +1,32 @@
+# This FW is used on the STM32L0 families.
+
+"FW":
+  CSSA:
+    ADD: [0, 0xFFFF]
+  CSL:
+    LENG: [0, 0x3FFF]
+  NVDSSA:
+    ADD: [0, 0xFFFF]
+  NVDSL:
+    LENG: [0, 0x3FFF]
+  VDSSA:
+    ADD: [0, 0x3FF]
+  VDSL:
+    LENG: [0, 0x3FF]
+  CR:
+    VDE:
+      _write:
+        Reset: [0, "Resets volatile data execution bit"]
+      _read:
+        NotExecutable: [0, "Volatile data segment cannot be executed if VDS = 0"]
+        Executable: [1, "Volatile data segment is declared executable whatever VDS bit value"]
+    VDS:
+      _write:
+        Reset: [0, "Resets volatile data shared bit"]
+      _read:
+        NotShared: [0, "Volatile data segment is not shared and cannot be hit by a non protected executable code when the Firewall is closed"]
+        Shared: [1, "Volatile data segment is shared with non protected application code"]
+    FPA:
+      _write:
+        PreArmReset: [0, "Any code executed outside the protected segment when the Firewall is opened will generate a system reset"]
+        PreArmSet: [1, "Any code executed outside the protected segment will close the Firewall"]

--- a/peripherals/gpio/gpio_l0.yaml
+++ b/peripherals/gpio/gpio_l0.yaml
@@ -1,8 +1,8 @@
-# This GPIO is used on the STM32F0, F3, F4, and F7 families.
+# This GPIO is used on the STM32L0 families.
 
 "GPIO*":
   MODER:
-    "MODER*":
+    "MODE*":
       Input: [0, "Input mode (reset state)"]
       Output: [1, "General purpose output mode"]
       Alternate: [2, "Alternate function mode"]
@@ -12,22 +12,22 @@
       PushPull: [0, "Output push-pull (reset state)"]
       OpenDrain: [1, "Output open-drain"]
   OSPEEDR:
-    "OSPEEDR*":
+    "OSPEED*":
       LowSpeed: [0, "Low speed"]
       MediumSpeed: [1, "Medium speed"]
       HighSpeed: [2, "High speed"]
       VeryHighSpeed: [3, "Very high speed"]
   PUPDR:
-    "PUPDR*":
+    "PUPD*":
       Floating: [0, "No pull-up, pull-down"]
       PullUp: [1, "Pull-up"]
       PullDown: [2, "Pull-down"]
   IDR:
-    "IDR*":
+    "ID*":
       High: [1, "Input is logic high"]
       Low: [0, "Input is logic low"]
   ODR:
-    "ODR*":
+    "OD*":
       High: [1, "Set output to logic high"]
       Low: [0, "Set output to logic low"]
   BSRR:
@@ -47,9 +47,8 @@
     "LCKK":
       NotActive: [0, "Port configuration lock key not active"]
       Active: [1, "Port configuration lock key active"]
-
   "AFR[LH]":
-    "AFR*":
+    "AFSEL*":
       AF0:  [0,  "AF0"]
       AF1:  [1,  "AF1"]
       AF2:  [2,  "AF2"]

--- a/peripherals/lptim/lptim_l0.yaml
+++ b/peripherals/lptim/lptim_l0.yaml
@@ -1,0 +1,146 @@
+# Low Power Timers for L0 Family
+
+LPTIM:
+  ISR:
+    DOWN:
+      _read:
+        Set: [1, "Counter direction change up to down"]
+    UP:
+      _read:
+        Set: [1, "Counter direction change down to up"]
+    ARROK:
+      _read:
+        Set: [1, "Autoreload register update OK"]
+    CMPOK:
+      _read:
+        Set: [1, "Compare register update OK"]
+    EXTTRIG:
+      _read:
+        Set: [1, "External trigger edge event"]
+    ARRM:
+      _read:
+        Set: [1, "Autoreload match"]
+    CMPM:
+      _read:
+        Set: [1, "Compare match"]
+  ICR:
+    DOWNCF:
+      _write:
+        Clear: [1, "Direction change to down Clear Flag"]
+    UPCF:
+      _write:
+        Clear: [1, "Direction change to up Clear Flag"]
+    ARROKCF:
+      _write:
+        Clear: [1, "Autoreload register update OK Clear Flag"]
+    CMPOKCF:
+      _write:
+        Clear: [1, "Compare register update OK Clear Flag"]
+    EXTTRIGCF:
+      _write:
+        Clear: [1, "External trigger valid edge Clear Flag"]
+    ARRMCF:
+      _write:
+        Clear: [1, "Autoreload match Clear Flag"]
+    CMPMCF:
+      _write:
+        Clear: [1, "Compare match Clear Flag"]
+  IER:
+    DOWNIE:
+      Disabled: [0, "DOWN interrupt disabled"]
+      Enabled: [1, "DOWN interrupt enabled"]
+    UPIE:
+      Disabled: [0, "UP interrupt disabled"]
+      Enabled: [1, "UP interrupt enabled"]
+    ARROKIE:
+      Disabled: [0, "ARROK interrupt disabled"]
+      Enabled: [1, "ARROK interrupt enabled"]
+    CMPOKIE:
+      Disabled: [0, "CMPOK interrupt disabled"]
+      Enabled: [1, "CMPOK interrupt enabled"]
+    EXTTRIGIE:
+      Disabled: [0, "EXTTRIG interrupt disabled"]
+      Enabled: [1, "EXTTRIG interrupt enabled"]
+    ARRMIE:
+      Disabled: [0, "ARRM interrupt disabled"]
+      Enabled: [1, "ARRM interrupt enabled"]
+    CMPMIE:
+      Disabled: [0, "CMPM interrupt disabled"]
+      Enabled: [1, "CMPM interrupt enabled"]
+  CFGR:
+    ENC:
+      Disabled: [0, "Encoder mode disabled"]
+      Enabled: [1, "Encoder mode enabled"]
+    COUNTMODE:
+      Internal: [0, "The counter is incremented following each internal clock pulse"]
+      External: [1, "The counter is incremented following each valid clock pulse on the LPTIM external Input1"]
+    PRELOAD:
+      Immediate:  [0, "Registers are updated after each APB bus write access"]
+      EndOfPeriod: [1, "Registers are updated at the end of the current LPTIM period"]
+    WAVPOL:
+      Positive: [0, "The LPTIM output reflects the compare results between LPTIM_ARR and LPTIM_CMP registers"]
+      Negative: [1, "The LPTIM output reflects the inverse of the compare results between LPTIM_ARR and LPTIM_CMP registers"]
+    WAVE:
+      Inactive: [0, "Deactivate Set-once mode, PWM / One Pulse waveform (depending on OPMODE bit)"]
+      Active: [1, "Activate the Set-once mode"]
+    TIMOUT:
+      Disabled: [0, "A trigger event arriving when the timer is already started will be ignored"]
+      Enabled: [1, "A trigger event arriving when the timer is already started will reset and restart the counter"]
+    TRIGEN:
+      SW: [0, "Software trigger (counting start is initiated by software)"]
+      RisingEdge: [1, "Rising edge is the active edge"]
+      FallingEdge: [2, "Falling edge is the active edge"]
+      BothEdges: [3, "Both edges are active edges"]
+    TRIGSEL:
+      Trig0: [0, "lptim_ext_trig0"]
+      Trig1: [1, "lptim_ext_trig1"]
+      Trig2: [2, "lptim_ext_trig2"]
+      Trig3: [3, "lptim_ext_trig3"]
+      Trig4: [4, "lptim_ext_trig4"]
+      Trig5: [5, "lptim_ext_trig5"]
+      Trig6: [6, "lptim_ext_trig6"]
+      Trig7: [7, "lptim_ext_trig7"]
+    PRESC:
+      Div1: [0, "/1"]
+      Div2: [1, "/2"]
+      Div4: [2, "/4"]
+      Div8: [3, "/8"]
+      Div16: [4, "/16"]
+      Div32: [5, "/32"]
+      Div64: [6, "/64"]
+      Div128: [7, "/128"]
+    TRGFLT:
+      Immediate: [0, "Any trigger active level change is considered as a valid trigger"]
+      TwoClocks: [1, "Trigger active level change must be stable for at least 2 clock periods before it is considered as valid trigger"]
+      FourClocks: [2, "Trigger active level change must be stable for at least 4 clock periods before it is considered as valid trigger"]
+      EightClocks: [3, "Trigger active level change must be stable for at least 8 clock periods before it is considered as valid trigger"]
+    CKFLT:
+      Immediate: [0, "Any external clock signal level change is considered as a valid transition"]
+      TwoClocks: [1, "External clock signal level change must be stable for at least 2 clock periods before it is considered as valid transition"]
+      FourClocks: [2, "External clock signal level change must be stable for at least 4 clock periods before it is considered as valid transition"]
+      EightClocks: [3, "External clock signal level change must be stable for at least 8 clock periods before it is considered as valid transition"]
+    CKPOL:
+      RisingEdge: [0, "The rising edge is the active edge used for counting. If LPTIM is in encoder mode: Encoder sub-mode 1 is active."]
+      FallingEdge: [1, "The falling edge is the active edge used for counting. If LPTIM is in encoder mode: Encoder sub-mode 2 is active."]
+      BothEdges: [2, "Both edges are active edge. If LPTIM is in encoder mode: Encoder sub-mode 3 is active."]
+    CKSEL:
+      Internal: [0, "LPTIM is clocked by internal clock source (APB clock or any of the embedded oscillators)"]
+      External: [1, "LPTIM is clocked by an external clock source through the LPTIM external Input1"]
+  CR:
+    CNTSTRT:
+      _write:
+        Start: [1, "Timer start in Continuous mode"]
+    SNGSTRT:
+      _write:
+        Start: [1, "LPTIM start in Single mode"]
+    ENABLE:
+        Disabled: [0, "LPTIM is disabled"]
+        Enabled: [1, "LPTIM is enabled"]
+  CMP: 
+    CMP: [0, 0xFFFF]
+  ARR:
+    ARR: [0, 0xFFFF]
+  CNT:
+    _read:
+      CNT: [0, 0xFFFF]
+  

--- a/peripherals/mpu/mpu_v1.yaml
+++ b/peripherals/mpu/mpu_v1.yaml
@@ -1,0 +1,46 @@
+# Memory Protection Unit - Programming Manual PM0214
+
+MPU:
+  TYPER:
+    _read:
+      IREGION: [0, 0xFF]
+      DREGION: [0, 0xFF]
+    SEPARATE: 
+      _read:
+        Unified: [0, "Unified"]
+        Separate: [1, "Separate"]
+  CTRL:
+    PRIVDEFENA:
+      Disabled: [0, "Disables use of the default memory map"]
+      Enabled: [1, "Enables use of the default memory map as a background region for privileged software accesses"]
+    HFNMIENA:
+      Disabled: [0, "Disabled during hard fault, NMI, and FAULTMASK handlers"]
+      Enabled: [1, "Enabled during hard fault, NMI, and FAULTMASK handlers"]
+    ENABLE:
+      Disabled: [0, "MPU disabled"]
+      Enabled: [1, "MPU enabled"]
+  RNR:
+    REGION: [0, 0xFF]
+  RBAR:
+    ADDR: [0x7FFFFFF]
+    VALID:
+      _write:
+        Update: [1, "Updates the base address for the region specified in the REGION field"]
+    REGION: [0, 0xF]
+  RASR:
+    XN:
+      Enabled: [0, "Instruction fetches enabled"]
+      Disabled: [1, "Instruction fetches disabled"]
+    AP: [0, 0x7]
+    TEX: [0, 0x7]
+    S: [0, 1]
+    C: [0, 1]
+    B: [0, 1]
+    SRD:
+      Enabled: [0, "Corresponding sub-region is enabled"]
+      Disabled: [1, "corresponding sub-region is disabled"]
+    SIZE: [0, 0x1F]
+    ENABLE:
+      Disabled: [0, "Disable region"]
+      Enabled: [1, "Enable region"]
+

--- a/peripherals/nvic/nvic_v1.yaml
+++ b/peripherals/nvic/nvic_v1.yaml
@@ -1,0 +1,51 @@
+# Nested Vectored Interrupt Controller - Programming Manual PM0215
+
+NVIC:
+  ISER:
+    SETENA: [0, 0xFFFFFFFF]
+  ICER:
+    CLRENA: [0, 0xFFFFFFFF]
+  ISPR:
+    SETPEND: [0, 0xFFFFFFFF]
+  ICPR:
+    CLRPEND: [0, 0xFFFFFFFF]
+  IPR0:
+    PRI_3: [0, 0xFF]
+    PRI_2: [0, 0xFF]
+    PRI_1: [0, 0xFF]
+    PRI_0: [0, 0xFF]
+  IPR1:
+    PRI_7: [0, 0xFF]
+    PRI_6: [0, 0xFF]
+    PRI_5: [0, 0xFF]
+    PRI_4: [0, 0xFF]
+  IPR2:
+    PRI_11: [0, 0xFF]
+    PRI_10: [0, 0xFF]
+    PRI_9: [0, 0xFF]
+    PRI_8: [0, 0xFF]
+  IPR3:
+    PRI_15: [0, 0xFF]
+    PRI_14: [0, 0xFF]
+    PRI_13: [0, 0xFF]
+    PRI_12: [0, 0xFF]
+  IPR4:
+    PRI_19: [0, 0xFF]
+    PRI_18: [0, 0xFF]
+    PRI_17: [0, 0xFF]
+    PRI_16: [0, 0xFF]
+  IPR5:
+    PRI_23: [0, 0xFF]
+    PRI_22: [0, 0xFF]
+    PRI_21: [0, 0xFF]
+    PRI_20: [0, 0xFF]
+  IPR6:
+    PRI_27: [0, 0xFF]
+    PRI_26: [0, 0xFF]
+    PRI_25: [0, 0xFF]
+    PRI_24: [0, 0xFF]
+  IPR7:
+    PRI_31: [0, 0xFF]
+    PRI_30: [0, 0xFF]
+    PRI_29: [0, 0xFF]
+    PRI_28: [0, 0xFF]

--- a/peripherals/pwr/pwr_l0.yaml
+++ b/peripherals/pwr/pwr_l0.yaml
@@ -1,0 +1,83 @@
+# Power Controller for L0 Family
+_include:
+  - pwr_v1.yaml
+
+PWR:
+  CR:
+    LPDS:
+      MAIN_MODE: [0, "Voltage regulator in Main mode during Deepsleep mode (Stop mode)"]
+      LOW_POWER_MODE: [1, "Voltage regulator switches to low-power mode when the CPU enters Deepsleep mode (Stop mode)"]
+    LPRUN:
+      MAIN_MODE: [0, "Voltage regulator in Main mode in Low-power run mode"]
+      LOW_POWER_MODE: [1, "Voltage regulator in low-power mode in Low-power run mode"]
+    DS_EE_KOFF:
+      NVMWakeUp: [0, "NVM woken up when exiting from Deepsleep mode even if the bit RUN_PD is set"]
+      NVMSleep: [1, "NVM not woken up when exiting from low-power mode (if the bit RUN_PD is set)"]
+    VOS:
+      1_8V: [1, "1.8 V (range 1)"]
+      1_5V: [2, "1.5 V (range 2)"]
+      1_2V: [3, "1.2 V (range 3)"]
+    FWU:
+      Disabled: [0, "Low-power modes exit occurs only when VREFINT is ready"]
+      Enabled: [1, "VREFINT start up time is ignored when exiting low-power modes"]
+    ULP:
+      Enabled: [0, "VREFINT is on in low-power mode"]
+      Disabled: [1, "VREFINT is off in low-power mode"]
+    DBP:
+      Disabled: [0, "Access to RTC, RTC Backup and RCC CSR registers disabled"]
+      Enabled: [1, "Access to RTC, RTC Backup and RCC CSR registers enabled"]
+    PLS:
+      1_9V: [0, "1.9 V"]
+      2_1V: [1, "2.1 V"]
+      2_3V: [2, "2.3 V"]
+      2_5V: [3, "2.5 V"]
+      2_7V: [4, "2.7 V"]
+      2_9V: [5, "2.9 V"]
+      3_1V: [6, "3.1 V"]
+      External: [7, "External input analog voltage (Compare internally to VREFINT)"]
+    PVDE:
+      Disabled: [0, "PVD Disabled"]
+      Enabled: [1, "PVD Enabled"]
+    CSBF:
+      _write:
+        Clear: [1, "Clear the SBF Standby flag"]
+    CWUF:
+      _write:
+        Clear: [1, "Clear the WUF Wakeup flag after 2 system clock cycles"]
+    LPSDSR:
+      MAIN_MODE: [0, "Voltage regulator on during Deepsleep/Sleep/Low-power run mode"]
+      LOW_POWER_MODE: [1, "Voltage regulator in low-power mode during Deepsleep/Sleep/Low-power run mode"]
+  CSR:
+    EWUP3:
+      Disabled: [0, "WKUP pin 3 is used for general purpose I/Os. An event on the WKUP pin 3 does not wakeup the device from Standby mode"]
+      Enabled: [1, "WKUP pin 3 is used for wakeup from Standby mode and forced in input pull down configuration (rising edge on WKUP pin 3wakes-up the system from Standby mode)"]
+    EWUP2:
+      Disabled: [0, "WKUP pin 2 is used for general purpose I/Os. An event on the WKUP pin 2 does not wakeup the device from Standby mode"]
+      Enabled: [1, "WKUP pin 2 is used for wakeup from Standby mode and forced in input pull down configuration (rising edge on WKUP pin 2 wakes-up the system from Standby mode)"]
+    EWUP1:
+      Disabled: [0, "WKUP pin 1 is used for general purpose I/Os. An event on the WKUP pin 1 does not wakeup the device from Standby mode"]
+      Enabled: [1, "WKUP pin 1 is used for wakeup from Standby mode and forced in input pull down configuration (rising edge on WKUP pin 1 wakes-up the system from Standby mode)"]
+    REGLPF:
+      _read:
+        Ready: [0, "Regulator is ready in Main mode"]
+        NotReady: [1, "Regulator voltage is in low-power mode"]
+    VOSF:
+      _read:
+        Ready: [0, "Regulator is ready in the selected voltage range"]
+        NotReady: [1, "Regulator voltage output is changing to the required VOS level"]
+    VREFINTRDYF:
+      _read:
+        NotReady: [0, "VREFINT is OFF"]
+        Ready: [1, "VREFINT is ready"]
+    PVDO:
+      _read:
+        AboveThreshold: [0, "VDD is higher than the PVD threshold selected with the PLS[2:0] bits"]
+        BelowThreshold: [1, "VDD is lower than the PVD threshold selected with the PLS[2:0] bits"]
+    SBF:
+      _read:
+        NoStandbyEvent: [0, "Device has not been in Standby mode"]
+        StandbyEvent: [1, "Device has been in Standby mode"]
+    WUF:
+      _read:
+        NoWakeupEvent: [0, "No wakeup event occurred"]
+        WakeupEvent: [1, "A wakeup event was received from the WKUP pin or from the RTC alarm (Alarm A or Alarm B), RTC Tamper event, RTC TimeStamp event or RTC Wakeup)"]

--- a/peripherals/rcc/rcc_l0.yaml
+++ b/peripherals/rcc/rcc_l0.yaml
@@ -1,0 +1,120 @@
+# RCC peripheral
+# Applicable to STM32L0xx
+
+RCC:
+  CR:
+    HSI16OUTEN:
+      Disabled: [0, "HSI output clock disabled"]
+      Enabled: [1, "HSI output clock enabled"]
+    HSI16DIVF:
+      _read:
+        NotDivided: [0, "16 MHz HSI clock not divided"]
+        Div4: [1, "16 MHz HSI clock divided by 4"]
+    HSI16DIVEN:
+      NotDivided: [0, "no 16 MHz HSI division requested"]
+      Div4: [1, "16 MHz HSI division by 4 requested"]
+    HSI16RDYF:
+      _read:
+        NotReady: [0, "HSI 16 MHz oscillator not ready"]
+        Ready: [1, "HSI 16 MHz oscillator ready"]
+  ICSCR:
+    MSITRIM: [0, 255]
+    MSICAL: [0, 255]
+    MSIRANGE:
+      Range0: [0, "range 0 around 65.536 kHz"]
+      Range1: [1, "range 1 around 131.072 kHz"]
+      Range2: [2, "range 2 around 262.144 kHz"]
+      Range3: [3, "range 3 around 524.288 kHz"]
+      Range4: [4, "range 4 around 1.048 MHz"]
+      Range5: [5, "range 5 around 2.097 MHz (reset value)"]
+      Range6: [6, "range 6 around 4.194 MHz"]
+      Range7: [7, "not allowed"]
+    HSI16TRIM: [0, 31]
+    HSI16CAL: [0, 255]
+  CFGR:
+    MCOSEL:
+      NoClock: [0, "No clock"]
+      SYSCLK: [1, "SYSCLK clock selected"]
+      HSI16: [2, "HSI oscillator clock selected"]
+      MSI: [3, "MSI oscillator clock selected"]
+      HSE: [4, "HSE oscillator clock selected"]
+      PLL: [5, "PLL clock selected"]
+      LSI: [6, "LSI oscillator clock selected"]
+      LSE: [7, "LSE oscillator clock selected"]
+    PLLSRC:
+      HSI16: [0, "HSI selected as PLL input clock"]
+      HSE: [1, "HSE selected as PLL input clock"]
+    STOPWUCK:
+      MSI: [0, "Internal 64 KHz to 4 MHz (MSI) oscillator selected as wake-up from Stop clock"]
+      HSI16: [1, "Internal 16 MHz (HSI) oscillator selected as wake-up from Stop clock (or HSI16/4 if HSI16DIVEN=1)"]
+    SWS:
+      MSI: [0, "MSI oscillator used as system clock"]
+      HSI16: [1, "HSI oscillator used as system clock"]
+      HSE: [2, "HSE oscillator used as system clock"]
+      PLL: [3, "PLL used as system clock"]
+    SW:
+      MSI: [0, "MSI oscillator used as system clock"]
+      HSI16: [1, "HSI oscillator used as system clock"]
+      HSE: [2, "HSE oscillator used as system clock"]
+      PLL: [3, "PLL used as system clock"]
+  CIER:
+    CSSLSE:
+      Disabled: [0, "LSE CSS interrupt disabled"]
+      Enabled: [1, "LSE CSS interrupt enabled"]
+    "*RDYIE":
+      Disabled: [0, "Ready interrupt disabled"]
+      Enabled: [1, "Ready interrupt enabled"]
+  CIFR:
+    CSSHSEF:
+      NoClock: [0, "No clock security interrupt caused by HSE clock failure"]
+      Clock: [1, "Clock security interrupt caused by HSE clock failure"]
+    CSSLSEF:
+      NoFailure: [0, "No failure detected on LSE clock failure"]
+      Failure: [1, "Failure detected on LSE clock failure"]
+    "*RDYF":
+      _read:
+        NotInterrupted: [0, "No clock ready interrupt"]
+        Interrupted: [1, "Clock ready interrupt"]
+  CICR:
+    "*SEC,*RDYC":
+      _write:
+        Clear: [1, "Clear interrupt flag"]
+  IOPRSTR:
+    "IOP*RST":
+      Reset: [1, "Reset I/O port"]
+  IOPENR:
+    "IOP*EN":
+      Disabled: [0, "Port clock disabled"]
+      Enabled: [1, "Port clock enabled"]
+  CCIPR:
+    "*SEL":
+      APB: [0, "APB clock selected as Timer clock"]
+      LSI: [1, "LSI clock selected as Timer clock"]
+      HSI16: [2, "HSI16 clock selected as Timer clock"]
+      LSE: [3, "LSE clock selected as Timer clock"]
+  CSR:
+    RTCEN:
+      Disabled: [0, "RTC clock disabled"]
+      Enabled: [1, "RTC clock enabled"]
+    RTCSEL:
+      NoClock: [0, "No clock"]
+      LSE: [1, "LSE oscillator clock used as RTC clock"]
+      LSI: [2, "LSI oscillator clock used as RTC clock"]
+      HSE: [3, "HSE oscillator clock divided by a programmable prescaler (selection through the RTCPRE[1:0] bits in the RCC clock control register (RCC_CR)) used as the RTC clock"]
+    CSSLSED:
+      NoFailure: [0, "No failure detected on LSE (32 kHz oscillator)"]
+      Failure: [1, "Failure detected on LSE (32 kHz oscillator)"]
+    LSEDRV:
+      Low: [0, "Lowest drive"]
+      MediumLow: [1, "Medium low drive"]
+      MediumHigh: [2, "Medium high drive"]
+      High: [3, "Highest drive"]
+    LSEBYP:
+      NotBypassed: [0, "LSE oscillator not bypassed"]
+      Bypassed: [1, "LSE oscillator bypassed"]
+    "*ON":
+      "Off": [0, "Oscillator OFF"]
+      "On": [1, "Oscillator ON"]
+    "*RDY":
+      NotReady: [0, "Oscillator not ready"]
+      Ready: [1, "Oscillator ready"]

--- a/peripherals/rcc/rcc_l0_l1_common.yaml
+++ b/peripherals/rcc/rcc_l0_l1_common.yaml
@@ -1,0 +1,85 @@
+RCC:
+  CR:
+    RTCPRE:
+      Div2: [0, "HSE divided by 2"]
+      Div4: [1, "HSE divided by 4"]
+      Div8: [2, "HSE divided by 8"]
+      Div16: [3, "HSE divided by 16"]
+    "*ON":
+      Disabled: [0, "Clock disabled"]
+      Enabled: [1, "Clock enabled"]
+    PLLRDY:
+      _read:
+        Unlocked: [0, "PLL unlocked"]
+        Locked: [1, "PLL locked"]
+    HSEBYP:
+      NotBypassed: [0, "HSE oscillator not bypassed"]
+      Bypassed: [1, "HSE oscillator bypassed"]
+    "HSERDY,HSIRDY,MSIRDY":
+      _read:
+        NotReady: [0, "Oscillator is not stable"]
+        Ready: [1, "Oscillator is stable"]
+  CFGR:
+    MCOPRE:
+      Div1: [0, "No division"]
+      Div2: [1, "Division by 2"]
+      Div4: [2, "Division by 4"]
+      Div8: [3, "Division by 8"]
+      Div16: [4, "Division by 16"]
+    PLLDIV:
+      Div2: [1, "PLLVCO / 2"]
+      Div3: [2, "PLLVCO / 3"]
+      Div4: [3, "PLLVCO / 4"]
+    PLLMUL:
+      Mul3: [0, "PLL clock entry x 3"]
+      Mul4: [1, "PLL clock entry x 4"]
+      Mul6: [2, "PLL clock entry x 6"]
+      Mul8: [3, "PLL clock entry x 8"]
+      Mul12: [4, "PLL clock entry x 12"]
+      Mul16: [5, "PLL clock entry x 16"]
+      Mul24: [6, "PLL clock entry x 24"]
+      Mul32: [7, "PLL clock entry x 32"]
+      Mul48: [8, "PLL clock entry x 48"]
+    "PPRE[12]":
+      Div1: [0, "HCLK not divided"]
+      Div2: [4, "HCLK divided by 2"]
+      Div4: [5, "HCLK divided by 4"]
+      Div8: [6, "HCLK divided by 8"]
+      Div16: [7, "HCLK divided by 16"]
+    HPRE:
+      Div1: [0, "system clock not divided"]
+      Div2: [8, "system clock divided by 2"]
+      Div4: [9, "system clock divided by 4"]
+      Div8: [10, "system clock divided by 8"]
+      Div16: [11, "system clock divided by 16"]
+      Div64: [12, "system clock divided by 64"]
+      Div128: [13, "system clock divided by 128"]
+      Div256: [14, "system clock divided by 256"]
+      Div512: [15, "system clock divided by 512"]
+  AHBRSTR:
+    "*RST":
+      _write:
+        Reset: [1, "Reset the module"]
+  "APB[12]RSTR":
+    "*RST":
+      _write:
+        Reset: [1, "Reset the module"]
+  AHBENR:
+    "*EN":
+      Disabled: [0, "Clock disabled"]
+      Enabled: [1, "Clock enabled"]
+  "APB*ENR":
+    "*EN":
+      Disabled: [0, "Clock disabled"]
+      Enabled: [1, "Clock enabled"]
+  CSR:
+    "*RSTF":
+      _read:
+        NoReset: [0, "No reset has occured"]
+        Reset: [1, "A reset has occured"]
+    RMVF:
+      _write:
+        Clear: [1, "Clears the reset flag"]
+    RTCRST:
+      _write:
+        Reset: [1, "Resets the RTC peripheral"]

--- a/peripherals/rcc/rcc_l1.yaml
+++ b/peripherals/rcc/rcc_l1.yaml
@@ -1,31 +1,8 @@
+# RCC peripheral
+# Applicable to STM32L1xx
+
 RCC:
-  CR:
-    RTCPRE:
-      Div2: [0, "HSE divided by 2"]
-      Div4: [1, "HSE divided by 4"]
-      Div8: [2, "HSE divided by 8"]
-      Div16: [3, "HSE divided by 16"]
-    "*ON":
-      Disabled: [0, "Clock disabled"]
-      Enabled: [1, "Clock enabled"]
-    PLLRDY:
-      _read:
-        Unlocked: [0, "PLL unlocked"]
-        Locked: [1, "PLL locked"]
-    HSEBYP:
-      NotBypassed: [0, "HSE oscillator not bypassed"]
-      Bypassed: [1, "HSE oscillator bypassed"]
-    "HSERDY,HSIRDY,MSIRDY":
-      _read:
-        NotReady: [0, "Oscillator is not stable"]
-        Ready: [1, "Oscillator is stable"]
   CFGR:
-    MCOPRE:
-      Div1: [0, "No division"]
-      Div2: [1, "Division by 2"]
-      Div4: [2, "Division by 4"]
-      Div8: [3, "Division by 8"]
-      Div16: [4, "Division by 16"]
     MCOSEL:
       NoClock: [0, "No clock"]
       SYSCLK: [1, "SYSCLK clock selected"]
@@ -35,39 +12,9 @@ RCC:
       PLL: [5, "PLL clock selected"]
       LSI: [6, "LSI oscillator clock selected"]
       LSE: [7, "LSE oscillator clock selected"]
-    PLLDIV:
-      Div2: [1, "PLLVCO / 2"]
-      Div3: [2, "PLLVCO / 3"]
-      Div4: [3, "PLLVCO / 4"]
-    PLLMUL:
-      Mul3: [0, "PLL clock entry x 3"]
-      Mul4: [1, "PLL clock entry x 4"]
-      Mul6: [2, "PLL clock entry x 6"]
-      Mul8: [3, "PLL clock entry x 8"]
-      Mul12: [4, "PLL clock entry x 12"]
-      Mul16: [5, "PLL clock entry x 16"]
-      Mul24: [6, "PLL clock entry x 24"]
-      Mul32: [7, "PLL clock entry x 32"]
-      Mul48: [8, "PLL clock entry x 48"]
     PLLSRC:
       HSI: [0, "HSI selected as PLL input clock"]
       HSE: [1, "HSE selected as PLL input clock"]
-    "PPRE[12]":
-      Div1: [0, "HCLK not divided"]
-      Div2: [4, "HCLK divided by 2"]
-      Div4: [5, "HCLK divided by 4"]
-      Div8: [6, "HCLK divided by 8"]
-      Div16: [7, "HCLK divided by 16"]
-    HPRE:
-      Div1: [0, "system clock not divided"]
-      Div2: [8, "system clock divided by 2"]
-      Div4: [9, "system clock divided by 4"]
-      Div8: [10, "system clock divided by 8"]
-      Div16: [11, "system clock divided by 16"]
-      Div64: [12, "system clock divided by 64"]
-      Div128: [13, "system clock divided by 128"]
-      Div256: [14, "system clock divided by 256"]
-      Div512: [15, "system clock divided by 512"]
     SWS:
       _read:
         HSI: [0, "MSI oscillator used as system clock"]
@@ -104,34 +51,7 @@ RCC:
       _read:
         NotStable: [0, "Clock is not stable"]
         Stable: [1, "Clock is stable"]
-  AHBRSTR:
-    "*RST":
-      _write:
-        Reset: [1, "Reset the module"]
-  "APB[12]RSTR":
-    "*RST":
-      _write:
-        Reset: [1, "Reset the module"]
-  AHBENR:
-    "*EN":
-      Disabled: [0, "Clock disabled"]
-      Enabled: [1, "Clock enabled"]
-  "APB*ENR":
-    "*EN":
-      Disabled: [0, "Clock disabled"]
-      Enabled: [1, "Clock enabled"]
   "AHBLPENR":
     "*EN":
       Disabled: [0, "Clock disabled"]
       Enabled: [1, "Clock enabled"]
-  CSR:
-    "*RSTF":
-      _read:
-        NoReset: [0, "No reset has occured"]
-        Reset: [1, "A reset has occured"]
-    RMVF:
-      _write:
-        Clear: [1, "Clears the reset flag"]
-    RTCRST:
-      _write:
-        Reset: [1, "Resets the RTC peripheral"]

--- a/peripherals/rtc/rtc_l0.yaml
+++ b/peripherals/rtc/rtc_l0.yaml
@@ -1,0 +1,274 @@
+# Real Time Clock for L0 Family
+
+RTC:
+  TR:
+    PM:
+      AM: [0, "AM or 24-hour format"]
+      PM: [1, "PM"]
+    HT: [0, 3]
+    HU: [0, 15]
+    MNT: [0, 7]
+    MNU: [0, 15]
+    ST: [0, 7]
+    SU: [0, 15]
+  DR:
+    YT: [0, 15]
+    YU: [0, 15]
+    WDU: [1, 7]
+    MT: [0, 1]
+    MU: [0, 15]
+    DT: [0, 3]
+    DU: [0, 15]
+  CR:
+    COE:
+      Disabled: [0, "Calibration output disabled"]
+      Enabled: [1, "Calibration output enabled"]
+    OSEL:
+      Disabled: [0, "Output disabled"]
+      AlarmA: [1, "Alarm A output enabled"]
+      AlarmB: [2, "Alarm B output enabled"]
+      Wakeup: [3, "Wakeup output enabled"]
+    POL:
+      High: [0, "The pin is high when ALRAF/ALRBF/WUTF is asserted (depending on OSEL[1:0])"]
+      Low: [1, "The pin is low when ALRAF/ALRBF/WUTF is asserted (depending on OSEL[1:0])"]
+    COSEL:
+      CalFreq_512Hz: [0, "Calibration output is 512 Hz (with default prescaler setting)"]
+      CalFreq_1Hz: [1, "Calibration output is 1 Hz (with default prescaler setting)"]
+    BKP:
+      DST_Not_Changed: [0, "Daylight Saving Time change has not been performed"]
+      DST_Changed: [1, "Daylight Saving Time change has been performed"]
+    SUB1H:
+      _write:
+        Sub1: [1, "Subtracts 1 hour to the current time. This can be used for winter time change outside initialization mode"]
+    ADD1H:
+      _write:
+        Add1: [1, "Adds 1 hour to the current time. This can be used for summer time change outside initialization mode"]
+    TSIE:
+      Disabled: [0, "Time-stamp Interrupt disabled"]
+      Enabled: [1, "Time-stamp Interrupt enabled"]
+    WUTIE:
+      Disabled: [0, "Wakeup timer interrupt disabled"]
+      Enabled: [1, "Wakeup timer interrupt enabled"]
+    ALRBIE:
+      Disabled: [0, "Alarm B Interrupt disabled"]
+      Enabled: [1, "Alarm B Interrupt enabled"]
+    ALRAIE:
+      Disabled: [0, "Alarm A interrupt disabled"]
+      Enabled: [1, "Alarm A interrupt enabled"]
+    TSE:
+      Disabled: [0, "Timestamp disabled"]
+      Enabled: [1, "Timestamp enabled"]
+    WUTE:
+      Disabled: [0, "Wakeup timer disabled"]
+      Enabled: [1, "Wakeup timer enabled"]
+    ALRBE:
+      Disabled: [0, "Alarm B disabled"]
+      Enabled: [1, "Alarm B enabled"]
+    ALRAE:
+      Disabled: [0, "Alarm A disabled"]
+      Enabled: [1, "Alarm A enabled"]
+    FMT:
+      Twenty_Four_Hour: [0, "24 hour/day format"]
+      AM_PM: [1, "AM/PM hour format"]
+    BYPSHAD:
+      ShadowReg: [0, "Calendar values (when reading from RTC_SSR, RTC_TR, and RTC_DR) are taken from the shadow registers, which are updated once every two RTCCLK cycles"]
+      BypassShadowReg: [1, "Calendar values (when reading from RTC_SSR, RTC_TR, and RTC_DR) are taken directly from the calendar counters"]
+    REFCKON:
+      Disabled: [0, "RTC_REFIN detection disabled"]
+      Enabled: [1, "RTC_REFIN detection enabled"]
+    TSEDGE:
+      RisingEdge: [0, "RTC_TS input rising edge generates a time-stamp event"]
+      FallingEdge: [1, "RTC_TS input falling edge generates a time-stamp event"]
+    WUCKSEL:
+      Div16: [0, "RTC/16 clock is selected"]
+      Div8: [1, "RTC/8 clock is selected"]
+      Div4: [2, "RTC/4 clock is selected"]
+      Div2: [3, "RTC/2 clock is selected"]
+      ClockSpare: [4, "ck_spre (usually 1 Hz) clock is selected"]
+      ClockSpareWithOffset: [6, "ck_spre (usually 1 Hz) clock is selected and 216 is added to the WUT counter value"]
+  ISR:
+    _add:
+      RECALPF:
+        description: Recalibration pending flag
+        bitWidth: 1
+        bitOffset: 16
+      TAMP3F:
+        description: RTC_TAMP3 detection flag
+        bitWidth: 1
+        bitOffset: 15
+    RECALPF:
+      _read:
+        Pending: [1, "The RECALPF status flag is automatically set to 1 when software writes to the RTC_CALR register, indicating that the RTC_CALR register is blocked. When the new calibration settings are taken into account, this bit returns to 0"]
+    "TAMP*F":
+      _read:
+        Tampered: [1, "This flag is set by hardware when a tamper detection event is detected on the RTC_TAMPx input"]
+      _write:
+        Clear: [0, "Flag cleared by software writing 0"]
+    TSOVF:
+      _read:
+        Overflow: [1, "This flag is set by hardware when a time-stamp event occurs while TSF is already set"]
+      _write:
+        Clear: [0, "This flag is cleared by software by writing 0"]
+    TSF:
+      _read:
+        TimestampEvent: [1, "This flag is set by hardware when a time-stamp event occurs"]
+      _write:
+        Clear: [0, "This flag is cleared by software by writing 0"]
+    WUTF:
+      _read:
+        Zero: [1, "This flag is set by hardware when the wakeup auto-reload counter reaches 0"]
+      _write:
+        Clear: [0, "This flag is cleared by software by writing 0"]
+    ALRBF:
+      _read:
+        Match: [1, "This flag is set by hardware when the time/date registers (RTC_TR and RTC_DR) match the Alarm B register (RTC_ALRMBR)"]
+      _write:
+        Clear: [0, "This flag is cleared by software by writing 0"]
+    ALRAF:
+      _read:
+        Match: [1, "This flag is set by hardware when the time/date registers (RTC_TR and RTC_DR) match the Alarm A register (RTC_ALRMAR)"]
+      _write:
+        Clear: [0, "This flag is cleared by software by writing 0"]        
+    INIT:
+      FreeRunningMode: [0, "Free running mode"]
+      InitMode: [1, "Initialization mode used to program time and date register (RTC_TR and RTC_DR), and prescaler register (RTC_PRER). Counters are stopped and start counting from the new value when INIT is reset."]
+    INITF:
+      _read:
+        NotAllowed: [0, "Calendar registers update is not allowed"]
+        Allowed: [1, "Calendar registers update is allowed"]
+    RSF:
+      _read:
+        NotSynced: [0, "Calendar shadow registers not yet synchronized"]
+        Synced: [1, "Calendar shadow registers synchronized"]
+      _write:
+        Clear: [0, "This flag is cleared by software by writing 0"]
+    INITS:
+      _read:
+        NotInitalized: [0, "Calendar has not been initialized"]
+        Initalized: [1, "Calendar has been initialized"]
+    SHPF:
+      _read:
+        NoShiftPending: [0, "No shift operation is pending"]
+        ShiftPending: [1, "A shift operation is pending"]
+    WUTWF:
+      _read:
+        UpdateNotAllowed: [0, "Wakeup timer configuration update not allowed"]
+        UpdateAllowed: [1, "Wakeup timer configuration update allowed"]
+    "ALR?WF":
+      _read:
+        UpdateNotAllowed: [0, "Alarm update not allowed"]
+        UpdateAllowed: [1, "Alarm update allowed"]
+  PRER:
+    PREDIV_A: [0, 0x7F]
+    PREDIV_S: [0, 0x7FFF]
+  WUTR:
+    WUT: [0, 0xFFFF]
+  "ALRM?R":
+    "MSK*":
+      Mask: [0, "Alarm set if the date/day match"]
+      NotMask: [1, "Date/day don’t care in Alarm comparison"]
+    WDSEL:
+      DateUnits: [0, "DU[3:0] represents the date units"]
+      WeekDay: [1, "DU[3:0] represents the week day. DT[1:0] is don’t care."]
+    DT: [0, 3]
+    DU: [0, 15]
+    PM:
+      AM: [0, "AM or 24-hour format"]
+      PM: [1, "PM"]
+    HT: [0, 3]
+    HU: [0, 15]
+    MNT: [0, 7]
+    MNU: [0, 15]
+    ST: [0, 7]
+    SU: [0, 15]
+  WPR:
+    KEY: [0, 255]
+  SSR:
+    SS: [0, 65535]
+  SHIFTR:
+    ADD1S:
+      _write:
+        Add1: [1, "Add one second to the clock/calendar"]
+    SUBFS: [0, 32767]
+  TSTR:
+    _read:
+      PM:
+        AM: [0, "AM or 24-hour format"]
+        PM: [1, "PM"]
+      HT: [0, 3]
+      HU: [0, 15]
+      MNT: [0, 7]
+      MNU: [0, 15]
+      ST: [0, 7]
+      SU: [0, 15]
+  TSDR:
+    _read:
+      WDU: [0, 3]
+      MT: [0, 1]
+      MU: [0, 7]
+      DT: [0, 3]
+      DU: [0, 15]
+  TSSSR:
+    _read:
+      SS: [0, 65535]
+  CALR:
+    CALP:
+      NoChange: [0, "No RTCCLK pulses are added"]
+      IncreaseFreq: [1, "One RTCCLK pulse is effectively inserted every 2^11 pulses (frequency increased by 488.5 ppm)"]
+    CALW8:
+      Eight_Second: [1, "When CALW8 is set to ‘1’, the 8-second calibration cycle period is selected"]
+    CALW16:
+      Sixteen_Second: [1, "When CALW16 is set to ‘1’, the 16-second calibration cycle period is selected.This bit must not be set to ‘1’ if CALW8=1"]
+    CALM: [0, 511]
+  TAMPCR:
+    "TAMP*MF":
+      NotMasked: [0, "Tamper x event generates a trigger event and TAMPxF must be cleared by software to allow next tamper event detection"]
+      Masked: [1, "Tamper x event generates a trigger event. TAMPxF is masked and internally cleared by hardware. The backup registers are not erased."]
+    "TAMP*NOERASE":
+      Erase: [0, "Tamper x event erases the backup registers"]
+      NoErase: [1, "Tamper x event does not erase the backup registers"]
+    "TAMP[123]IE":
+      Disabled: [0, "Tamper x interrupt is disabled if TAMPIE = 0"]
+      Enabled: [1, "Tamper x interrupt enabled"]
+    TAMPPUDIS:
+      Enabled: [0, "Precharge RTC_TAMPx pins before sampling (enable internal pull-up)"]
+      Disabled: [1, "Disable precharge of RTC_TAMPx pins"]
+    TAMPPRCH:
+      RTCCLK_1_cycle: [0, "1 RTCCLK cycle"]
+      RTCCLK_2_cycle: [1, "2 RTCCLK cycles"]
+      RTCCLK_4_cycle: [2, "4 RTCCLK cycles"]
+      RTCCLK_8_cycle: [3, "8 RTCCLK cycles"]
+    TAMPFLT:
+      Immediate: [0, "Tamper event is activated on edge of RTC_TAMPx input transitions to the active level (no internal pull-up on RTC_TAMPx input)"]
+      Two_Samples: [1, "Tamper event is activated after 2 consecutive samples at the active level"]
+      Four_Samples: [2, "Tamper event is activated after 4 consecutive samples at the active level"]
+      Eight_Samples: [3, "Tamper event is activated after 8 consecutive samples at the active level"]
+    TAMPFREQ:
+      Div32768: [0, "RTCCLK / 32768 (1 Hz when RTCCLK = 32768 Hz)"]
+      Div16384: [1, "RTCCLK / 16384 (2 Hz when RTCCLK = 32768 Hz)"]
+      Div8192: [2, "RTCCLK / 8192 (4 Hz when RTCCLK = 32768 Hz)"]
+      Div4096: [3, "RTCCLK / 4096 (8 Hz when RTCCLK = 32768 Hz)"]
+      Div2048: [4, "RTCCLK / 2048 (16 Hz when RTCCLK = 32768 Hz)"]
+      Div1024: [5, "RTCCLK / 1024 (32 Hz when RTCCLK = 32768 Hz)"]
+      Div512: [6, "RTCCLK / 512 (64 Hz when RTCCLK = 32768 Hz)"]
+      Div256: [7, "RTCCLK / 256 (128 Hz when RTCCLK = 32768 Hz)"]
+    TAMPTS:
+      NoSave: [0, "Tamper detection event does not cause a timestamp to be saved"]
+      Save: [1, "Save timestamp on tamper detection event"]
+    "TAMP*TRG":
+      RisingEdge: [0, "If TAMPFLT = 00: RTC_TAMPx input rising edge triggers a tamper detection event. If TAMPFLT ≠ 00: RTC_TAMPx input staying low triggers a tamper detection event."]
+      FallingEdge: [1, "If TAMPFLT = 00: RTC_TAMPx input staying high triggers a tamper detection event. If TAMPFLT ≠ 00: RTC_TAMPx input falling edge triggers a tamper detection event"]
+    "TAMP[123]E":
+      Disabled: [0, "RTC_TAMPx input detection disabled"]
+      Enabled: [1, "RTC_TAMPx input detection enabled"]
+    TAMPIE:
+      Disabled: [0, "Tamper interrupt disabled"]
+      Enabled: [1, "Tamper interrupt enabled"]
+  "ALRM?SSR":
+    MASKSS: [0, 15]
+    SS: [0, 32767]
+  OR:
+    RTC_OUT_RMP: [0, 1]
+    RTC_ALARM_TYPE: [0, 1]
+  "BKP?R":
+    BKP: [0, 0xFFFFFFFF]

--- a/peripherals/spi/spi_l0.yaml
+++ b/peripherals/spi/spi_l0.yaml
@@ -1,0 +1,10 @@
+# SPI for L0
+
+_include:
+  - "spi_common.yaml"
+
+"SPI*,I2S*":
+  CR1:
+    DFF:
+      EightBit: [0, "8-bit data frame format is selected for transmission/reception"]
+      SixteenBit: [1, "16-bit data frame format is selected for transmission/reception"]

--- a/peripherals/syscfg/syscfg_l0.yaml
+++ b/peripherals/syscfg/syscfg_l0.yaml
@@ -1,0 +1,235 @@
+# System configuration controller and COMP registers for L0 family
+SYSCFG:
+  CFGR1:
+    BOOT_MODE:
+      MainFlash: [0, "Main Flash memory boot mode"]
+      SystemFlash: [1, "System Flash memory boot mode"]
+      SRAM: [3, "Embedded SRAM boot mode"]
+    UFB:
+      Bank1: [0, "Flash Program memory Bank 1 is mapped at 0x0800 0000 (and aliased at 0x0000 0000 if MEM_MODE=00) and Data EEPROM Bank 1 at 0x0808 0000 (aliased at 0x0008 0000 if MEM_MODE=00)"]
+      Bank2: [1, "Flash Program memory Bank 2 is mapped at 0x0800 0000 (and aliased at 0x0000 0000 if MEM_MODE=00) and Data EEPROM Bank 2 at 0x0808 0000 (and aliased at 0x0008 0000 if MEM_MODE=00)"]
+    MEM_MODE:
+      MainFlash: [0, "Main Flash memory mapped at 0x0000_0000"]
+      SystemFlash: [1, "System Flash memory mapped at 0x0000_0000"]
+      SRAM: [3, "Embedded SRAM mapped at 0x0000_0000"]
+  CFGR2:
+    I2C3_FMP:
+      Standard: [0, "FM+ mode is controlled by I2C_Pxx_FMP bits only"]
+      FMP: [1, "FM+ mode is enabled on all I2C3 pins selected through selection bits in GPIOx_AFR registers"]
+    I2C2_FMP:
+      Standard: [0, "FM+ mode is controlled by I2C_Pxx_FMP bits only"]
+      FMP: [1, "FM+ mode is enabled on all I2C2 pins selected through selection bits in GPIOx_AFR registers"]
+    I2C1_FMP:
+      Standard: [0, "FM+ mode is controlled by I2C_Pxx_FMP bits only"]
+      FMP: [1, "FM+ mode is enabled on all I2C1 pins selected through selection bits in GPIOx_AFR registers"]
+    I2C_PB9_FMP:
+      Standard: [0, "PB9 pin operate in standard mode"]
+      FMP: [1, "I2C FM+ mode enabled on PB9 and the Speed control is bypassed"]
+    I2C_PB8_FMP:
+      Standard: [0, "PB8 pin operate in standard mode"]
+      FMP: [1, "I2C FM+ mode enabled on PB8 and the Speed control is bypassed"]
+    I2C_PB7_FMP:
+      Standard: [0, "PB7 pin operate in standard mode"]
+      FMP: [1, "I2C FM+ mode enabled on PB7 and the Speed control is bypassed"]
+    I2C_PB6_FMP:
+      Standard: [0, "PB6 pin operate in standard mode"]
+      FMP: [1, "I2C FM+ mode enabled on PB6 and the Speed control is bypassed"]
+    FWDIS:
+      Enabled: [0, "Firewall access enabled"]
+      Disabled: [1, "Firewall access disabled"]
+  CFGR3:
+    REF_LOCK:
+      ReadWrite: [0, "SYSCFG_CFGR3[31:0] bits are read/write"]
+      ReadOnly: [1, "SYSCFG_CFGR3[31:0] bits are read-only"]
+    VREFINT_RDYF:
+      NotReady: [0, "VREFINT OFF"]
+      Ready: [1, "VREFINT ready"]
+    ENBUF_VREFINT_COMP2:
+      Disabled: [0, "Disables the buffer used to generate VREFINT references for COMP2"]
+      Enabled: [1, "Enables the buffer used to generate VREFINT references for COMP2"]
+    ENBUF_SENSOR_ADC:
+      Disabled: [0, "Disables the buffer used to generate VREFINT reference for the temperature sensor"]
+      Enabled: [1, "Enables the buffer used to generate VREFINT reference for the temperature sensor"]
+    ENBUF_VREFINT_ADC:
+      Disabled: [0, "Disables the buffer used to generate VREFINT reference for the ADC"]
+      Enabled: [1, "Enables the buffer used to generate VREFINT reference for the ADC"]
+    SEL_VREF_OUT:
+      NoConnection: [0, "no pad connected"]
+      PB0: [1, "PB0 connected"]
+      PB1: [2, "PB1 connected"]
+      Both: [3, "PB0 and PB1 connected"]
+    EN_VREFINT:
+      Disabled: [0, "VREFINT voltage disabled in low-power mode (if ULP=1) and scaler for COMP2 disabled"]
+      Enabled: [1, "VREFINT voltage enabled in low-power mode and scaler for COMP2 enabled"]
+  EXTICR1:
+    EXTI0:
+      PA0: [0, "Select PA0 as the source input for the EXTI0 external interrupt"]
+      PB0: [1, "Select PB0 as the source input for the EXTI0 external interrupt"]
+      PC0: [2, "Select PC0 as the source input for the EXTI0 external interrupt"]
+      PD0: [3, "Select PD0 as the source input for the EXTI0 external interrupt"]
+      PE0: [4, "Select PE0 as the source input for the EXTI0 external interrupt"]
+      PH0: [5, "Select PH0 as the source input for the EXTI0 external interrupt"]
+    EXTI1:
+      PA1: [0, "Select PA1 as the source input for the EXTI1 external interrupt"]
+      PB1: [1, "Select PB1 as the source input for the EXTI1 external interrupt"]
+      PC1: [2, "Select PC1 as the source input for the EXTI1 external interrupt"]
+      PD1: [3, "Select PD1 as the source input for the EXTI1 external interrupt"]
+      PE1: [4, "Select PE1 as the source input for the EXTI1 external interrupt"]
+      PH1: [5, "Select PH1 as the source input for the EXTI1 external interrupt"]
+    EXTI2:
+      PA2: [0, "Select PA2 as the source input for the EXTI2 external interrupt"]
+      PB2: [1, "Select PB2 as the source input for the EXTI2 external interrupt"]
+      PC2: [2, "Select PC2 as the source input for the EXTI2 external interrupt"]
+      PD2: [3, "Select PD2 as the source input for the EXTI2 external interrupt"]
+      PE2: [4, "Select PE2 as the source input for the EXTI2 external interrupt"]
+      PH2: [5, "Select PH2 as the source input for the EXTI2 external interrupt"]
+    EXTI3:
+      PA3: [0, "Select PA3 as the source input for the EXTI3 external interrupt"]
+      PB3: [1, "Select PB3 as the source input for the EXTI3 external interrupt"]
+      PC3: [2, "Select PC3 as the source input for the EXTI3 external interrupt"]
+      PD3: [3, "Select PD3 as the source input for the EXTI3 external interrupt"]
+      PE3: [4, "Select PE3 as the source input for the EXTI3 external interrupt"]
+      PH3: [5, "Select PH3 as the source input for the EXTI3 external interrupt"]
+  EXTICR2:
+    EXTI4:
+      PA4: [0, "Select PA4 as the source input for the EXTI4 external interrupt"]
+      PB4: [1, "Select PB4 as the source input for the EXTI4 external interrupt"]
+      PC4: [2, "Select PC4 as the source input for the EXTI4 external interrupt"]
+      PD4: [3, "Select PD4 as the source input for the EXTI4 external interrupt"]
+      PE4: [4, "Select PE4 as the source input for the EXTI4 external interrupt"]
+    EXTI5:
+      PA5: [0, "Select PA5 as the source input for the EXTI5 external interrupt"]
+      PB5: [1, "Select PB5 as the source input for the EXTI5 external interrupt"]
+      PC5: [2, "Select PC5 as the source input for the EXTI5 external interrupt"]
+      PD5: [3, "Select PD5 as the source input for the EXTI5 external interrupt"]
+      PE5: [4, "Select PE5 as the source input for the EXTI5 external interrupt"]
+    EXTI6:
+      PA6: [0, "Select PA6 as the source input for the EXTI6 external interrupt"]
+      PB6: [1, "Select PB6 as the source input for the EXTI6 external interrupt"]
+      PC6: [2, "Select PC6 as the source input for the EXTI6 external interrupt"]
+      PD6: [3, "Select PD6 as the source input for the EXTI6 external interrupt"]
+      PE6: [4, "Select PE6 as the source input for the EXTI6 external interrupt"]
+    EXTI7:
+      PA7: [0, "Select PA7 as the source input for the EXTI7 external interrupt"]
+      PB7: [1, "Select PB7 as the source input for the EXTI7 external interrupt"]
+      PC7: [2, "Select PC7 as the source input for the EXTI7 external interrupt"]
+      PD7: [3, "Select PD7 as the source input for the EXTI7 external interrupt"]
+      PE7: [4, "Select PE7 as the source input for the EXTI7 external interrupt"]
+  EXTICR3:
+    EXTI8:
+      PA8: [0, "Select PA8 as the source input for the EXTI8 external interrupt"]
+      PB8: [1, "Select PB8 as the source input for the EXTI8 external interrupt"]
+      PC8: [2, "Select PC8 as the source input for the EXTI8 external interrupt"]
+      PD8: [3, "Select PD8 as the source input for the EXTI8 external interrupt"]
+      PE8: [4, "Select PE8 as the source input for the EXTI8 external interrupt"]
+      PH8: [5, "Select PH8 as the source input for the EXTI8 external interrupt"]
+    EXTI9:
+      PA9: [0, "Select PA9 as the source input for the EXTI9 external interrupt"]
+      PB9: [1, "Select PB9 as the source input for the EXTI9 external interrupt"]
+      PC9: [2, "Select PC9 as the source input for the EXTI9 external interrupt"]
+      PD9: [3, "Select PD9 as the source input for the EXTI9 external interrupt"]
+      PE9: [4, "Select PE9 as the source input for the EXTI9 external interrupt"]
+      PH9: [5, "Select PH9 as the source input for the EXTI9 external interrupt"]
+    EXTI10:
+      PA10: [0, "Select PA10 as the source input for the EXTI10 external interrupt"]
+      PB10: [1, "Select PB10 as the source input for the EXTI10 external interrupt"]
+      PC10: [2, "Select PC10 as the source input for the EXTI10 external interrupt"]
+      PD10: [3, "Select PD10 as the source input for the EXTI10 external interrupt"]
+      PE10: [4, "Select PE10 as the source input for the EXTI10 external interrupt"]
+      PH10: [5, "Select PH10 as the source input for the EXTI10 external interrupt"]
+    EXTI11:
+      PA11: [0, "Select PA11 as the source input for the EXTI11 external interrupt"]
+      PB11: [1, "Select PB11 as the source input for the EXTI11 external interrupt"]
+      PC11: [2, "Select PC11 as the source input for the EXTI11 external interrupt"]
+      PD11: [3, "Select PD11 as the source input for the EXTI11 external interrupt"]
+      PE11: [4, "Select PE11 as the source input for the EXTI11 external interrupt"]
+      PH11: [5, "Select PH11 as the source input for the EXTI11 external interrupt"]
+  EXTICR4:
+    EXTI12:
+      PA12: [0, "Select PA12 as the source input for the EXTI12 external interrupt"]
+      PB12: [1, "Select PB12 as the source input for the EXTI12 external interrupt"]
+      PC12: [2, "Select PC12 as the source input for the EXTI12 external interrupt"]
+      PD12: [3, "Select PD12 as the source input for the EXTI12 external interrupt"]
+      PE12: [4, "Select PE12 as the source input for the EXTI12 external interrupt"]
+    EXTI13:
+      PA13: [0, "Select PA13 as the source input for the EXTI13 external interrupt"]
+      PB13: [1, "Select PB13 as the source input for the EXTI13 external interrupt"]
+      PC13: [2, "Select PC13 as the source input for the EXTI13 external interrupt"]
+      PD13: [3, "Select PD13 as the source input for the EXTI13 external interrupt"]
+      PE13: [4, "Select PE13 as the source input for the EXTI13 external interrupt"]
+    EXTI14:
+      PA14: [0, "Select PA14 as the source input for the EXTI14 external interrupt"]
+      PB14: [1, "Select PB14 as the source input for the EXTI14 external interrupt"]
+      PC14: [2, "Select PC14 as the source input for the EXTI14 external interrupt"]
+      PD14: [3, "Select PD14 as the source input for the EXTI14 external interrupt"]
+      PE14: [4, "Select PE14 as the source input for the EXTI14 external interrupt"]
+    EXTI15:
+      PA15: [0, "Select PA15 as the source input for the EXTI15 external interrupt"]
+      PB15: [1, "Select PB15 as the source input for the EXTI15 external interrupt"]
+      PC15: [2, "Select PC15 as the source input for the EXTI15 external interrupt"]
+      PD15: [3, "Select PD15 as the source input for the EXTI15 external interrupt"]
+      PE15: [4, "Select PE15 as the source input for the EXTI15 external interrupt"]
+  COMP1_CSR:
+    COMP1LOCK:
+      ReadWrite: [0, "COMP1_CSR[31:0] for comparator 1 are read/write"]
+      ReadOnly: [1, "COMP1_CSR[31:0] for comparator 1 are read-only"]
+    COMP1VALUE:
+      _read:
+        NotEqual: [0, "Comparator values are not equal"]
+        Equal: [1, "Comparator values are equal"]
+    COMP1POLARITY:
+      NotInverted: [0, "Comparator 1 output value not inverted"]
+      Inverted: [1, "Comparator 1 output value inverted"]
+    COMP1LPTIMIN1:
+      Gated: [0, "Comparator 1 output gated"]
+      NotGated: [1, "Comparator 1 output sent to LPTIM input 1"]
+    COMP1WM:
+      PA1: [0, "Plus input of comparator 1 connected to PA1"]
+      Comp2Plus: [1, "Plus input of comparator 1 shorted with Plus input of comparator 2 (see COMP1_CSR)"]
+    COMP1INNSEL:
+      VREFINT: [0, "VREFINT"]
+      PA0: [1, "PA0"]
+      PA4: [2, "PA4"]
+      PA5: [3, "PA5"]
+    COMP1EN:
+      Disabled: [0, "Comparator 1 switched OFF"]
+      Enabled: [1, "Comparator 1 switched ON"]
+  COMP2_CSR:
+    COMP2LOCK:
+      ReadWrite: [0, "COMP2_CSR[31:0] for comparator 2 are read/write"]
+      ReadOnly: [1, "COMP2_CSR[31:0] for comparator 2 are read-only"]
+    COMP2VALUE:
+      _read:
+        NotEqual: [0, "Comparator values are not equal"]
+        Equal: [1, "Comparator values are equal"]
+    COMP2POLARITY:
+      NotInverted: [0, "Comparator 2 output value not inverted"]
+      Inverted: [1, "Comparator 2 output value inverted"]
+    COMP2LPTIMIN1:
+      Gated: [0, "Comparator 2 output gated"]
+      NotGated: [1, "Comparator 2 output sent to LPTIM input 1"]
+    COMP2LPTIMIN2:
+      Gated: [0, "Comparator 2 output gated"]
+      NotGated: [1, "Comparator 2 output sent to LPTIM input 2"]
+    COMP2INPSEL:
+      PA3: [0, "PA3"]
+      PB4: [1, "PB4"]
+      PB5: [2, "PB5"]
+      PB6: [3, "PB6"]
+      PB7: [4, "PB7"]
+      PA7: [5, "PA7"]
+    COMP2INNSEL:
+      VREFINT: [0, "VREFINT"]
+      PA2: [1, "PA2"]
+      PA4: [2, "PA4"]
+      PA5: [3, "PA5"]
+      VREFINT_Div4: [4, "1/4 VREFINT"]
+      VREFINT_Div2: [5, "1/2 VREFINT"]
+      VREFINT_Div3_4: [6, "3/4 VREFINT"]
+      PB3: [7, "PB3"]
+    COMP2SPEED:
+      Slow: [0, "Slow speed"]
+      Fast: [1, "Fast speed"]
+    COMP2EN:
+      Disabled: [0, "Comparator 2 switched OFF"]
+      Enabled: [1, "Comparator 2 switched ON"]

--- a/peripherals/tim/tim21.yaml
+++ b/peripherals/tim/tim21.yaml
@@ -1,36 +1,39 @@
-# Common base for 16bit and 32bit TIM2 peripheral
+# TIM21 and TIM22 peripherals
 
-"TIM[23]":
+"TIM2?":
   CR1:
     CKD:
-      NotDivided: [0, "CK_INT not divided"]
-      DividedBy2: [1, "CK_INT divided by 2"]
-      DividedBy4: [2, "CK_INT divided by 4"]
+      NoMul: [0, "tDTS = tCK_INT"]
+      Mul2: [1, "tDTS = 2 × tCK_INT"]
+      Mul4: [2, "tDTS = 4 × tCK_INT"]
+    CMS:
+      Edge_Aligned: [0, "Edge-aligned mode"]
+      Center_Mode1: [1, "Center-aligned mode 1"]
+      Center_Mode2: [2, "Center-aligned mode 2"]
+      Center_Mode3: [3, "Center-aligned mode 3"]
+    DIR:
+      Upcounter: [0, "Counter used as upcounter"]
+      Downcounter: [1, "Counter used as downcounter"]
+    OPM:
+      NotStopped: [0, "Counter is not stopped on the update event"]
+      Stopped: [1, "Counter stops counting on the next update event (clearing the CEN bit)"]
   CR2:
-    TI1S:
-      Normal: [0, "The TIMx_CH1 pin is connected to TI1 input"]
-      XOR: [1, "The TIMx_CH1, CH2, CH3 pins are connected to TI1 input"]
     MMS:
-      Reset: [0, "The UG bit from the TIMx_EGR register is used as trigger output"]
-      Enable: [1, "The counter enable signal, CNT_EN, is used as trigger output"]
-      Update: [2, "The update event is selected as trigger output"]
-      ComparePulse: [3, "The trigger output send a positive pulse when the CC1IF flag it to be set, as soon as a capture or a compare match occurred"]
-      CompareOC1: [4, "OC1REF signal is used as trigger output"]
-      CompareOC2: [5, "OC2REF signal is used as trigger output"] 
-      CompareOC3: [6, "OC3REF signal is used as trigger output"]
-      CompareOC4: [7, "OC4REF signal is used as trigger output"]
-    CCDS:
-      OnCompare: [0, "CCx DMA request sent when CCx event occurs"]
-      OnUpdate: [1, "CCx DMA request sent when update event occurs"]
+      Reset: [0, "Reset - the UG bit from the TIMx_EGR register is used as trigger output (TRGO)"]
+      Enable: [1, "Enable - the Counter enable signal, CNT_EN, is used as trigger output (TRGO)"]
+      Update: [2, "Update - The update event is selected as trigger output (TRGO)"]
+      ComparePulse: [3, "Compare Pulse - The trigger output send a positive pulse when the CC1IF flag is to be set (even if it was already high), as soon as a capture or a compare match occurred"]
+      OC1REF: [4, "OC1REF signal is used as trigger output (TRGO)"]
+      OC2REF: [5, "OC2REF signal is used as trigger output (TRGO)"]
   SMCR:
     ETP:
-      NotInverted: [0, "ETR is noninverted, active at high level or rising edge"]
-      Inverted: [1, "ETR is inverted, active at low level or falling edge"]
+      RisingEdge: [0, "ETR is non-inverted, active at high level or rising edge"]
+      FallingEdge: [1, "ETR is inverted, active at low level or falling edge"]
     ECE:
       Disabled: [0, "External clock mode 2 disabled"]
-      Enabled: [1, "External clock mode 2 enabled. The counter is clocked by any active edge on the ETRF signal."]
+      Enabled: [1, "External clock mode 2 enabled"]
     ETPS:
-      NoDiv: [0, "Prescaler OFF"]
+      NoPrescaler: [0, "Prescaler OFF"]
       Div2: [1, "ETRP frequency divided by 2"]
       Div4: [2, "ETRP frequency divided by 4"]
       Div8: [3, "ETRP frequency divided by 8"]
@@ -72,15 +75,6 @@
       Trigger_Mode: [6, "Trigger Mode - The counter starts at a rising edge of the trigger TRGI (but it is not reset). Only the start of the counter is controlled."]
       Ext_Clock_Mode: [7, "External Clock Mode 1 - Rising edges of the selected trigger (TRGI) clock the counter."]
   DIER:
-    TDE:
-      Disabled: [0, "Trigger DMA request disabled"]
-      Enabled: [1, "Trigger DMA request enabled"]
-    "CC?DE":
-      Disabled: [0, "CCx DMA request disabled"]
-      Enabled: [1, "CCx DMA request enabled"]
-    UDE:
-      Disabled: [0, "Update DMA request disabled"]
-      Enabled: [1, "Update DMA request enabled"]
     TIE:
       Disabled: [0, "Trigger interrupt disabled"]
       Enabled: [1, "Trigger interrupt enabled"]
@@ -113,6 +107,7 @@
         Trigger: [1, "If CC1 is an output: CC1IF flag is set, Corresponding interrupt or DMA request is sent if enabled. If CC1 is an input: The current value of the counter is captured in TIMx_CCR1 register."]
   CCMR1_Input:
     IC2F: [0, 15]
+    IC2PSC: [0, 3]
     CC2S:
       Output: [0, "CC2 channel is configured as output"]
       TI2: [1, "CC2 channel is configured as input, IC2 is mapped on TI2"]
@@ -135,27 +130,36 @@
       FDTS_Div32_N5: [13, "fSAMPLING=fDTS/32, N=5"]
       FDTS_Div32_N6: [14, "fSAMPLING=fDTS/32, N=6"]
       FDTS_Div32_N8: [15, "fSAMPLING=fDTS/32, N=8"]
+    IC1PSC: [0, 3]
     CC1S:
       Output: [0, "CC1 channel is configured as output"]
       TI1: [1, "CC1 channel is configured as input, IC1 is mapped on TI1"]
       TI2: [2, "CC1 channel is configured as input, IC1 is mapped on TI2"]
       TRC: [3, "CC1 channel is configured as input, IC1 is mapped on TRC"]
-  CCMR2_Input:
-    IC4F: [0, 15]
-    IC4PSC: [0, 3]
-    CC4S:
-      Output: [0, "CC4 channel is configured as output"]
-      TI4: [1, "CC4 channel is configured as input, IC4 is mapped on TI4"]
-      TI3: [2, "CC4 channel is configured as input, IC4 is mapped on TI3"]
-      TRC: [3, "CC4 channel is configured as input, IC4 is mapped on TRC"]
-    IC3F: [0, 15]
-    IC3PSC: [0, 3]
-    CC3S: 
-      Output: [0, "CC3 channel is configured as output"]
-      TI3: [1, "CC3 channel is configured as input, IC3 is mapped on TI3"]
-      TI4: [2, "CC3 channel is configured as input, IC3 is mapped on TI4"]
-      TRC: [3, "CC3 channel is configured as input, IC3 is mapped on TRC"]
-  DCR:
-    DBL: [0, 18]
-    DBA: [0, 31]
+  CCER:
+    "CC?NP":
+      Negative: [0, "Negative polarity"]
+      Positive: [1, "Positive polarity"]
+    "CC?P":
+      RisingEdge: [0, "Noninverted/rising edge"]
+      FallingEdge: [1, "Inverted/falling edge"]
+    "CC?E":
+      Disabled: [0, "Capture disabled"]
+      Enabled: [1, "Capture enabled"]
+  CNT:
+    CNT: [0, 65536]
+  ARR:
+    ARR: [0, 65536]
+  "CCR?":
+    "CCR?": [0, 65536]
+  OR:
+    TI1_RMP:
+      GPIO: [0, "TIM22 TI1 input connected to GPIO"]
+      COMP2_OUT: [1, "TIM22 TI1 input connected to COMP2_OUT"]
+      COMP1_OUT: [2, "TIM22 TI1 input connected to COMP1_OUT"]
+    ETR_RMP:
+      GPIO: [0, "TIM22 ETR input connected to GPIO"]
+      COMP2_OUT: [1, "TIM22 ETR input connected to COMP2_OUT"]
+      COMP1_OUT: [2, "TIM22 ETR input connected to COMP1_OUT"]
+      LSE: [3, "TIM22 ETR input connected to LSE clock"]
 

--- a/peripherals/tim/tim_l0.yaml
+++ b/peripherals/tim/tim_l0.yaml
@@ -1,0 +1,33 @@
+# TIM2 and TIM3 registers specific to the L0 Family (and possibly others)
+
+"TIM[23]":
+  CCMR1_Input:
+    IC2F: [0, 15]
+    IC2PSC: [0, 3]
+    IC1PSC:
+      NoPrescaler: [0, "no prescaler, capture is done each time an edge is detected on the capture input"]
+      Two_Events: [1, "Capture is done once every 2 events"]
+      Four_Events: [2, "Capture is done once every 4 events"]
+      Eight_Events: [3, "Capture is done once every 8 events"]
+  CCER:
+    "CC?NP":
+      Negative: [0, "Negative polarity"]
+      Positive: [1, "Positive polarity"]
+    "CC?P":
+      RisingEdge: [0, "Noninverted/rising edge"]
+      FallingEdge: [1, "Inverted/falling edge"]
+    "CC?E":
+      Disabled: [0, "Capture disabled"]
+      Enabled: [1, "Capture enabled"]
+  DMAR:
+    DMAB: [0, 65535]
+  OR:
+    TI4_RMP: 
+      COMP2_OUT: [1, "TIM2 TI4 input connected to COMP2_OUT"]
+      COMP1_OUT: [2, "TIM2 TI4 input connected to COMP1_OUT"]
+    ETR_RMP:
+      COMP1_OUT: [7, "TIM2 ETR input is connected to COMP1_OUT"]
+      COMP2_OUT: [6, "TIM2 ETR input is connected to COMP2_OUT"]
+      LSE: [5, "TIM2 ETR input is connected to LSE"]
+      HSI: [3, "TIM2 ETR input is connected to HSI16 when HSI16OUTEN bit is set"]
+


### PR DESCRIPTION
This PR contains the requested changes from PR #126 (which failed to merge cleanly) and the remaining peripherals required to complete coverage of the L0 family.