### PR TITLE
Uart fixes and documentation on F1, F2 and F7

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,16 @@ _add:
                 description: ADC global interrupt
                 value: 18
 
+# A whole new peripheral can also be created as derivedFrom another peripheral.
+_add:
+    USART3:
+        derivedFrom: USART1
+        baseAddress: "0x40004800"
+        interrupts:
+            USART3:
+                description: USART3 global interrupt
+                value: 39
+
 # Reorder the hierarchy of peripherals with 'deriveFrom'.
 _rebase:
     # The KEY peripheral steals everything but 'interrupt', 'name',

--- a/README.md
+++ b/README.md
@@ -214,6 +214,13 @@ _add:
                 description: USART3 global interrupt
                 value: 39
 
+# Replace peripheral registers by a 'deriveFrom'.
+_derive:
+    # The KEY peripheral looses all its elements but 'interrupt', 'name',
+    # and 'baseAddress', and it is derivedFrom the VALUE peripheral.
+    # Peripherals that were 'deriveFrom="KEY"' are now 'deriveFrom="VALUE"'.
+    UART5: UART4
+
 # Reorder the hierarchy of peripherals with 'deriveFrom'.
 _rebase:
     # The KEY peripheral steals everything but 'interrupt', 'name',

--- a/devices/stm32f100.yaml
+++ b/devices/stm32f100.yaml
@@ -33,6 +33,9 @@ _include:
  - ../peripherals/tim/tim16.yaml
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_16bit.yaml
+ - ../peripherals/usart/uart_common.yaml
+ - ../peripherals/usart/uart_uart.yaml
+ - ../peripherals/usart/uart_usart.yaml
  - ../peripherals/rcc/rcc_f1.yaml
  - common_patches/dma/dma_v1.yaml
  - ../peripherals/dma/dma_v1.yaml

--- a/devices/stm32f100.yaml
+++ b/devices/stm32f100.yaml
@@ -1,5 +1,8 @@
 _svd: ../svd/stm32f100.svd
 
+_derive:
+  UART5: UART4
+
 WWDG:
   # EWIF is named incorrectly in the SVD compared to its name in RM0008
   SR:

--- a/devices/stm32f101.yaml
+++ b/devices/stm32f101.yaml
@@ -50,6 +50,9 @@ _include:
  - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_16bit.yaml
+ - ../peripherals/usart/uart_common.yaml
+ - ../peripherals/usart/uart_uart.yaml
+ - ../peripherals/usart/uart_usart.yaml
  - ../peripherals/rcc/rcc_f1.yaml
  - common_patches/dma/dma_v1.yaml
  - ../peripherals/dma/dma_v1.yaml

--- a/devices/stm32f101.yaml
+++ b/devices/stm32f101.yaml
@@ -1,5 +1,8 @@
 _svd: ../svd/stm32f101.svd
 
+_derive:
+  UART5: UART4
+
 # Merge the thousands of individal bit fields into a single field for each
 # CAN filter register. This is not only much easier to use but also saves
 # a huge amount of filespace and compilation time etc -- as much as 30% of all

--- a/devices/stm32f102.yaml
+++ b/devices/stm32f102.yaml
@@ -83,6 +83,9 @@ _include:
  - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_16bit.yaml
+ - ../peripherals/usart/uart_common.yaml
+ - ../peripherals/usart/uart_uart.yaml
+ - ../peripherals/usart/uart_usart.yaml
  - ../peripherals/rcc/rcc_f1.yaml
  - common_patches/dma/dma_v1.yaml
  - ../peripherals/dma/dma_v1.yaml

--- a/devices/stm32f102.yaml
+++ b/devices/stm32f102.yaml
@@ -1,5 +1,8 @@
 _svd: ../svd/stm32f102.svd
 
+_rebase:
+  UART4: UART5
+
 # Merge the thousands of individal bit fields into a single field for each
 # CAN filter register. This is not only much easier to use but also saves
 # a huge amount of filespace and compilation time etc -- as much as 30% of all

--- a/devices/stm32f102.yaml
+++ b/devices/stm32f102.yaml
@@ -50,6 +50,15 @@ RCC:
         bitOffset: 14
         bitWidth: 1
 
+_add:
+  USART3:
+    derivedFrom: USART1
+    baseAddress: "0x40004800"
+    interrupts:
+      USART3:
+        description: USART3 global interrupt
+        value: 39
+
 WWDG:
   # EWIF is named incorrectly in the SVD compared to its name in RM0008
   SR:

--- a/devices/stm32f103.yaml
+++ b/devices/stm32f103.yaml
@@ -1,5 +1,8 @@
 _svd: ../svd/stm32f103.svd
 
+_derive:
+  UART5: UART4
+
 # Merge the thousands of individal bit fields into a single field for each
 # CAN filter register. This is not only much easier to use but also saves
 # a huge amount of filespace and compilation time etc -- as much as 30% of all

--- a/devices/stm32f103.yaml
+++ b/devices/stm32f103.yaml
@@ -67,6 +67,9 @@ _include:
  - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_16bit.yaml
+ - ../peripherals/usart/uart_common.yaml
+ - ../peripherals/usart/uart_uart.yaml
+ - ../peripherals/usart/uart_usart.yaml
  - ../peripherals/rcc/rcc_f1.yaml
  - ../peripherals/rcc/rcc_f1_usb.yaml
  - common_patches/dma/dma_v1.yaml

--- a/devices/stm32f107.yaml
+++ b/devices/stm32f107.yaml
@@ -1,5 +1,8 @@
 _svd: ../svd/stm32f107.svd
 
+_derive:
+  UART5: UART4
+
 # Merge the thousands of individal bit fields into a single field for each
 # CAN filter register. This is not only much easier to use but also saves
 # a huge amount of filespace and compilation time etc -- as much as 30% of all

--- a/devices/stm32f107.yaml
+++ b/devices/stm32f107.yaml
@@ -46,6 +46,9 @@ _include:
  - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_16bit.yaml
+ - ../peripherals/usart/uart_common.yaml
+ - ../peripherals/usart/uart_uart.yaml
+ - ../peripherals/usart/uart_usart.yaml
  - ../peripherals/rcc/rcc_f1.yaml
  - ../peripherals/rcc/rcc_f1_usb.yaml
  - common_patches/dma/dma_v1.yaml

--- a/devices/stm32f215.yaml
+++ b/devices/stm32f215.yaml
@@ -59,6 +59,10 @@ _include:
  - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_32bit.yaml
+ - ../peripherals/usart/uart_common.yaml
+ - ../peripherals/usart/uart_sample.yaml
+ - ../peripherals/usart/uart_uart.yaml
+ - ../peripherals/usart/uart_usart.yaml
  - ../peripherals/iwdg/iwdg.yaml
  - ../peripherals/i2c/i2c_v1.yaml
  - common_patches/hash/hash_v1.yaml

--- a/devices/stm32f215.yaml
+++ b/devices/stm32f215.yaml
@@ -1,5 +1,8 @@
 _svd: ../svd/stm32f215.svd
 
+_derive:
+  UART5: UART4
+
 _rebase:
   # Make I2C1 the base type
   I2C1: I2C3

--- a/devices/stm32f217.yaml
+++ b/devices/stm32f217.yaml
@@ -1,5 +1,8 @@
 _svd: ../svd/stm32f217.svd
 
+_derive:
+  UART5: UART4
+
 _rebase:
   # Make I2C1 the base type
   I2C1: I2C3

--- a/devices/stm32f217.yaml
+++ b/devices/stm32f217.yaml
@@ -58,6 +58,10 @@ _include:
  - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2_32bit.yaml
+ - ../peripherals/usart/uart_common.yaml
+ - ../peripherals/usart/uart_sample.yaml
+ - ../peripherals/usart/uart_uart.yaml
+ - ../peripherals/usart/uart_usart.yaml
  - ../peripherals/iwdg/iwdg.yaml
  - ../peripherals/i2c/i2c_v1.yaml
  - common_patches/hash/hash_v1.yaml

--- a/devices/stm32f301.yaml
+++ b/devices/stm32f301.yaml
@@ -1,5 +1,17 @@
 _svd: ../svd/stm32f301.svd
 
+_add:
+  I2C3:
+    derivedFrom: I2C1
+    baseAddress: "0x40007800"
+    interrupts:
+      I2C3_EV_IRQ:
+        description: I2C3 event interrupt / EXTI Line27 interrupt
+        value: 72
+      I2C3_ER_IRQ:
+        description: I2C3 error interrupt
+        value: 73
+
 # The SVD puts CSR and CCR at 0x0 and 0x8 offset, which is their offset
 # for a common ADC peripheral which is 0x300 above ADC, but this peripheral
 # isn't defined in the SVD and instead the fields are described as aliasing

--- a/devices/stm32f401.yaml
+++ b/devices/stm32f401.yaml
@@ -40,6 +40,7 @@ _include:
  - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/tim/tim_gp1.yaml
  - ../peripherals/usart/uart_common.yaml
+ - ../peripherals/usart/uart_sample.yaml
  - ../peripherals/usart/uart_usart.yaml
  - ../peripherals/i2c/i2c_v1.yaml
  - ../peripherals/wwdg/wwdg.yaml

--- a/devices/stm32f405.yaml
+++ b/devices/stm32f405.yaml
@@ -86,6 +86,7 @@ _include:
  - ../peripherals/tim/tim_opm.yaml
  - ../peripherals/tim/tim_gp1.yaml
  - ../peripherals/usart/uart_common.yaml
+ - ../peripherals/usart/uart_sample.yaml
  - ../peripherals/usart/uart_uart.yaml
  - ../peripherals/usart/uart_usart.yaml
  - ../peripherals/i2c/i2c_v1.yaml

--- a/devices/stm32f407.yaml
+++ b/devices/stm32f407.yaml
@@ -92,6 +92,7 @@ _include:
  - ../peripherals/eth/eth_dma.yaml
  - ../peripherals/flash/flash_v1.yaml
  - ../peripherals/usart/uart_usart.yaml
+ - ../peripherals/usart/uart_sample.yaml
  - ../peripherals/usart/uart_uart.yaml
  - ../peripherals/usart/uart_common.yaml
  - ../peripherals/i2c/i2c_v1.yaml

--- a/devices/stm32f410.yaml
+++ b/devices/stm32f410.yaml
@@ -59,6 +59,7 @@ _include:
  - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/tim/tim_gp1.yaml
  - ../peripherals/usart/uart_common.yaml
+ - ../peripherals/usart/uart_sample.yaml
  - ../peripherals/usart/uart_usart.yaml
  - ../peripherals/i2c/i2c_v1.yaml
  - ../peripherals/wwdg/wwdg.yaml

--- a/devices/stm32f411.yaml
+++ b/devices/stm32f411.yaml
@@ -51,6 +51,7 @@ _include:
  - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/tim/tim_gp1.yaml
  - ../peripherals/usart/uart_common.yaml
+ - ../peripherals/usart/uart_sample.yaml
  - ../peripherals/usart/uart_usart.yaml
  - ../peripherals/i2c/i2c_v1.yaml
  - ../peripherals/wwdg/wwdg.yaml

--- a/devices/stm32f412.yaml
+++ b/devices/stm32f412.yaml
@@ -171,6 +171,7 @@ _include:
  - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/tim/tim_gp1.yaml
  - ../peripherals/usart/uart_common.yaml
+ - ../peripherals/usart/uart_sample.yaml
  - ../peripherals/usart/uart_usart.yaml
  - ../peripherals/i2c/i2c_v1.yaml
  - ../peripherals/wwdg/wwdg.yaml

--- a/devices/stm32f413.yaml
+++ b/devices/stm32f413.yaml
@@ -137,6 +137,7 @@ _include:
  - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/tim/tim_gp1.yaml
  - ../peripherals/usart/uart_common.yaml
+ - ../peripherals/usart/uart_sample.yaml
  - ../peripherals/usart/uart_usart.yaml
  - ../peripherals/i2c/i2c_v1.yaml
  - ../peripherals/wwdg/wwdg.yaml

--- a/devices/stm32f427.yaml
+++ b/devices/stm32f427.yaml
@@ -173,6 +173,7 @@ _include:
  - ../peripherals/eth/eth_mmc.yaml
  - ../peripherals/eth/eth_dma.yaml
  - ../peripherals/usart/uart_common.yaml
+ - ../peripherals/usart/uart_sample.yaml
  - ../peripherals/usart/uart_uart.yaml
  - ../peripherals/usart/uart_usart.yaml
  - ../peripherals/i2c/i2c_v1.yaml

--- a/devices/stm32f429.yaml
+++ b/devices/stm32f429.yaml
@@ -154,6 +154,7 @@ _include:
  - ../peripherals/eth/eth_mmc.yaml
  - ../peripherals/eth/eth_dma.yaml
  - ../peripherals/usart/uart_common.yaml
+ - ../peripherals/usart/uart_sample.yaml
  - ../peripherals/usart/uart_uart.yaml
  - ../peripherals/usart/uart_usart.yaml
  - ../peripherals/i2c/i2c_v1.yaml

--- a/devices/stm32f446.yaml
+++ b/devices/stm32f446.yaml
@@ -98,6 +98,7 @@ _include:
  - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/tim/tim_gp1.yaml
  - ../peripherals/usart/uart_common.yaml
+ - ../peripherals/usart/uart_sample.yaml
  - ../peripherals/usart/uart_uart.yaml
  - ../peripherals/usart/uart_usart.yaml
  - ../peripherals/i2c/i2c_v1.yaml

--- a/devices/stm32f469.yaml
+++ b/devices/stm32f469.yaml
@@ -109,6 +109,7 @@ _include:
  - ../peripherals/eth/eth_mmc.yaml
  - ../peripherals/eth/eth_dma.yaml
  - ../peripherals/usart/uart_common.yaml
+ - ../peripherals/usart/uart_sample.yaml
  - ../peripherals/usart/uart_uart.yaml
  - ../peripherals/usart/uart_usart.yaml
  - ../peripherals/i2c/i2c_v1.yaml

--- a/devices/stm32f7x2.yaml
+++ b/devices/stm32f7x2.yaml
@@ -1,5 +1,8 @@
 _svd: ../svd/stm32f7x2.svd
 
+_derive:
+  USART3: USART1
+
 _rebase:
   SPI1: SPI5
 
@@ -17,7 +20,6 @@ _include:
  - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
  - ./common_patches/merge_USART_CR2_ABRMODx_fields.yaml
  - ./common_patches/merge_USART_CR1_DEDTx_fields.yaml
- - ./common_patches/rename_USART_CR2_DATAINV_field.yaml
  - common_patches/merge_USART_BRR_fields.yaml
  - common_patches/can/can.yaml
  - common_patches/can/can_filter_bank.yaml

--- a/devices/stm32f7x3.yaml
+++ b/devices/stm32f7x3.yaml
@@ -1,5 +1,8 @@
 _svd: ../svd/stm32f7x3.svd
 
+_derive:
+  USART3: USART1
+
 _rebase:
   SPI1: SPI5
 
@@ -27,7 +30,6 @@ _include:
  - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
  - ./common_patches/merge_USART_CR2_ABRMODx_fields.yaml
  - ./common_patches/merge_USART_CR1_DEDTx_fields.yaml
- - ./common_patches/rename_USART_CR2_DATAINV_field.yaml
  - common_patches/merge_USART_BRR_fields.yaml
  - common_patches/can/can.yaml
  - common_patches/can/can_filter_bank.yaml

--- a/peripherals/usart/_v2_ABC_common.yaml
+++ b/peripherals/usart/_v2_ABC_common.yaml
@@ -60,10 +60,10 @@ CR2:
     Standard: [0, "TX/RX pins are used as defined in standard pinout"]
     Swapped: [1, "The TX and RX pins functions are swapped"]
   STOP:
-    Bit1: [0, "1 stop bit"]
-    Bit0_5: [1, "0.5 stop bit"]
-    Bit2: [2, "2 stop bit"]
-    Bit1_5: [3, "1.5 stop bit"]
+    Stop1: [0, "1 stop bit"]
+    Stop0p5: [1, "0.5 stop bit"]
+    Stop2: [2, "2 stop bit"]
+    Stop1p5: [3, "1.5 stop bit"]
   CLKEN:
     Disabled: [0, "CK pin disabled"]
     Enabled: [1, "CK pin enabled"]

--- a/peripherals/usart/uart_common.yaml
+++ b/peripherals/usart/uart_common.yaml
@@ -8,9 +8,6 @@
     DIV_Fraction: [0, 0xF]
 
   CR1:
-    OVER8:
-      Oversample16: [0, "Oversampling by 16"]
-      Oversample8: [1, "Oversampling by 8"]
     UE:
       Disabled: [0, "USART prescaler and outputs disabled"]
       Enabled: [1, "USART enabled"]
@@ -67,9 +64,6 @@
     ADD: [0, 0xF]
 
   CR3:
-    ONEBIT:
-      Sample3: [0, "Three sample bit method"]
-      Sample1: [1, "One sample bit method"]
     DMAT:
       Disabled: [0, "DMA mode is disabled for transmission"]
       Enabled: [1, "DMA mode is enabled for transmission"]

--- a/peripherals/usart/uart_sample.yaml
+++ b/peripherals/usart/uart_sample.yaml
@@ -1,0 +1,9 @@
+"UART*,USART*":
+  CR1:
+    OVER8:
+      Oversample16: [0, "Oversampling by 16"]
+      Oversample8: [1, "Oversampling by 8"]
+  CR3:
+    ONEBIT:
+      Sample3: [0, "Three sample bit method"]
+      Sample1: [1, "One sample bit method"]

--- a/scripts/svdpatch.py
+++ b/scripts/svdpatch.py
@@ -222,11 +222,15 @@ def process_device_add(device, pname, padd):
         if ptag.find('name').text == pname:
             raise SvdPatchError('device already has a peripheral {}'
                                 .format(pname))
-    pnew = ET.SubElement(parent, 'peripheral')
+    if "derivedFrom" in padd:
+        derived = padd["derivedFrom"]
+        pnew = ET.SubElement(parent, 'peripheral', {"derivedFrom": derived})
+    else:
+        pnew = ET.SubElement(parent, 'peripheral')
     ET.SubElement(pnew, 'name').text = pname
-    ET.SubElement(pnew, 'registers')
     for (key, value) in padd.items():
         if key == "registers":
+            ET.SubElement(pnew, 'registers')
             for rname in value:
                 process_peripheral_add_reg(pnew, rname, value[rname])
         elif key == "interrupts":
@@ -236,7 +240,7 @@ def process_device_add(device, pname, padd):
             ab = ET.SubElement(pnew, 'addressBlock')
             for (ab_key, ab_value) in value.items():
                 ET.SubElement(ab, ab_key).text = str(ab_value)
-        else:
+        elif key != "derivedFrom":
             ET.SubElement(pnew, key).text = str(value)
     pnew.tail = "\n    "
 


### PR DESCRIPTION
This also add support for a new `_derive` instruction to mark an existing peripheral as derivedFrom another one, and allows to set a derivedFrom for peripheral `_add`.