### PR TITLE
rename DBG to DBGMCU

### DIFF
--- a/devices/common_patches/dbgmcu.yaml
+++ b/devices/common_patches/dbgmcu.yaml
@@ -1,0 +1,10 @@
+_include:
+ - dbgmcu_rename.yaml
+
+DBGMCU:
+  _strip:
+    - DBGMCU_
+  APB1_FZ:
+    _modify:
+      DBG_IWDEG_STOP:
+        name: DBG_IWDG_STOP

--- a/devices/common_patches/dbgmcu_rename.yaml
+++ b/devices/common_patches/dbgmcu_rename.yaml
@@ -1,0 +1,3 @@
+_modify:
+  DBG:
+    name: DBGMCU

--- a/devices/common_patches/f3_dbgmcu.yaml
+++ b/devices/common_patches/f3_dbgmcu.yaml
@@ -1,0 +1,6 @@
+DBGMCU:
+  _modify:
+    APB1FZ:
+      name: APB1_FZ
+    APB2_FZ:
+      name: APB2_FZ

--- a/devices/common_patches/f7_dbgmcu.yaml
+++ b/devices/common_patches/f7_dbgmcu.yaml
@@ -1,0 +1,163 @@
+_add:
+  DBGMCU:
+    description: Debug support
+    baseAddress: 0xE0042000
+    addressBlock:
+      offset: 0x0
+      size: 0x400
+    registers:
+      IDCODE:
+        description: IDCODE
+        addressOffset: 0x0
+        size: 0x20
+        access: read-only
+        fields:
+          DEV_ID:
+            description: DEV_ID
+            bitOffset: 0
+            bitWidth: 12
+          REV_ID:
+            description: REV_ID
+            bitOffset: 16
+            bitWidth: 16
+      CR:
+        description: Control Register
+        addressOffset: 0x4
+        size: 0x20
+        access: read-write
+        resetValue: 0x00000000
+        fields:
+          DBG_SLEEP:
+            description: DBG_SLEEP
+            bitOffset: 0
+            bitWidth: 1
+          DBG_STOP:
+            description: DBG_STOP
+            bitOffset: 1
+            bitWidth: 1
+          DBG_STANDBY:
+            description: DBG_STANDBY
+            bitOffset: 2
+            bitWidth: 1
+          TRACE_IOEN:
+            description: TRACE_IOEN
+            bitOffset: 5
+            bitWidth: 1
+          TRACE_MODE:
+            description: TRACE_MODE
+            bitOffset: 6
+            bitWidth: 2
+      APB1_FZ:
+        description: Debug MCU APB1 Freeze register
+        addressOffset: 0x8
+        size: 0x20
+        access: read-write
+        resetValue: 0x00000000
+        fields:
+          DBG_TIM2_STOP:
+            description: DBG_TIM2_STOP
+            bitOffset: 0
+            bitWidth: 1
+          DBG_TIM3_STOP:
+            description: DBG_TIM3_STOP
+            bitOffset: 1
+            bitWidth: 1
+          DBG_TIM4_STOP:
+            description: DBG_TIM4_STOP
+            bitOffset: 2
+            bitWidth: 1
+          DBG_TIM5_STOP:
+            description: DBG_TIM5_STOP
+            bitOffset: 3
+            bitWidth: 1
+          DBG_TIM6_STOP:
+            description: DBG_TIM6_STOP
+            bitOffset: 4
+            bitWidth: 1
+          DBG_TIM7_STOP:
+            description: DBG_TIM7_STOP
+            bitOffset: 5
+            bitWidth: 1
+          DBG_TIM12_STOP:
+            description: DBG_TIM12_STOP
+            bitOffset: 6
+            bitWidth: 1
+          DBG_TIM13_STOP:
+            description: DBG_TIM13_STOP
+            bitOffset: 7
+            bitWidth: 1
+          DBG_TIM14_STOP:
+            description: DBG_TIM14_STOP
+            bitOffset: 8
+            bitWidth: 1
+          DBG_LPTIM1_STOP:
+            description: DBG_LPTIM1_STOP
+            bitOffset: 9
+            bitWidth: 1
+          DBG_RTC_STOP:
+            description: DBG_RTC_STOP
+            bitOffset: 10
+            bitWidth: 1
+          DBG_WWDG_STOP:
+            description: DBG_WWDG_STOP
+            bitOffset: 11
+            bitWidth: 1
+          DBG_IWDG_STOP:
+            description: DBG_IWDG_STOP
+            bitOffset: 12
+            bitWidth: 1
+          DBG_CAN3_STOP:
+            description: DBG_CAN3_STOP
+            bitOffset: 13
+            bitWidth: 1
+          DBG_I2C1_SMBUS_TIMEOUT:
+            description: DBG_I2C1_SMBUS_TIMEOUT
+            bitOffset: 21
+            bitWidth: 1
+          DBG_I2C2_SMBUS_TIMEOUT:
+            description: DBG_I2C2_SMBUS_TIMEOUT
+            bitOffset: 22
+            bitWidth: 1
+          DBG_I2C3_SMBUS_TIMEOUT:
+            description: DBG_I2C3_SMBUS_TIMEOUT
+            bitOffset: 23
+            bitWidth: 1
+          DBG_I2C4_SMBUS_TIMEOUT:
+            description: DBG_I2C4SMBUS_TIMEOUT
+            bitOffset: 24
+            bitWidth: 1
+          DBG_CAN1_STOP:
+            description: DBG_CAN1_STOP
+            bitOffset: 25
+            bitWidth: 1
+          DBG_CAN2_STOP:
+            description: DBG_CAN2_STOP
+            bitOffset: 26
+            bitWidth: 1
+      APB2_FZ:
+        description: Debug MCU APB2 Freeze register
+        addressOffset: 0xC
+        size: 0x20
+        access: read-write
+        resetValue: 0x00000000
+        fields:
+          DBG_TIM1_STOP:
+            description: TIM1 counter stopped when core is halted
+            bitOffset: 0
+            bitWidth: 1
+          DBG_TIM8_STOP:
+            description: TIM8 counter stopped when core is halted
+            bitOffset: 1
+            bitWidth: 1
+          DBG_TIM9_STOP:
+            description: TIM9 counter stopped when core is halted
+            bitOffset: 16
+            bitWidth: 1
+          DBG_TIM10_STOP:
+            description: TIM10 counter stopped when core is halted
+            bitOffset: 17
+            bitWidth: 1
+          DBG_TIM11_STOP:
+            description: TIM11 counter stopped when core is halted
+            bitOffset: 18
+            bitWidth: 1

--- a/devices/stm32f100.yaml
+++ b/devices/stm32f100.yaml
@@ -42,3 +42,4 @@ _include:
  - ../peripherals/dma/dma_v1.yaml
  - ../peripherals/iwdg/iwdg.yaml
  - common_patches/tim/tim_ccr.yaml
+ - common_patches/dbgmcu_rename.yaml

--- a/devices/stm32f101.yaml
+++ b/devices/stm32f101.yaml
@@ -61,3 +61,4 @@ _include:
  - ../peripherals/iwdg/iwdg.yaml
  - common_patches/tim/tim_ccr.yaml
  - ../peripherals/usb/usb.yaml
+ - common_patches/dbgmcu_rename.yaml

--- a/devices/stm32f102.yaml
+++ b/devices/stm32f102.yaml
@@ -94,3 +94,4 @@ _include:
  - ../peripherals/iwdg/iwdg.yaml
  - common_patches/tim/tim_ccr.yaml
  - ../peripherals/usb/usb.yaml
+ - common_patches/dbgmcu_rename.yaml

--- a/devices/stm32f103.yaml
+++ b/devices/stm32f103.yaml
@@ -72,3 +72,4 @@ _include:
  - ../peripherals/adc/adc_array.yaml
  - common_patches/tim/tim_ccr.yaml
  - ../peripherals/usb/usb.yaml
+ - common_patches/dbgmcu_rename.yaml

--- a/devices/stm32f107.yaml
+++ b/devices/stm32f107.yaml
@@ -57,3 +57,4 @@ _include:
  - ../peripherals/iwdg/iwdg.yaml
  - common_patches/tim/tim_ccr.yaml
  - ../peripherals/usb/usb.yaml
+ - common_patches/dbgmcu_rename.yaml

--- a/devices/stm32f215.yaml
+++ b/devices/stm32f215.yaml
@@ -69,3 +69,4 @@ _include:
  - common_patches/hash/hash_v1.yaml
  - common_patches/rtc/rtc_bkpr.yaml
  - common_patches/tim/tim_ccr.yaml
+ - common_patches/dbgmcu.yaml

--- a/devices/stm32f217.yaml
+++ b/devices/stm32f217.yaml
@@ -68,3 +68,4 @@ _include:
  - common_patches/hash/hash_v1.yaml
  - common_patches/rtc/rtc_bkpr.yaml
  - common_patches/tim/tim_ccr.yaml
+ - common_patches/dbgmcu.yaml

--- a/devices/stm32f301.yaml
+++ b/devices/stm32f301.yaml
@@ -82,3 +82,4 @@ _include:
  - common_patches/tsc/tsc.yaml
  - common_patches/tim/tim_ccr.yaml
  - ../peripherals/usb/usb.yaml
+ - common_patches/f3_dbgmcu.yaml

--- a/devices/stm32f302.yaml
+++ b/devices/stm32f302.yaml
@@ -53,3 +53,4 @@ _include:
  - common_patches/tsc/tsc.yaml
  - common_patches/tim/tim_ccr.yaml
  - ../peripherals/usb/usb.yaml
+ - common_patches/f3_dbgmcu.yaml

--- a/devices/stm32f303.yaml
+++ b/devices/stm32f303.yaml
@@ -81,3 +81,4 @@ _include:
  - common_patches/tsc/tsc.yaml
  - common_patches/tim/tim_ccr.yaml
  - ../peripherals/usb/usb.yaml
+ - common_patches/f3_dbgmcu.yaml

--- a/devices/stm32f373.yaml
+++ b/devices/stm32f373.yaml
@@ -60,3 +60,4 @@ _include:
  - common_patches/tsc/tsc.yaml
  - common_patches/tim/tim_ccr.yaml
  - ../peripherals/usb/usb.yaml
+ - common_patches/f3_dbgmcu.yaml

--- a/devices/stm32f3x4.yaml
+++ b/devices/stm32f3x4.yaml
@@ -66,4 +66,4 @@ _include:
  - ../peripherals/usart/usart_v2B.yaml
  - common_patches/tsc/tsc.yaml
  - common_patches/tim/tim_ccr.yaml
-
+ - common_patches/f3_dbgmcu.yaml

--- a/devices/stm32f3x8.yaml
+++ b/devices/stm32f3x8.yaml
@@ -59,3 +59,4 @@ _include:
  - common_patches/tsc/tsc.yaml
  - common_patches/tim/tim_ccr.yaml
  - ../peripherals/usb/usb.yaml
+ - common_patches/f3_dbgmcu.yaml

--- a/devices/stm32f401.yaml
+++ b/devices/stm32f401.yaml
@@ -63,3 +63,4 @@ _include:
  - ../peripherals/iwdg/iwdg.yaml
  - common_patches/rtc/rtc_bkpr.yaml
  - common_patches/tim/tim_ccr.yaml
+ - common_patches/dbgmcu.yaml

--- a/devices/stm32f405.yaml
+++ b/devices/stm32f405.yaml
@@ -99,3 +99,4 @@ _include:
  - common_patches/rtc/rtc_bkpr.yaml
  - common_patches/otg_fs_fixes.yaml
  - common_patches/tim/tim_ccr.yaml
+ - common_patches/dbgmcu.yaml

--- a/devices/stm32f407.yaml
+++ b/devices/stm32f407.yaml
@@ -105,3 +105,4 @@ _include:
  - common_patches/rtc/rtc_bkpr.yaml
  - common_patches/otg_fs_fixes.yaml
  - common_patches/tim/tim_ccr.yaml
+ - common_patches/dbgmcu.yaml

--- a/devices/stm32f410.yaml
+++ b/devices/stm32f410.yaml
@@ -68,3 +68,4 @@ _include:
  - ../peripherals/iwdg/iwdg.yaml
  - common_patches/rtc/rtc_bkpr.yaml
  - common_patches/tim/tim_ccr.yaml
+ - common_patches/dbgmcu.yaml

--- a/devices/stm32f411.yaml
+++ b/devices/stm32f411.yaml
@@ -60,3 +60,4 @@ _include:
  - ../peripherals/iwdg/iwdg.yaml
  - common_patches/rtc/rtc_bkpr.yaml
  - common_patches/tim/tim_ccr.yaml
+ - common_patches/dbgmcu.yaml

--- a/devices/stm32f412.yaml
+++ b/devices/stm32f412.yaml
@@ -181,3 +181,4 @@ _include:
  - ../peripherals/iwdg/iwdg.yaml
  - common_patches/rtc/rtc_bkpr.yaml
  - common_patches/tim/tim_ccr.yaml
+ - common_patches/dbgmcu.yaml

--- a/devices/stm32f413.yaml
+++ b/devices/stm32f413.yaml
@@ -146,3 +146,4 @@ _include:
  - ../peripherals/iwdg/iwdg.yaml
  - common_patches/rtc/rtc_bkpr.yaml
  - common_patches/tim/tim_ccr.yaml
+ - common_patches/dbgmcu.yaml

--- a/devices/stm32f427.yaml
+++ b/devices/stm32f427.yaml
@@ -186,3 +186,4 @@ _include:
  - common_patches/rtc/rtc_bkpr.yaml
  - common_patches/otg_fs_fixes.yaml
  - common_patches/tim/tim_ccr.yaml
+ - common_patches/dbgmcu.yaml

--- a/devices/stm32f429.yaml
+++ b/devices/stm32f429.yaml
@@ -167,3 +167,4 @@ _include:
  - common_patches/rtc/rtc_bkpr.yaml
  - common_patches/otg_fs_fixes.yaml
  - common_patches/tim/tim_ccr.yaml
+ - common_patches/dbgmcu.yaml

--- a/devices/stm32f446.yaml
+++ b/devices/stm32f446.yaml
@@ -109,3 +109,4 @@ _include:
  - ../peripherals/iwdg/iwdg.yaml
  - common_patches/rtc/rtc_bkpr.yaml
  - common_patches/tim/tim_ccr.yaml
+ - common_patches/dbgmcu.yaml

--- a/devices/stm32f469.yaml
+++ b/devices/stm32f469.yaml
@@ -121,3 +121,4 @@ _include:
  - common_patches/hash/hash.yaml
  - common_patches/rtc/rtc_bkpr.yaml
  - common_patches/tim/tim_ccr.yaml
+ - common_patches/dbgmcu.yaml

--- a/devices/stm32f7x2.yaml
+++ b/devices/stm32f7x2.yaml
@@ -46,3 +46,4 @@ _include:
  - ../peripherals/usart/usart_v2C.yaml
  - common_patches/rtc/rtc_bkpr.yaml
  - common_patches/tim/tim_ccr.yaml
+ - common_patches/dbgmcu.yaml

--- a/devices/stm32f7x3.yaml
+++ b/devices/stm32f7x3.yaml
@@ -56,3 +56,4 @@ _include:
  - ../peripherals/usart/usart_v2C.yaml
  - common_patches/rtc/rtc_bkpr.yaml
  - common_patches/tim/tim_ccr.yaml
+ - common_patches/dbgmcu.yaml

--- a/devices/stm32f7x5.yaml
+++ b/devices/stm32f7x5.yaml
@@ -180,3 +180,4 @@ _include:
  - common_patches/hash/hash.yaml
  - common_patches/rtc/rtc_bkpr.yaml
  - common_patches/tim/tim_ccr.yaml
+ - common_patches/dbgmcu.yaml

--- a/devices/stm32f7x6.yaml
+++ b/devices/stm32f7x6.yaml
@@ -161,3 +161,4 @@ _include:
  - common_patches/hash/hash.yaml
  - common_patches/rtc/rtc_bkpr.yaml
  - common_patches/tim/tim_ccr.yaml
+ - common_patches/dbgmcu.yaml

--- a/devices/stm32f7x7.yaml
+++ b/devices/stm32f7x7.yaml
@@ -329,3 +329,4 @@ _include:
  - common_patches/mdios/mdios.yaml
  - common_patches/rtc/rtc_bkpr.yaml
  - common_patches/tim/tim_ccr.yaml
+ - common_patches/f7_dbgmcu.yaml

--- a/devices/stm32f7x9.yaml
+++ b/devices/stm32f7x9.yaml
@@ -316,3 +316,4 @@ _include:
  - common_patches/mdios/mdios.yaml
  - common_patches/rtc/rtc_bkpr.yaml
  - common_patches/tim/tim_ccr.yaml
+ - common_patches/f7_dbgmcu.yaml


### PR DESCRIPTION
Some of the families name this device DBGMCU and others DBG, even though the Reference Manual for all those families are describing this device in the exact same way.
It is presented in a DBG chapter which contains various kind of devices such as ETM or TPIU as well as DBGMCU, each with their own register set.
So for consistency across families, and for better matching of the reference manual, I propose that we name this device DBGMCU in all families.