### PR TITLE
stm32h7x3: strip PWR_ prefix in PWR registers

### DIFF
--- a/devices/stm32h7x3.yaml
+++ b/devices/stm32h7x3.yaml
@@ -305,6 +305,25 @@ FLASH:
       addressOffset: "0x12C"
       alternateRegister: ""
 
+PWR:
+  _modify:
+    PWR_CR1:
+      name: CR1
+    PWR_CSR1:
+      name: CSR1
+    PWR_CR2:
+      name: CR2
+    PWR_CR3:
+      name: CR3
+    PWR_CPUCR:
+      name: CPUCR
+    PWR_D3CR:
+      name: D3CR
+    PWR_WKUPCR:
+      name: WKUPCR
+    PWR_WKUPEPR:
+      name: WKUPEPR
+
 _include:
  - common_patches/4_nvic_prio_bits.yaml
  - common_patches/dma_fcr_wo.yaml


### PR DESCRIPTION
Sorry for the noise in #174 