### PR TITLE
Flash peripheral support for stm32f0xx

### DIFF
--- a/devices/common_patches/f0_ram_parity_check.yaml
+++ b/devices/common_patches/f0_ram_parity_check.yaml
@@ -1,0 +1,5 @@
+"Flash":
+  OBR:
+    _modify:
+      RAM_PARITY_CHECK_:
+        name: "RAM_PARITY_CHECK"

--- a/devices/stm32f0x0.yaml
+++ b/devices/stm32f0x0.yaml
@@ -57,3 +57,4 @@ _include:
  - ../peripherals/syscfg/syscfg_f0.yaml
  - ../peripherals/adc/adc_aditf4_v1_1.yaml
  - ../peripherals/spi/spi_v2_without_UDR_CHSIDE.yaml
+ - ../peripherals/flash/flash_f0.yaml

--- a/devices/stm32f0x0.yaml
+++ b/devices/stm32f0x0.yaml
@@ -57,4 +57,5 @@ _include:
  - ../peripherals/syscfg/syscfg_f0.yaml
  - ../peripherals/adc/adc_aditf4_v1_1.yaml
  - ../peripherals/spi/spi_v2_without_UDR_CHSIDE.yaml
+ - common_patches/f0_ram_parity_check.yaml
  - ../peripherals/flash/flash_f0.yaml

--- a/devices/stm32f0x1.yaml
+++ b/devices/stm32f0x1.yaml
@@ -53,4 +53,5 @@ _include:
  - ../peripherals/comp/comp_f0.yaml
  - ../peripherals/adc/adc_aditf4_v1_1_RM0091.yaml
  - ../peripherals/spi/spi_v2.yaml
- - ../peripherals/flash/flash_f0.yaml
+ - common_patches/f0_ram_parity_check.yaml
+ - ../peripherals/flash/flash_f04x_f09x.yaml

--- a/devices/stm32f0x1.yaml
+++ b/devices/stm32f0x1.yaml
@@ -53,3 +53,4 @@ _include:
  - ../peripherals/comp/comp_f0.yaml
  - ../peripherals/adc/adc_aditf4_v1_1_RM0091.yaml
  - ../peripherals/spi/spi_v2.yaml
+ - ../peripherals/flash/flash_f0.yaml

--- a/devices/stm32f0x2.yaml
+++ b/devices/stm32f0x2.yaml
@@ -59,4 +59,5 @@ _include:
  - ../peripherals/comp/comp_f0.yaml
  - ../peripherals/adc/adc_aditf4_v1_1_RM0091.yaml
  - ../peripherals/spi/spi_v2.yaml
- - ../peripherals/flash/flash_f0.yaml
+ - common_patches/f0_ram_parity_check.yaml
+ - ../peripherals/flash/flash_f04x_f09x.yaml

--- a/devices/stm32f0x2.yaml
+++ b/devices/stm32f0x2.yaml
@@ -59,3 +59,4 @@ _include:
  - ../peripherals/comp/comp_f0.yaml
  - ../peripherals/adc/adc_aditf4_v1_1_RM0091.yaml
  - ../peripherals/spi/spi_v2.yaml
+ - ../peripherals/flash/flash_f0.yaml

--- a/devices/stm32f0x8.yaml
+++ b/devices/stm32f0x8.yaml
@@ -46,4 +46,5 @@ _include:
  - ../peripherals/comp/comp_f0.yaml
  - ../peripherals/adc/adc_aditf4_v1_1_RM0091.yaml
  - ../peripherals/spi/spi_v2.yaml
- - ../peripherals/flash/flash_f0.yaml
+ - common_patches/f0_ram_parity_check.yaml
+ - ../peripherals/flash/flash_f04x_f09x.yaml

--- a/devices/stm32f0x8.yaml
+++ b/devices/stm32f0x8.yaml
@@ -46,3 +46,4 @@ _include:
  - ../peripherals/comp/comp_f0.yaml
  - ../peripherals/adc/adc_aditf4_v1_1_RM0091.yaml
  - ../peripherals/spi/spi_v2.yaml
+ - ../peripherals/flash/flash_f0.yaml

--- a/peripherals/flash/flash_f0.yaml
+++ b/peripherals/flash/flash_f0.yaml
@@ -1,3 +1,7 @@
+# Flash peripheral
+# Applicable to STM32F0
+# OBR->BOOT_SEL and OBR->nBOOT0 available only on STM32F04x and STM32F09x
+
 "Flash":
   ACR:
     PRFTBS:
@@ -63,6 +67,34 @@
 
   AR:
     FAR: [0, 0xFFFFFFFF]
+
+  OBR:
+    Data1: [0, 0xFFFF]
+    Data0: [0, 0xFFFF]
+    RAM_PARITY_CHECK:
+      Disabled: [1, "RAM parity check disabled"]
+      Enabled: [0, "RAM parity check enabled"]
+    VDDA_MONITOR:
+      Disabled: [0, "VDDA power supply supervisor disabled"]
+      Enabled: [1, "VDDA power supply supervisor enabled"]
+    nBOOT1:
+      Disabled: [0, "Together with BOOT0, select the device boot mode"]
+      Enabled: [1, "Together with BOOT0, select the device boot mode"]
+    nRST_STDBY:
+      Reset: [0, "Reset generated when entering Standby mode"]
+      NoReset: [1, "No reset generated"]
+    nRST_STOP:
+      Reset: [0, "Reset generated when entering Stop mode"]
+      NoReset: [1, "No reset generated"]
+    WDG_SW:
+      Hardware: [0, "Hardware watchdog"]
+      Software: [1, "Software watchdog"]
+    RDPRT:
+      Level0: [0, "Level 0"]
+      Level1: [1, "Level 1"]
+      Level2: [3, "Level 2"]
+    OPTERR:
+      OptionByteError: [1, "The loaded option byte and its complement do not match"]
 
   WRPR:
     WRP: [0, 0xFFFFFFFF]

--- a/peripherals/flash/flash_f0.yaml
+++ b/peripherals/flash/flash_f0.yaml
@@ -1,0 +1,68 @@
+"Flash":
+  ACR:
+    PRFTBS:
+      _read:
+        Disabled: [0, "Prefetch buffer is disabled"]
+        Enabled: [1, "Prefetch buffer is enabled"]
+    PRFTBE:
+      Disabled: [0, "Prefetch is disabled"]
+      Enabled: [1, "Prefetch is enabled"]
+    LATENCY:
+      WS0: [0, "0 wait states"]
+      WS1: [1, "1 wait state"]
+
+  KEYR:
+    FKEYR: [0, 0xFFFFFFFF]
+
+  OPTKEYR:
+    OPTKEYR: [0, 0xFFFFFFFF]
+
+  SR:
+    EOP:
+      NoEvent: [0, "No EOP operation occurred"]
+      Event: [1, "An EOP event occurred"]
+    WRPRT:
+      NoError: [0, "No write protection error occurred"]
+      Error: [1, "A write protection error occurred"]
+    PGERR:
+      NoError: [0, "No programming error occurred"]
+      Error: [1, "A programming error occurred"]
+    BSY:
+      _read:
+        Inactive: [0, "No write/erase operation is in progress"]
+        Active: [1, "No write/erase operation is in progress"]
+
+  CR:
+    FORCE_OPTLOAD:
+      Inactive: [0, "Force option byte loading inactive"]
+      Active: [1, "Force option byte loading active"]
+    EOPIE:
+      Disabled: [0, "End of operation interrupt disabled"]
+      Enabled: [1, "End of operation interrupt enabled"]
+    ERRIE:
+      Disabled: [0, "Error interrupt generation disabled"]
+      Enabled: [1, "Error interrupt generation enabled"]
+    OPTWRE:
+      Disabled: [0, "Option byte write enabled"]
+      Enabled: [1, "Option byte write disabled"]
+    LOCK:
+      Unlocked: [0, "FLASH_CR register is unlocked"]
+      Locked: [1, "FLASH_CR register is locked"]
+    STRT:
+      Start: [1, "Trigger an erase operation"]
+    OPTER:
+      OptionByteErase: [1, "Erase option byte activated"]
+    OPTPG:
+      OptionByteProgramming: [1, "Program option byte activated"]
+    MER:
+      MassErase: [1, "Erase activated for all user sectors"]
+    PER:
+      PageErase: [1, "Erase activated for selected page"]
+    PG:
+      Program: [1, "Flash programming activated"]
+
+  AR:
+    FAR: [0, 0xFFFFFFFF]
+
+  WRPR:
+    WRP: [0, 0xFFFFFFFF]

--- a/peripherals/flash/flash_f0.yaml
+++ b/peripherals/flash/flash_f0.yaml
@@ -69,8 +69,8 @@
     FAR: [0, 0xFFFFFFFF]
 
   OBR:
-    Data1: [0, 0xFFFF]
-    Data0: [0, 0xFFFF]
+    Data1: [0, 0xFF]
+    Data0: [0, 0xFF]
     RAM_PARITY_CHECK:
       Disabled: [1, "RAM parity check disabled"]
       Enabled: [0, "RAM parity check enabled"]

--- a/peripherals/flash/flash_f04x_f09x.yaml
+++ b/peripherals/flash/flash_f04x_f09x.yaml
@@ -1,0 +1,11 @@
+_include:
+  - ./flash_f0.yaml
+
+"Flash":
+  OBR:
+    BOOT_SEL:
+      nBOOT0: [0, "BOOT0 signal is defined by nBOOT0 option bit"]
+      BOOT0: [1, "BOOT0 signal is defined by BOOT0 pin value (legacy mode)"]
+    nBOOT0:
+      Disabled: [0, "When BOOT_SEL is cleared, select the device boot mode"]
+      Enabled: [1, "When BOOT_SEL is cleared, select the device boot mode"]


### PR DESCRIPTION
This adds full coverage of the Flash peripheral for all stm32f0 devices. Wasn't too sure what to document for `nBOOT0` and `nBOOT1`; they could probably be improved. Functionally I'm fairly confident it's all good to go, however.

Let me know if anything needs fixing.