### PR TITLE
F3 syscfg / comp / opamp

### DIFF
--- a/devices/common_patches/f0_comp_common.yaml
+++ b/devices/common_patches/f0_comp_common.yaml
@@ -1,0 +1,98 @@
+_add:
+  COMP:
+    description: "General purpose comparators"
+    baseAddress: 0x40010000
+    addressBlock:
+      offset: 0
+    registers:
+      CSR:
+        description: control and status register
+        addressOffset: 0x1C
+        size: 0x20
+        resetValue: 0x00000000
+        fields:
+          COMP1EN:
+            description: Comparator 1 enable
+            bitOffset: 0
+            bitWidth: 1
+            access: read-write
+          COMP1MODE:
+            description: Comparator 1 mode
+            bitOffset: 2
+            bitWidth: 2
+            access: read-write
+          COMP1INSEL:
+            description: Comparator 1 inverting input selection
+            bitOffset: 4
+            bitWidth: 3
+            access: read-write
+          COMP1OUTSEL:
+            description: Comparator 1 output selection
+            bitOffset: 8
+            bitWidth: 3
+            access: read-write
+          COMP1POL:
+            description: Comparator 1 output polarity
+            bitOffset: 11
+            bitWidth: 1
+            access: read-write
+          COMP1HYST:
+            description: Comparator 1 hysteresis
+            bitOffset: 12
+            bitWidth: 2
+            access: read-write
+          COMP1OUT:
+            description: Comparator 1 output
+            bitOffset: 14
+            bitWidth: 1
+            access: read-only
+          COMP1LOCK:
+            description: Comparator 1 lock
+            bitOffset: 15
+            bitWidth: 1
+            access: read-write
+          COMP2EN:
+            description: Comparator 2 enable
+            bitOffset: 16
+            bitWidth: 1
+            access: read-write
+          COMP2MODE:
+            description: Comparator 2 mode
+            bitOffset: 18
+            bitWidth: 2
+            access: read-write
+          COMP2INSEL:
+            description: Comparator 2 inverting input selection
+            bitOffset: 20
+            bitWidth: 3
+            access: read-write
+          WNDWEN:
+            description: Window mode enable
+            bitOffset: 23
+            bitWidth: 1
+            access: read-write
+          COMP2OUTSEL:
+            description: Comparator 2 output selection
+            bitOffset: 24
+            bitWidth: 3
+            access: read-write
+          COMP2POL:
+            description: Comparator 2 output polarity
+            bitOffset: 27
+            bitWidth: 1
+            access: read-write
+          COMP2HYST:
+            description: Comparator 2 hysteresis
+            bitOffset: 28
+            bitWidth: 2
+            access: read-write
+          COMP2OUT:
+            description: Comparator 2 output
+            bitOffset: 30
+            bitWidth: 1
+            access: read-only
+          COMP2LOCK:
+            description: Comparator 2 lock
+            bitOffset: 31
+            bitWidth: 1
+            access: read-write

--- a/devices/common_patches/f0_syscfg_comp.yaml
+++ b/devices/common_patches/f0_syscfg_comp.yaml
@@ -44,107 +44,13 @@ SYSCFG:
 
 _include:
  - ./f0_syscfg_common.yaml
+ - ./f0_comp_common.yaml
 
-_add:
-  COMP:
-    description: "General purpose comparators"
-    baseAddress: 0x40010000
-    addressBlock:
-      offset: 0
-    registers:
-      CSR:
-        description: control and status register
-        addressOffset: 0x1C
-        size: 0x20
-        resetValue: 0x00000000
-        fields:
-          COMP1EN:
-            description: Comparator 1 enable
-            bitOffset: 0
-            bitWidth: 1
-            access: read-write
-          COMP1SW1:
-            description: Comparator 1 non inverting input DAC switch
-            bitOffset: 1
-            bitWidth: 1
-            access: read-write
-          COMP1MODE:
-            description: Comparator 1 mode
-            bitOffset: 2
-            bitWidth: 2
-            access: read-write
-          COMP1INSEL:
-            description: Comparator 1 inverting input selection
-            bitOffset: 4
-            bitWidth: 3
-            access: read-write
-          COMP1OUTSEL:
-            description: Comparator 1 output selection
-            bitOffset: 8
-            bitWidth: 3
-            access: read-write
-          COMP1POL:
-            description: Comparator 1 output polarity
-            bitOffset: 11
-            bitWidth: 1
-            access: read-write
-          COMP1HYST:
-            description: Comparator 1 hysteresis
-            bitOffset: 12
-            bitWidth: 2
-            access: read-write
-          COMP1OUT:
-            description: Comparator 1 output
-            bitOffset: 14
-            bitWidth: 1
-            access: read-only
-          COMP1LOCK:
-            description: Comparator 1 lock
-            bitOffset: 15
-            bitWidth: 1
-            access: read-write
-          COMP2EN:
-            description: Comparator 2 enable
-            bitOffset: 16
-            bitWidth: 1
-            access: read-write
-          COMP2MODE:
-            description: Comparator 2 mode
-            bitOffset: 18
-            bitWidth: 2
-            access: read-write
-          COMP2INSEL:
-            description: Comparator 2 inverting input selection
-            bitOffset: 20
-            bitWidth: 3
-            access: read-write
-          WNDWEN:
-            description: Window mode enable
-            bitOffset: 23
-            bitWidth: 1
-            access: read-write
-          COMP2OUTSEL:
-            description: Comparator 2 output selection
-            bitOffset: 24
-            bitWidth: 3
-            access: read-write
-          COMP2POL:
-            description: Comparator 2 output polarity
-            bitOffset: 27
-            bitWidth: 1
-            access: read-write
-          COMP2HYST:
-            description: Comparator 2 hysteresis
-            bitOffset: 28
-            bitWidth: 2
-            access: read-write
-          COMP2OUT:
-            description: Comparator 2 output
-            bitOffset: 30
-            bitWidth: 1
-            access: read-only
-          COMP2LOCK:
-            description: Comparator 2 lock
-            bitOffset: 31
-            bitWidth: 1
-            access: read-write
+COMP:
+  CSR:
+    _add:
+      COMP1SW1:
+        description: Comparator 1 non inverting input DAC switch
+        bitOffset: 1
+        bitWidth: 1
+        access: read-write

--- a/devices/common_patches/f3_comp1234567.yaml
+++ b/devices/common_patches/f3_comp1234567.yaml
@@ -1,0 +1,188 @@
+_include:
+ - f3_comp1246.yaml
+ - f3_comp246_inmsel3.yaml
+
+COMP:
+  _add:
+    COMP3_CSR:
+      description: control and status register
+      addressOffset: 0x24
+      size: 0x20
+      resetValue: 0x00000000
+      fields:
+        COMP3EN:
+          description: Comparator 3 enable
+          bitOffset: 0
+          bitWidth: 1
+          access: read-write
+        COMP3MODE:
+          description: Comparator 3 mode
+          bitOffset: 2
+          bitWidth: 2
+          access: read-write
+        COMP3INMSEL:
+          description: Comparator 3 inverting input selection
+          bitOffset: 4
+          bitWidth: 3
+          access: read-write
+        COMP3INPSEL:
+          description: Comparator 3 non inverted input
+          bitOffset: 7
+          bitWidth: 1
+          access: read-write
+        COMP3OUTSEL:
+          description: Comparator 3 output selection
+          bitOffset: 10
+          bitWidth: 4
+          access: read-write
+        COMP3POL:
+          description: Comparator 3 output polarity
+          bitOffset: 15
+          bitWidth: 1
+          access: read-write
+        COMP3HYST:
+          description: Comparator 3 hysteresis
+          bitOffset: 16
+          bitWidth: 2
+          access: read-write
+        COMP3_BLANKING:
+          description: Comparator 3 blanking source
+          bitOffset: 18
+          bitWidth: 3
+          access: read-write
+        COMP3OUT:
+          description: Comparator 3 output
+          bitOffset: 30
+          bitWidth: 1
+          access: read-only
+        COMP3LOCK:
+          description: Comparator 3 lock
+          bitOffset: 31
+          bitWidth: 1
+          access: read-write
+    COMP5_CSR:
+      description: control and status register
+      addressOffset: 0x2C
+      size: 0x20
+      resetValue: 0x00000000
+      fields:
+        COMP5EN:
+          description: Comparator 5 enable
+          bitOffset: 0
+          bitWidth: 1
+          access: read-write
+        COMP5MODE:
+          description: Comparator 5 mode
+          bitOffset: 2
+          bitWidth: 2
+          access: read-write
+        COMP5INMSEL:
+          description: Comparator 5 inverting input selection
+          bitOffset: 4
+          bitWidth: 3
+          access: read-write
+        COMP5INPSEL:
+          description: Comparator 5 non inverted input
+          bitOffset: 7
+          bitWidth: 1
+          access: read-write
+        COMP5OUTSEL:
+          description: Comparator 5 output selection
+          bitOffset: 10
+          bitWidth: 4
+          access: read-write
+        COMP5POL:
+          description: Comparator 5 output polarity
+          bitOffset: 15
+          bitWidth: 1
+          access: read-write
+        COMP5HYST:
+          description: Comparator 5 hysteresis
+          bitOffset: 16
+          bitWidth: 2
+          access: read-write
+        COMP5_BLANKING:
+          description: Comparator 5 blanking source
+          bitOffset: 18
+          bitWidth: 3
+          access: read-write
+        COMP5OUT:
+          description: Comparator 5 output
+          bitOffset: 30
+          bitWidth: 1
+          access: read-only
+        COMP5LOCK:
+          description: Comparator 5 lock
+          bitOffset: 31
+          bitWidth: 1
+          access: read-write
+    COMP7_CSR:
+      description: control and status register
+      addressOffset: 0x34
+      size: 0x20
+      resetValue: 0x00000000
+      fields:
+        COMP7EN:
+          description: Comparator 7 enable
+          bitOffset: 0
+          bitWidth: 1
+          access: read-write
+        COMP7MODE:
+          description: Comparator 7 mode
+          bitOffset: 2
+          bitWidth: 2
+          access: read-write
+        COMP7INMSEL:
+          description: Comparator 7 inverting input selection
+          bitOffset: 4
+          bitWidth: 3
+          access: read-write
+        COMP7INPSEL:
+          description: Comparator 7 non inverted input
+          bitOffset: 7
+          bitWidth: 1
+          access: read-write
+        COMP7OUTSEL:
+          description: Comparator 7 output selection
+          bitOffset: 10
+          bitWidth: 4
+          access: read-write
+        COMP7POL:
+          description: Comparator 7 output polarity
+          bitOffset: 15
+          bitWidth: 1
+          access: read-write
+        COMP7HYST:
+          description: Comparator 7 hysteresis
+          bitOffset: 16
+          bitWidth: 2
+          access: read-write
+        COMP7_BLANKING:
+          description: Comparator 7 blanking source
+          bitOffset: 18
+          bitWidth: 3
+          access: read-write
+        COMP7OUT:
+          description: Comparator 7 output
+          bitOffset: 30
+          bitWidth: 1
+          access: read-only
+        COMP7LOCK:
+          description: Comparator 7 lock
+          bitOffset: 31
+          bitWidth: 1
+          access: read-write
+  COMP4_CSR:
+    _add:
+      COMP4WINMODE:
+        description: Comparator 4 window mode
+        bitOffset: 9
+        bitWidth: 1
+        access: read-write
+  COMP6_CSR:
+    _add:
+      COMP6WINMODE:
+        description: Comparator 6 window mode
+        bitOffset: 9
+        bitWidth: 1
+        access: read-write

--- a/devices/common_patches/f3_comp1246.yaml
+++ b/devices/common_patches/f3_comp1246.yaml
@@ -1,0 +1,117 @@
+_include:
+ - f3_comp246.yaml
+
+COMP:
+  _add:
+    COMP1_CSR:
+      description: control and status register
+      addressOffset: 0x1C
+      size: 0x20
+      resetValue: 0x00000000
+      fields:
+        COMP1EN:
+          description: Comparator 1 enable
+          bitOffset: 0
+          bitWidth: 1
+          access: read-write
+        COMP1_INP_DAC:
+          description: Comparator 1 non inverting input connection to DAC output
+          bitOffset: 1
+          bitWidth: 1
+          access: read-write
+        COMP1MODE:
+          description: Comparator 1 mode
+          bitOffset: 2
+          bitWidth: 2
+          access: read-write
+        COMP1INMSEL:
+          description: Comparator 1 inverting input selection
+          bitOffset: 4
+          bitWidth: 3
+          access: read-write
+        COMP1OUTSEL:
+          description: Comparator 1 output selection
+          bitOffset: 10
+          bitWidth: 4
+          access: read-write
+        COMP1POL:
+          description: Comparator 1 output polarity
+          bitOffset: 15
+          bitWidth: 1
+          access: read-write
+        COMP1HYST:
+          description: Comparator 1 hysteresis
+          bitOffset: 16
+          bitWidth: 2
+          access: read-write
+        COMP1_BLANKING:
+          description: Comparator 1 blanking source
+          bitOffset: 18
+          bitWidth: 3
+          access: read-write
+        COMP1OUT:
+          description: Comparator 1 output
+          bitOffset: 30
+          bitWidth: 1
+          access: read-only
+        COMP1LOCK:
+          description: Comparator 1 lock
+          bitOffset: 31
+          bitWidth: 1
+          access: read-write
+  COMP2_CSR:
+    _add:
+      COMP2MODE:
+        description: Comparator 2 mode
+        bitOffset: 2
+        bitWidth: 2
+        access: read-write
+      COMP2INPSEL:
+        description: Comparator 2 non inverted input
+        bitOffset: 7
+        bitWidth: 1
+        access: read-write
+      COMP2WINMODE:
+        description: Comparator 2 window mode
+        bitOffset: 9
+        bitWidth: 1
+        access: read-write
+      COMP2HYST:
+        description: Comparator 2 hysteresis
+        bitOffset: 16
+        bitWidth: 2
+        access: read-write
+  COMP4_CSR:
+    _add:
+      COMP4MODE:
+        description: Comparator 4 mode
+        bitOffset: 2
+        bitWidth: 2
+        access: read-write
+      COMP4INPSEL:
+        description: Comparator 4 non inverted input
+        bitOffset: 7
+        bitWidth: 1
+        access: read-write
+      COMP4HYST:
+        description: Comparator 4 hysteresis
+        bitOffset: 16
+        bitWidth: 2
+        access: read-write
+  COMP6_CSR:
+    _add:
+      COMP6MODE:
+        description: Comparator 6 mode
+        bitOffset: 2
+        bitWidth: 2
+        access: read-write
+      COMP6INPSEL:
+        description: Comparator 6 non inverted input
+        bitOffset: 7
+        bitWidth: 1
+        access: read-write
+      COMP6HYST:
+        description: Comparator 6 hysteresis
+        bitOffset: 16
+        bitWidth: 2
+        access: read-write

--- a/devices/common_patches/f3_comp246.yaml
+++ b/devices/common_patches/f3_comp246.yaml
@@ -1,0 +1,130 @@
+_add:
+  COMP:
+    description: General purpose comparators
+    baseAddress: 0x40010000
+    addressBlock:
+      offset: 0
+    registers:
+      COMP2_CSR:
+        description: control and status register
+        addressOffset: 0x20
+        size: 0x20
+        resetValue: 0x00000000
+        fields:
+          COMP2EN:
+            description: Comparator 2 enable
+            bitOffset: 0
+            bitWidth: 1
+            access: read-write
+          COMP2INMSEL:
+            description: Comparator 2 inverting input selection
+            bitOffset: 4
+            bitWidth: 3
+            access: read-write
+          COMP2OUTSEL:
+            description: Comparator 2 output selection
+            bitOffset: 10
+            bitWidth: 4
+            access: read-write
+          COMP2POL:
+            description: Comparator 2 output polarity
+            bitOffset: 15
+            bitWidth: 1
+            access: read-write
+          COMP2_BLANKING:
+            description: Comparator 2 blanking source
+            bitOffset: 18
+            bitWidth: 3
+            access: read-write
+          COMP2OUT:
+            description: Comparator 2 output
+            bitOffset: 30
+            bitWidth: 1
+            access: read-only
+          COMP2LOCK:
+            description: Comparator 2 lock
+            bitOffset: 31
+            bitWidth: 1
+            access: read-write
+      COMP4_CSR:
+        description: control and status register
+        addressOffset: 0x28
+        size: 0x20
+        resetValue: 0x00000000
+        fields:
+          COMP4EN:
+            description: Comparator 4 enable
+            bitOffset: 0
+            bitWidth: 1
+            access: read-write
+          COMP4INMSEL:
+            description: Comparator 4 inverting input selection
+            bitOffset: 4
+            bitWidth: 3
+            access: read-write
+          COMP4OUTSEL:
+            description: Comparator 4 output selection
+            bitOffset: 10
+            bitWidth: 4
+            access: read-write
+          COMP4POL:
+            description: Comparator 4 output polarity
+            bitOffset: 15
+            bitWidth: 1
+            access: read-write
+          COMP4_BLANKING:
+            description: Comparator 4 blanking source
+            bitOffset: 18
+            bitWidth: 3
+            access: read-write
+          COMP4OUT:
+            description: Comparator 4 output
+            bitOffset: 30
+            bitWidth: 1
+            access: read-only
+          COMP4LOCK:
+            description: Comparator 4 lock
+            bitOffset: 31
+            bitWidth: 1
+            access: read-write
+      COMP6_CSR:
+        description: control and status register
+        addressOffset: 0x30
+        size: 0x20
+        resetValue: 0x00000000
+        fields:
+          COMP6EN:
+            description: Comparator 6 enable
+            bitOffset: 0
+            bitWidth: 1
+            access: read-write
+          COMP6INMSEL:
+            description: Comparator 6 inverting input selection
+            bitOffset: 4
+            bitWidth: 3
+            access: read-write
+          COMP6OUTSEL:
+            description: Comparator 6 output selection
+            bitOffset: 10
+            bitWidth: 4
+            access: read-write
+          COMP6POL:
+            description: Comparator 6 output polarity
+            bitOffset: 15
+            bitWidth: 1
+            access: read-write
+          COMP6_BLANKING:
+            description: Comparator 6 blanking source
+            bitOffset: 18
+            bitWidth: 3
+            access: read-write
+          COMP6OUT:
+            description: Comparator 6 output
+            bitOffset: 30
+            bitWidth: 1
+            access: read-only
+          COMP6LOCK:
+            description: Comparator 6 lock
+            bitOffset: 31
+            bitWidth: 1
+            access: read-write

--- a/devices/common_patches/f3_comp246_inmsel3.yaml
+++ b/devices/common_patches/f3_comp246_inmsel3.yaml
@@ -1,0 +1,22 @@
+COMP:
+  COMP2_CSR:
+    _add:
+      COMP2INMSEL3:
+        description: Comparator 2 inverting input selection
+        bitOffset: 22
+        bitWidth: 1
+        access: read-write
+  COMP4_CSR:
+    _add:
+      COMP4INMSEL3:
+        description: Comparator 4 inverting input selection
+        bitOffset: 22
+        bitWidth: 1
+        access: read-write
+  COMP6_CSR:
+    _add:
+      COMP6INMSEL3:
+        description: Comparator 6 inverting input selection
+        bitOffset: 22
+        bitWidth: 1
+        access: read-write

--- a/devices/common_patches/f3_comp2_inp_dac.yaml
+++ b/devices/common_patches/f3_comp2_inp_dac.yaml
@@ -1,0 +1,8 @@
+COMP:
+  COMP2_CSR:
+    _add:
+      COMP2_INP_DAC:
+        description: Comparator 2 non inverting input connection to DAC output
+        bitOffset: 1
+        bitWidth: 1
+        access: read-write

--- a/devices/common_patches/f3_opamp12.yaml
+++ b/devices/common_patches/f3_opamp12.yaml
@@ -1,0 +1,16 @@
+_include:
+ - f3_opamp2.yaml
+
+OPAMP:
+  _add:
+    OPAMP1_CSR:
+      description: OPAMP1 control register
+      addressOffset: 0x38
+      size: 0x20
+      resetValue: 0x00000000
+      fields:
+        OPAMP1EN:
+          description: OPAMP1 enable
+          bitOffset: 0
+          bitWidth: 1
+          access: read-write

--- a/devices/common_patches/f3_opamp1234.yaml
+++ b/devices/common_patches/f3_opamp1234.yaml
@@ -1,0 +1,27 @@
+_include:
+ - f3_opamp12.yaml
+
+OPAMP:
+  _add:
+    OPAMP3_CSR:
+      description: OPAMP3 control register
+      addressOffset: 0x40
+      size: 0x20
+      resetValue: 0x00000000
+      fields:
+        OPAMP3EN:
+          description: OPAMP3 enable
+          bitOffset: 0
+          bitWidth: 1
+          access: read-write
+    OPAMP4_CSR:
+      description: OPAMP4 control register
+      addressOffset: 0x44
+      size: 0x20
+      resetValue: 0x00000000
+      fields:
+        OPAMP4EN:
+          description: OPAMP4 enable
+          bitOffset: 0
+          bitWidth: 1
+          access: read-write

--- a/devices/common_patches/f3_opamp2.yaml
+++ b/devices/common_patches/f3_opamp2.yaml
@@ -1,0 +1,97 @@
+_add:
+  OPAMP:
+    description: Operational Amplifier
+    baseAddress: 0x40010000
+    addressBlock:
+        offset: 0
+    registers:
+      OPAMP2_CSR:
+        description: OPAMP2 control register
+        addressOffset: 0x3C
+        size: 0x20
+        resetValue: 0x00000000
+        fields:
+          OPAMP2EN:
+            description: OPAMP2 enable
+            bitOffset: 0
+            bitWidth: 1
+            access: read-write
+
+OPAMP:
+  "OPAMP*_CSR":
+    _add:
+      FORCE_VP:
+        description: FORCE_VP
+        bitOffset: 1
+        bitWidth: 1
+        access: read-write
+      VP_SEL:
+        description: OPAMP Non inverting input selection
+        bitOffset: 2
+        bitWidth: 2
+        access: read-write
+      VM_SEL:
+        description: OPAMP inverting input selection
+        bitOffset: 5
+        bitWidth: 2
+        access: read-write
+      TCM_EN:
+        description: Timer controlled Mux mode enable
+        bitOffset: 7
+        bitWidth: 1
+        access: read-write
+      VMS_SEL:
+        description: OPAMP inverting input secondary selection
+        bitOffset: 8
+        bitWidth: 1
+        access: read-write
+      VPS_SEL:
+        description: OPAMP Non inverting input secondary selection
+        bitOffset: 9
+        bitWidth: 2
+        access: read-write
+      CALON:
+        description: Calibration mode enable
+        bitOffset: 11
+        bitWidth: 1
+        access: read-write
+      CALSEL:
+        description: Calibration selection
+        bitOffset: 12
+        bitWidth: 2
+        access: read-write
+      PGA_GAIN:
+        description: Gain in PGA mode
+        bitOffset: 14
+        bitWidth: 4
+        access: read-write
+      USER_TRIM:
+        description: User trimming enable
+        bitOffset: 18
+        bitWidth: 1
+        access: read-write
+      TRIMOFFSETP:
+        description: Offset trimming value (PMOS)
+        bitOffset: 19
+        bitWidth: 5
+        access: read-write
+      TRIMOFFSETN:
+        description: Offset trimming value (NMOS)
+        bitOffset: 24
+        bitWidth: 5
+        access: read-write
+      TSTREF:
+        description: TSTREF
+        bitOffset: 29
+        bitWidth: 1
+        access: read-write
+      OUTCAL:
+        description: OPAMP ouput status flag
+        bitOffset: 30
+        bitWidth: 1
+        access: read-only
+      LOCK:
+        description: OPAMP lock
+        bitOffset: 31
+        bitWidth: 1
+        access: read-write

--- a/devices/common_patches/f3_syscfg.yaml
+++ b/devices/common_patches/f3_syscfg.yaml
@@ -1,0 +1,47 @@
+_modify:
+  SYSCFG_COMP_OPAMP:
+    name: SYSCFG
+    groupName: SYSCFG
+    description: System configuration controller
+
+SYSCFG:
+  _modify:
+    SYSCFG_CFGR1:
+      name: CFGR1
+      displayName: CFGR1
+    SYSCFG_CFGR2:
+      name: CFGR2
+      displayName: CFGR2
+    SYSCFG_EXTICR1:
+      name: EXTICR1
+      displayName: EXTICR1
+    SYSCFG_EXTICR2:
+      name: EXTICR2
+      displayName: EXTICR2
+    SYSCFG_EXTICR3:
+      name: EXTICR3
+      displayName: EXTICR3
+    SYSCFG_EXTICR4:
+      name: EXTICR4
+      displayName: EXTICR4
+  _delete:
+    - OPAMP*
+    - COMP*
+  CFGR1:
+    _modify:
+      TIM1_ITR_RMP:
+        name: TIM1_ITR3_RMP
+      I2C_PB6_FM:
+        name: I2C_PB6_FMP
+      I2C_PB7_FM:
+        name: I2C_PB7_FMP
+      I2C_PB8_FM:
+        name: I2C_PB8_FMP
+      I2C_PB9_FM:
+        name: I2C_PB9_FMP
+      I2C1_FM:
+        name: I2C1_FMP
+      I2C2_FM:
+        name: I2C2_FMP
+      FPU_IT:
+        name: FPU_IE

--- a/devices/common_patches/f3_syscfg_cfgr1_dac2_ch1_dma_rmp.yaml
+++ b/devices/common_patches/f3_syscfg_cfgr1_dac2_ch1_dma_rmp.yaml
@@ -1,0 +1,8 @@
+SYSCFG:
+  CFGR1:
+    _add:
+      DAC2_CH1_DMA_RMP:
+        description: DAC2 channel1 DMA remap
+        bitOffset: 15
+        bitWidth: 1
+        access: read-write

--- a/devices/common_patches/f3_syscfg_cfgr1_i2c3_fmp.yaml
+++ b/devices/common_patches/f3_syscfg_cfgr1_i2c3_fmp.yaml
@@ -1,0 +1,8 @@
+SYSCFG:
+  CFGR1:
+    _add:
+      I2C3_FMP:
+        description: I2C3 Fast Mode Plus
+        bitOffset: 24
+        bitWidth: 1
+        access: read-write

--- a/devices/common_patches/f3_syscfg_cfgr1_mem_mode_3.yaml
+++ b/devices/common_patches/f3_syscfg_cfgr1_mem_mode_3.yaml
@@ -1,0 +1,5 @@
+SYSCFG:
+  CFGR1:
+    _modify:
+      MEM_MODE:
+        bitWidth: 3

--- a/devices/common_patches/f3_syscfg_cfgr2.yaml
+++ b/devices/common_patches/f3_syscfg_cfgr2.yaml
@@ -1,0 +1,7 @@
+SYSCFG:
+  CFGR2:
+    _modify:
+      LOCUP_LOCK:
+        name: LOCKUP_LOCK
+      BYP_ADD_PAR:
+        name: BYP_ADDR_PAR

--- a/devices/common_patches/f3_syscfg_cfgr4.yaml
+++ b/devices/common_patches/f3_syscfg_cfgr4.yaml
@@ -1,0 +1,65 @@
+SYSCFG:
+  _add:
+    CFGR4:
+      description: configuration register 4
+      addressOffset: 0x48
+      size: 0x20
+      resetValue: 0x00000000
+      access: read-write
+      fields:
+        ADC12_EXT2_RMP:
+          description: Controls the Input trigger of ADC12 regular channel EXT2
+          bitOffset: 0
+          bitWidth: 1
+        ADC12_EXT3_RMP:
+          description: Controls the Input trigger of ADC12 regular channel EXT3
+          bitOffset: 1
+          bitWidth: 1
+        ADC12_EXT5_RMP:
+          description: Controls the Input trigger of ADC12 regular channel EXT5
+          bitOffset: 2
+          bitWidth: 1
+        ADC12_EXT13_RMP:
+          description: Controls the Input trigger of ADC12 regular channel EXT13
+          bitOffset: 3
+          bitWidth: 1
+        ADC12_EXT15_RMP:
+          description: Controls the Input trigger of ADC12 regular channel EXT15
+          bitOffset: 4
+          bitWidth: 1
+        ADC12_JEXT3_RMP:
+          description: Controls the Input trigger of ADC12 injected channel JEXT3
+          bitOffset: 5
+          bitWidth: 1
+        ADC12_JEXT6_RMP:
+          description: Controls the Input trigger of ADC12 injected channel JEXT6
+          bitOffset: 6
+          bitWidth: 1
+        ADC12_JEXT13_RMP:
+          description: Controls the Input trigger of ADC12 injected channel JEXT13
+          bitOffset: 7
+          bitWidth: 1
+        ADC34_EXT5_RMP:
+          description: Controls the Input trigger of ADC34 regular channel EXT5
+          bitOffset: 8
+          bitWidth: 1
+        ADC34_EXT6_RMP:
+          description: Controls the Input trigger of ADC34 regular channel EXT6
+          bitOffset: 9
+          bitWidth: 1
+        ADC34_EXT15_RMP:
+          description: Controls the Input trigger of ADC34 regular channel EXT15
+          bitOffset: 10
+          bitWidth: 1
+        ADC34_JEXT5_RMP:
+          description: Controls the Input trigger of ADC34 injected channel JEXT5
+          bitOffset: 11
+          bitWidth: 1
+        ADC34_JEXT11_RMP:
+          description: Controls the Input trigger of ADC34 injected channel JEXT11
+          bitOffset: 12
+          bitWidth: 1
+        ADC34_JEXT14_RMP:
+          description: Controls the Input trigger of ADC34 injected channel JEXT14
+          bitOffset: 13
+          bitWidth: 1

--- a/devices/common_patches/f3_syscfg_rcr_page8-15.yaml
+++ b/devices/common_patches/f3_syscfg_rcr_page8-15.yaml
@@ -1,0 +1,35 @@
+SYSCFG:
+  RCR:
+    _add:
+      PAGE8_WP:
+        description: CCM SRAM page write protection bit
+        bitOffset: 8
+        bitWidth: 1
+      PAGE9_WP:
+        description: CCM SRAM page write protection bit
+        bitOffset: 9
+        bitWidth: 1
+      PAGE10_WP:
+        description: CCM SRAM page write protection bit
+        bitOffset: 10
+        bitWidth: 1
+      PAGE11_WP:
+        description: CCM SRAM page write protection bit
+        bitOffset: 11
+        bitWidth: 1
+      PAGE12_WP:
+        description: CCM SRAM page write protection bit
+        bitOffset: 12
+        bitWidth: 1
+      PAGE13_WP:
+        description: CCM SRAM page write protection bit
+        bitOffset: 13
+        bitWidth: 1
+      PAGE14_WP:
+        description: CCM SRAM page write protection bit
+        bitOffset: 14
+        bitWidth: 1
+      PAGE15_WP:
+        description: CCM SRAM page write protection bit
+        bitOffset: 15
+        bitWidth: 1

--- a/devices/stm32f301.yaml
+++ b/devices/stm32f301.yaml
@@ -46,6 +46,8 @@ _include:
  - ./common_patches/f3_syscfg.yaml
  - ./common_patches/f3_syscfg_cfgr1_i2c3_fmp.yaml
  - ./common_patches/f3_opamp2.yaml
+ - ./common_patches/f3_comp246.yaml
+ - ./common_patches/f3_comp2_inp_dac.yaml
  - common_patches/can/can.yaml
  - common_patches/can/can_filter_bank.yaml
  - ../peripherals/crc/crc_basic.yaml

--- a/devices/stm32f301.yaml
+++ b/devices/stm32f301.yaml
@@ -45,6 +45,7 @@ _include:
  - ./common_patches/merge_USART_BRR_fields.yaml
  - ./common_patches/f3_syscfg.yaml
  - ./common_patches/f3_syscfg_cfgr1_i2c3_fmp.yaml
+ - ./common_patches/f3_opamp2.yaml
  - common_patches/can/can.yaml
  - common_patches/can/can_filter_bank.yaml
  - ../peripherals/crc/crc_basic.yaml

--- a/devices/stm32f301.yaml
+++ b/devices/stm32f301.yaml
@@ -20,12 +20,31 @@ _svd: ../svd/stm32f301.svd
       TIFRFE:
         name: "FRE"
 
+SYSCFG:
+  _delete:
+    - SYSCFG_RCR
+    - SYSCFG_CFGR3
+  CFGR1:
+    _delete:
+      - USB_IT_RMP
+      - DAC_TRIG_RMP
+      - ADC24_DMA_RMP
+      - TIM7_DAC2_DMA_RMP
+  CFGR2:
+    _delete:
+      - LOCUP_LOCK
+      - SRAM_PARITY_LOCK
+      - BYP_ADD_PAR
+      - SRAM_PEF
+
 _include:
  - common_patches/4_nvic_prio_bits.yaml
  - ./common_patches/merge_I2C_CR2_SADDx_fields.yaml
  - ./common_patches/merge_I2C_OAR1_OA1x_fields.yaml
  - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
  - ./common_patches/merge_USART_BRR_fields.yaml
+ - ./common_patches/f3_syscfg.yaml
+ - ./common_patches/f3_syscfg_cfgr1_i2c3_fmp.yaml
  - common_patches/can/can.yaml
  - common_patches/can/can_filter_bank.yaml
  - ../peripherals/crc/crc_basic.yaml

--- a/devices/stm32f302.yaml
+++ b/devices/stm32f302.yaml
@@ -7,12 +7,24 @@ _svd: ../svd/stm32f302.svd
       TIFRFE:
         name: "FRE"
 
+SYSCFG:
+  _delete:
+    - SYSCFG_RCR
+    - SYSCFG_CFGR3
+  CFGR1:
+    _delete:
+      - TIM7_DAC2_DMA_RMP
+
 _include:
  - common_patches/4_nvic_prio_bits.yaml
  - ./common_patches/merge_I2C_CR2_SADDx_fields.yaml
  - ./common_patches/merge_I2C_OAR1_OA1x_fields.yaml
  - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
  - ./common_patches/merge_USART_BRR_fields.yaml
+ - ./common_patches/f3_syscfg.yaml
+ - ./common_patches/f3_syscfg_cfgr1_mem_mode_3.yaml
+ - ./common_patches/f3_syscfg_cfgr1_i2c3_fmp.yaml
+ - ./common_patches/f3_syscfg_cfgr2.yaml
  - common_patches/can/can.yaml
  - common_patches/can/can_filter_bank.yaml
  - ../peripherals/dac/dac_wavegen.yaml

--- a/devices/stm32f302.yaml
+++ b/devices/stm32f302.yaml
@@ -25,6 +25,7 @@ _include:
  - ./common_patches/f3_syscfg_cfgr1_mem_mode_3.yaml
  - ./common_patches/f3_syscfg_cfgr1_i2c3_fmp.yaml
  - ./common_patches/f3_syscfg_cfgr2.yaml
+ - ./common_patches/f3_opamp12.yaml
  - common_patches/can/can.yaml
  - common_patches/can/can_filter_bank.yaml
  - ../peripherals/dac/dac_wavegen.yaml

--- a/devices/stm32f302.yaml
+++ b/devices/stm32f302.yaml
@@ -26,6 +26,8 @@ _include:
  - ./common_patches/f3_syscfg_cfgr1_i2c3_fmp.yaml
  - ./common_patches/f3_syscfg_cfgr2.yaml
  - ./common_patches/f3_opamp12.yaml
+ - ./common_patches/f3_comp1246.yaml
+ - ./common_patches/f3_comp2_inp_dac.yaml
  - common_patches/can/can.yaml
  - common_patches/can/can_filter_bank.yaml
  - ../peripherals/dac/dac_wavegen.yaml

--- a/devices/stm32f303.yaml
+++ b/devices/stm32f303.yaml
@@ -54,6 +54,7 @@ _include:
  - ./common_patches/f3_syscfg_cfgr2.yaml
  - ./common_patches/f3_syscfg_cfgr4.yaml
  - ./common_patches/f3_syscfg_rcr_page8-15.yaml
+ - ./common_patches/f3_opamp1234.yaml
  - common_patches/can/can.yaml
  - common_patches/can/can_filter_bank.yaml
  - ../peripherals/dac/dac_wavegen.yaml

--- a/devices/stm32f303.yaml
+++ b/devices/stm32f303.yaml
@@ -7,12 +7,53 @@ _svd: ../svd/stm32f303.svd
       TIFRFE:
         name: "FRE"
 
+SYSCFG:
+  _modify:
+    SYSCFG_RCR:
+      name: RCR
+      displayName: RCR
+  _add:
+    CFGR3:
+      description: configuration register 3
+      addressOffset: 0x50
+      size: 0x20
+      resetValue: 0x00000200
+      access: read-write
+      fields:
+        SPI1_RX_DMA_RMP:
+          description: SPI1_RX DMA remapping bit
+          bitOffset: 0
+          bitWidth: 2
+        SPI1_TX_DMA_RMP:
+          description: SPI1_TX DMA remapping bit
+          bitOffset: 2
+          bitWidth: 2
+        I2C1_RX_DMA_RMP:
+          description: I2C1_RX DMA remapping bit
+          bitOffset: 4
+          bitWidth: 2
+        I2C1_TX_DMA_RMP:
+          description: I2C1_TX DMA remapping bit
+          bitOffset: 6
+          bitWidth: 2
+        ADC2_DMA_RMP:
+          description: ADC2 DMA remapping bit
+          bitOffset: 8
+          bitWidth: 2
+
 _include:
  - common_patches/4_nvic_prio_bits.yaml
  - ./common_patches/merge_I2C_CR2_SADDx_fields.yaml
  - ./common_patches/merge_I2C_OAR1_OA1x_fields.yaml
  - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
  - ./common_patches/merge_USART_BRR_fields.yaml
+ - ./common_patches/f3_syscfg.yaml
+ - ./common_patches/f3_syscfg_cfgr1_mem_mode_3.yaml
+ - ./common_patches/f3_syscfg_cfgr1_dac2_ch1_dma_rmp.yaml
+ - ./common_patches/f3_syscfg_cfgr1_i2c3_fmp.yaml
+ - ./common_patches/f3_syscfg_cfgr2.yaml
+ - ./common_patches/f3_syscfg_cfgr4.yaml
+ - ./common_patches/f3_syscfg_rcr_page8-15.yaml
  - common_patches/can/can.yaml
  - common_patches/can/can_filter_bank.yaml
  - ../peripherals/dac/dac_wavegen.yaml

--- a/devices/stm32f303.yaml
+++ b/devices/stm32f303.yaml
@@ -55,6 +55,7 @@ _include:
  - ./common_patches/f3_syscfg_cfgr4.yaml
  - ./common_patches/f3_syscfg_rcr_page8-15.yaml
  - ./common_patches/f3_opamp1234.yaml
+ - ./common_patches/f3_comp1234567.yaml
  - common_patches/can/can.yaml
  - common_patches/can/can_filter_bank.yaml
  - ../peripherals/dac/dac_wavegen.yaml

--- a/devices/stm32f373.yaml
+++ b/devices/stm32f373.yaml
@@ -21,6 +21,15 @@ SYSCFG:
     _delete:
       - BYP_ADD_PAR
 
+COMP:
+  CSR:
+    _add:
+      COMP1_INP_DAC:
+        description: Comparator 1 non inverting input connection to DAC output
+        bitOffset: 1
+        bitWidth: 1
+        access: read-write
+
 _include:
  - common_patches/4_nvic_prio_bits.yaml
  - ./common_patches/merge_I2C_CR2_SADDx_fields.yaml
@@ -29,6 +38,7 @@ _include:
  - ./common_patches/merge_USART_BRR_fields.yaml
  - ./common_patches/f3_syscfg.yaml
  - ./common_patches/f3_syscfg_cfgr2.yaml
+ - ./common_patches/f0_comp_common.yaml
  - common_patches/can/can.yaml
  - common_patches/can/can_filter_bank.yaml
  - ../peripherals/crc/crc_basic.yaml

--- a/devices/stm32f373.yaml
+++ b/devices/stm32f373.yaml
@@ -1,11 +1,34 @@
 _svd: ../svd/stm32f373.svd
 
+SYSCFG:
+  _delete:
+    - SYSCFG_RCR
+    - SYSCFG_CFGR3
+  CFGR1:
+    _delete:
+      - USB_IT_RMP
+      - TIM1_ITR_RMP
+      - DAC_TRIG_RMP
+      - ADC24_DMA_RMP
+      - ENCODER_MODE
+    _add:
+      VBAT_MON:
+        description: VBAT monitoring enable
+        bitOffset: 24
+        bitWidth: 1
+        access: read-write
+  CFGR2:
+    _delete:
+      - BYP_ADD_PAR
+
 _include:
  - common_patches/4_nvic_prio_bits.yaml
  - ./common_patches/merge_I2C_CR2_SADDx_fields.yaml
  - ./common_patches/merge_I2C_OAR1_OA1x_fields.yaml
  - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
  - ./common_patches/merge_USART_BRR_fields.yaml
+ - ./common_patches/f3_syscfg.yaml
+ - ./common_patches/f3_syscfg_cfgr2.yaml
  - common_patches/can/can.yaml
  - common_patches/can/can_filter_bank.yaml
  - ../peripherals/crc/crc_basic.yaml

--- a/devices/stm32f3x4.yaml
+++ b/devices/stm32f3x4.yaml
@@ -3,12 +3,45 @@ _svd: ../svd/stm32f3x4.svd
 _rebase:
   SPI1: SPI3
 
+SYSCFG:
+  _modify:
+    SYSCFG_RCR:
+      name: RCR
+      displayName: RCR
+    SYSCFG_CFGR3:
+      name: CFGR3
+      displayName: CFGR3
+  CFGR1:
+    _delete:
+      - USB_IT_RMP
+  CFGR3:
+    _delete:
+      - ADC2_DMA_RMP*
+    _add:
+      I2C1_TX_DMA_RMP:
+        description: I2C1_TX DMA remapping bit
+        bitOffset: 6
+        bitWidth: 2
+      ADC2_DMA_RMP:
+        description: ADC2 DMA remapping bit
+        bitOffset: 8
+        bitWidth: 2
+  RCR:
+    _delete:
+      - PAGE4_WP
+      - PAGE5_WP
+      - PAGE6_WP
+      - PAGE7_WP
+
 _include:
  - common_patches/4_nvic_prio_bits.yaml
  - ./common_patches/merge_I2C_CR2_SADDx_fields.yaml
  - ./common_patches/merge_I2C_OAR1_OA1x_fields.yaml
  - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
  - ./common_patches/merge_USART_BRR_fields.yaml
+ - ./common_patches/f3_syscfg.yaml
+ - ./common_patches/f3_syscfg_cfgr1_dac2_ch1_dma_rmp.yaml
+ - ./common_patches/f3_syscfg_cfgr2.yaml
  - common_patches/can/can.yaml
  - common_patches/can/can_filter_bank.yaml
  - ../peripherals/gpio/gpio_v2.yaml

--- a/devices/stm32f3x4.yaml
+++ b/devices/stm32f3x4.yaml
@@ -43,6 +43,8 @@ _include:
  - ./common_patches/f3_syscfg_cfgr1_dac2_ch1_dma_rmp.yaml
  - ./common_patches/f3_syscfg_cfgr2.yaml
  - ./common_patches/f3_opamp2.yaml
+ - ./common_patches/f3_comp246.yaml
+ - ./common_patches/f3_comp246_inmsel3.yaml
  - common_patches/can/can.yaml
  - common_patches/can/can_filter_bank.yaml
  - ../peripherals/gpio/gpio_v2.yaml

--- a/devices/stm32f3x4.yaml
+++ b/devices/stm32f3x4.yaml
@@ -42,6 +42,7 @@ _include:
  - ./common_patches/f3_syscfg.yaml
  - ./common_patches/f3_syscfg_cfgr1_dac2_ch1_dma_rmp.yaml
  - ./common_patches/f3_syscfg_cfgr2.yaml
+ - ./common_patches/f3_opamp2.yaml
  - common_patches/can/can.yaml
  - common_patches/can/can_filter_bank.yaml
  - ../peripherals/gpio/gpio_v2.yaml

--- a/devices/stm32f3x8.yaml
+++ b/devices/stm32f3x8.yaml
@@ -36,6 +36,7 @@ _include:
  - ./common_patches/f3_syscfg_cfgr4.yaml
  - ./common_patches/f3_syscfg_rcr_page8-15.yaml
  - ./common_patches/f3_opamp1234.yaml
+ - ./common_patches/f3_comp1234567.yaml
  - common_patches/can/can.yaml
  - common_patches/can/can_filter_bank.yaml
  - ../peripherals/crc/crc_basic.yaml

--- a/devices/stm32f3x8.yaml
+++ b/devices/stm32f3x8.yaml
@@ -1,11 +1,40 @@
 _svd: ../svd/stm32f3x8.svd
 
+SYSCFG:
+  _modify:
+    SYSCFG_RCR:
+      name: RCR
+      displayName: RCR
+    SYSCFG_CFGR3:
+      name: CFGR3
+      displayName: CFGR3
+  CFGR3:
+    _delete:
+      - ADC2_DMA_RMP*
+      - DAC1_TRIG*
+    _add:
+      I2C1_TX_DMA_RMP:
+        description: I2C1_TX DMA remapping bit
+        bitOffset: 6
+        bitWidth: 2
+      ADC2_DMA_RMP:
+        description: ADC2 DMA remapping bit
+        bitOffset: 8
+        bitWidth: 2
+
 _include:
  - common_patches/4_nvic_prio_bits.yaml
  - ./common_patches/merge_I2C_CR2_SADDx_fields.yaml
  - ./common_patches/merge_I2C_OAR1_OA1x_fields.yaml
  - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
  - ./common_patches/merge_USART_BRR_fields.yaml
+ - ./common_patches/f3_syscfg.yaml
+ - ./common_patches/f3_syscfg_cfgr1_mem_mode_3.yaml
+ - ./common_patches/f3_syscfg_cfgr1_dac2_ch1_dma_rmp.yaml
+ - ./common_patches/f3_syscfg_cfgr1_i2c3_fmp.yaml
+ - ./common_patches/f3_syscfg_cfgr2.yaml
+ - ./common_patches/f3_syscfg_cfgr4.yaml
+ - ./common_patches/f3_syscfg_rcr_page8-15.yaml
  - common_patches/can/can.yaml
  - common_patches/can/can_filter_bank.yaml
  - ../peripherals/crc/crc_basic.yaml

--- a/devices/stm32f3x8.yaml
+++ b/devices/stm32f3x8.yaml
@@ -35,6 +35,7 @@ _include:
  - ./common_patches/f3_syscfg_cfgr2.yaml
  - ./common_patches/f3_syscfg_cfgr4.yaml
  - ./common_patches/f3_syscfg_rcr_page8-15.yaml
+ - ./common_patches/f3_opamp1234.yaml
  - common_patches/can/can.yaml
  - common_patches/can/can_filter_bank.yaml
  - ../peripherals/crc/crc_basic.yaml


### PR DESCRIPTION
split stm32f3 syscfg_comp_opamp into 3 separate devices, syscfg, comp and opamp to match the datasheet and fix all registers that need to be fixed.