### PR TITLE
stm32h7x3/SPI: CSTART is read-write

### DIFF
--- a/devices/stm32h7x3.yaml
+++ b/devices/stm32h7x3.yaml
@@ -324,6 +324,12 @@ PWR:
     PWR_WKUPEPR:
       name: WKUPEPR
 
+"SPI*":
+  CR1:
+    _modify:
+      CSTART:
+        access: read-write
+
 _include:
  - common_patches/4_nvic_prio_bits.yaml
  - common_patches/dma_fcr_wo.yaml


### PR DESCRIPTION
It's "read-set" according to the RM. Definitely writable.