### PR TITLE
stm32h7x3: add SPI peripheral documentation

### DIFF
--- a/devices/stm32h7x3.yaml
+++ b/devices/stm32h7x3.yaml
@@ -329,6 +329,17 @@ PWR:
     _modify:
       CSTART:
         access: read-write
+      TCRCI:
+        name: TCRCINI
+      RCRCI:
+        name: RCRCINI
+  IER:
+    _modify:
+      DPXPIE:
+        name: DXPIE
+  _modify:
+    CGFR:
+      name: I2SCFGR
 
 _include:
  - common_patches/4_nvic_prio_bits.yaml

--- a/devices/stm32h7x3.yaml
+++ b/devices/stm32h7x3.yaml
@@ -344,6 +344,7 @@ _include:
  - common_patches/tim/tim_o24ce.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/gpio/gpio_v2.yaml
+ - ../peripherals/spi/spi_v3.yaml
  - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/tim/tim16.yaml
  - ../peripherals/tim/tim6.yaml

--- a/peripherals/spi/spi_v3.yaml
+++ b/peripherals/spi/spi_v3.yaml
@@ -1,0 +1,281 @@
+"SPI*":
+  CR1:
+    IOLOCK:
+      Unlocked: [0, "IO configuration unlocked"]
+      Locked: [1, "IO configuration locked"]
+    TCRCI:
+      AllZeros: [0, "All zeros TX CRC initialization pattern"]
+      AllOnes: [1, "All ones TX CRC initialization pattern"]
+    RCRCI:
+      AllZeros: [0, "All zeros RX CRC initialization pattern"]
+      AllOnes: [1, "All ones RX CRC initialization pattern"]
+    CRC33_17:
+      Disabled: [0, "Full size (33/17 bit) CRC polynomial is not used"]
+      Enabled: [1, "Full size (33/17 bit) CRC polynomial is used"]
+    SSI:
+      SlaveSelected: [0, "0 is forced onto the SS signal and the I/O value of the SS pin is ignored"]
+      SlaveNotSelected: [1, "1 is forced onto the SS signal and the I/O value of the SS pin is ignored"]
+    HDDIR:
+      Receiver: [0, "Receiver in half duplex mode"]
+      Transmitter: [1, "Transmitter in half duplex mode"]
+    CSUSP:
+      _write:
+        NotRequested: [0, "Do not request master suspend"]
+        Requested: [1, "Request master suspend"]
+    CSTART:
+      NotStarted: [0, "Do not start master transfer"]
+      Started: [1, "Start master transfer"]
+    MASRX:
+      Disabled: [0, "Automatic suspend in master receive-only mode disabled"]
+      Enabled: [1, "Automatic suspend in master receive-only mode enabled"]
+    SPE:
+      Disabled: [0, "Peripheral disabled"]
+      Enabled: [1, "Peripheral enabled"]
+
+  CR2:
+    TSER: [0, 65535]
+    TSIZE: [0, 65535]
+
+  CFG1:
+    MBR:
+      Div2: [0, "f_spi_ker_ck / 2"]
+      Div4: [1, "f_spi_ker_ck / 4"]
+      Div8: [2, "f_spi_ker_ck / 8"]
+      Div16: [3, "f_spi_ker_ck / 16"]
+      Div32: [4, "f_spi_ker_ck / 32"]
+      Div64: [5, "f_spi_ker_ck / 64"]
+      Div128: [6, "f_spi_ker_ck / 128"]
+      Div256: [7, "f_spi_ker_ck / 256"]
+    CRCEN:
+      Disabled: [0, "CRC calculation disabled"]
+      Enabled: [1, "CRC calculation enabled"]
+    CRCSIZE: [3, 31]
+    TXDMAEN:
+      Disabled: [0, "Tx buffer DMA disabled"]
+      Enabled: [1, "Tx buffer DMA enabled"]
+    RXDMAEN:
+      Disabled: [0, "Rx buffer DMA disabled"]
+      Enabled: [1, "Rx buffer DMA enabled"]
+    UDRDET:
+      StartOfFrame: [0, "Underrun is detected at begin of data frame"]
+      EndOfFrame: [1, "Underrun is detected at end of last data frame"]
+      StartOfSlaveSelect: [2, "Underrun is detected at begin of active SS signal"]
+    UDRCFG:
+      Constant: [0, "Slave sends a constant underrun pattern"]
+      RepeatReceived: [1, "Slave repeats last received data frame from master"]
+      RepeatTransmitted: [2, "Slave repeats last transmitted data frame"]
+    FTHVL:
+      OneFrame: [0, "1 frame"]
+      TwoFrames: [1, "3 frames"]
+      ThreeFrames: [2, "3 frames"]
+      FourFrames: [3, "4 frames"]
+      FiveFrames: [4, "5 frames"]
+      SixFrames: [5, "6 frames"]
+      SevenFrames: [6, "7 frames"]
+      EightFrames: [7, "8 frames"]
+      NineFrames: [8, "9 frames"]
+      TenFrames: [9, "10 frames"]
+      ElevenFrames: [10, "11 frames"]
+      TwelveFrames: [11, "12 frames"]
+      ThirteenFrames: [12, "13 frames"]
+      FourteenFrames: [13, "14 frames"]
+      FifteenFrames: [14, "15 frames"]
+      SixteenFrames: [15, "16 frames"]
+    DSIZE: [3, 31]
+
+  CFG2:
+    AFCNTR:
+      NotControlled: [0, "Peripheral takes no control of GPIOs while disabled"]
+      Controlled: [1, "Peripheral controls GPIOs while disabled"]
+    SSOM:
+      Asserted: [0, "SS is asserted until data transfer complete"]
+      NotAasserted: [1, "Data frames interleaved with SS not asserted during MIDI"]
+    SSOE:
+      Disabled: [0, "SS output is disabled in master mode"]
+      Enabled: [1, "SS output is enabled in master mode"]
+    SSIOP:
+    SSM:
+      Disabled: [0, "Software slave management disabled"]
+      Enabled: [1, "Software slave management enabled"]
+    CPOL:
+      IdleLow: [0, "CK to 0 when idle"]
+      IdleHigh: [1, "CK to 1 when idle"]
+    CPHA:
+      FirstEdge: [0, "The first clock transition is the first data capture edge"]
+      SecondEdge: [1, "The second clock transition is the first data capture edge"]
+    LSBFRST:
+      MSBFirst: [0, "Data is transmitted/received with the MSB first"]
+      LSBFirst: [1, "Data is transmitted/received with the LSB first"]
+    MASTER:
+      Slave: [0, "Slave configuration"]
+      Master: [1, "Master configuration"]
+    SP:
+      Motorola: [0, "Motorola SPI protocol"]
+      TI: [1, "TI SPI protocol"]
+    COMM:
+      FullDuplex: [0, "Full duplex"]
+      Transmitter: [1, "Simplex transmitter only"]
+      Receiver: [2, "Simplex receiver only"]
+      HalfDuplex: [3, "Half duplex"]
+    IOSWP:
+      Disabled: [0, "MISO and MOSI not swapped"]
+      Enabled: [1, "MISO and MOSI swapped"]
+    MIDI: [0, 15]
+    MSSI: [0, 15]
+
+  IER:
+    TSERFIE:
+      Masked: [0, "TSER loaded interrupt masked"]
+      NotMasked: [1, "TSER loaded interrupt not masked"]
+    MODFIE:
+      Masked: [0, "Mode fault interrupt masked"]
+      NotMasked: [1, "Mode fault interrupt not masked"]
+    TIFREIE:
+      Masked: [0, "TI frame format error interrupt masked"]
+      NotMasked: [1, "TI frame format error interrupt not masked"]
+    CRCEIE:
+      Masked: [0, "CRC error interrupt masked"]
+      NotMasked: [1, "CRC error interrupt not masked"]
+    OVRIE:
+      Masked: [0, "Overrun interrupt masked"]
+      NotMasked: [1, "Overrun interrupt not masked"]
+    UDRIE:
+      Masked: [0, "Underrun interrupt masked"]
+      NotMasked: [1, "Underrun interrupt not masked"]
+    TXTFIE:
+      Masked: [0, "Transmission transfer filled interrupt masked"]
+      NotMasked: [1, "Transmission transfer filled interrupt not masked"]
+    EOTIE:
+      Masked: [0, "End-of-transfer interrupt masked"]
+      NotMasked: [1, "End-of-transfer interrupt not masked"]
+    DPXPIE:
+      Masked: [0, "Duplex transfer complete interrupt masked"]
+      NotMasked: [1, "Duplex transfer complete interrupt not masked"]
+    TXPIE:
+      Masked: [0, "TX space available interrupt masked"]
+      NotMasked: [1, "TX space available interrupt not masked"]
+    RXPIE:
+      Masked: [0, "RX data available interrupt masked"]
+      NotMasked: [1, "RX data available interrupt not masked"]
+
+  SR:
+    CTSIZE: [0, 65535]
+    RXWNE:
+      LessThan32: [0, "Less than 32-bit data frame received"]
+      AtLeast32: [1, "At least 32-bit data frame received"]
+    RXPLVL:
+      ZeroFrames: [0, "Zero frames beyond packing ratio available"]
+      OneFrame: [1, "One frame beyond packing ratio available"]
+      TwoFrames: [2, "Two frame beyond packing ratio available"]
+      ThreeFrames: [3, "Three frame beyond packing ratio available"]
+    TXC:
+      Ongoing: [0, "Transmission ongoing"]
+      Completed: [1, "Transmission completed"]
+    SUSP:
+      NotSuspended: [0, "Master not suspended"]
+      Suspended: [1, "Master suspended"]
+    TSERF:
+      NotLoaded: [0, "Additional number of SPI data to be transacted not yet loaded"]
+      Loaded: [1, "Additional number of SPI data to be transacted was reloaded"]
+    MODF:
+      NoFault: [0, "No mode fault detected"]
+      Fault: [1, "Mode fault detected"]
+    TIFRE:
+      NoError: [0, "TI frame format error detected"]
+      Error: [1, "TI frame format error detected"]
+    CRCE:
+      Match: [0, "No CRC error detected"]
+      NoMatch: [1, "CRC error detected"]
+    OVR:
+      NoOverrun: [0, "No overrun occurred"]
+      Overrun: [1, "Overrun occurred"]
+    UDR:
+      NoUnderrun: [0, "No underrun occurred"]
+      Underrun: [1, "Underrun occurred"]
+    TXTF:
+      NotCompleted: [0, "Transmission buffer incomplete"]
+      Completed: [1, "Transmission buffer filled with at least one transfer"]
+    EOT:
+      NotCompleted: [0, "Transfer ongoing or not started"]
+      Completed: [1, "Transfer complete"]
+    DXP:
+      Unavailable: [0, "Duplex packet unavailable: no space for transmission and/or no data received"]
+      Available: [1, "Duplex packet available: space for transmission and data received"]
+    TXP:
+      Full: [0, "Tx buffer full"]
+      NotFull: [1, "Tx buffer not full"]
+    RXP:
+      Empty: [0, "Rx buffer empty"]
+      NotEmpty: [1, "Rx buffer not empty"]
+
+  IFCR:
+    "*C":
+      _write:
+        Clear: [1, "Clear interrupt flag"]
+
+  TXDR:
+    TXDR: [0, 4294967295]
+
+  RXDR:
+    _read:
+      RXDR:
+
+  CRCPOLY:
+    CRCPOLY: [0, 4294967295]
+
+  TXCRC:
+    _read:
+      TXCRC:
+
+  RXCRC:
+    _read:
+      RXCRC:
+
+  UDRDR:
+    UDRDR: [0, 4294967295]
+
+  CGFR:
+    MCKOE:
+      Disabled: [0, "Master clock output disabled"]
+      Enabled: [1, "Master clock output enabled"]
+    ODD:
+      Even: [0, "Real divider value is I2SDIV*2"]
+      Odd: [1, "Real divider value is I2SDIV*2 + 1"]
+    I2SDIV: [0, 255]
+    DATFMT:
+      RightAligned: [0, "The data inside RXDR and TXDR are right aligned"]
+      LeftAligned: [1, "The data inside RXDR and TXDR are left aligned"]
+    WSINV:
+      Disabled: [0, "Word select inversion disabled"]
+      Enabled: [1, "Word select inversion enabled"]
+    FIXCH:
+      NotFixed: [0, "The channel length in slave mode is different from 16 or 32 bits (CHLEN not taken into account)"]
+      Fixed: [1, "The channel length in slave mode is supposed to be 16 or 32 bits (according to CHLEN)"]
+    CKPOL:
+      SampleOnRising: [0, "Signals are sampled on rising and changed on falling clock edges"]
+      SampleOnFalling: [1, "Signals are sampled on falling and changed on rising clock edges"]
+    CHLEN:
+      Bits16: [0, "16 bit per channel"]
+      Bits32: [1, "32 bit per channel"]
+    DATLEN:
+      Bits16: [0, "16 bit data length"]
+      Bits24: [1, "16 bit data length"]
+      Bits32: [2, "16 bit data length"]
+    PCMSYNC:
+      Short: [0, "Short PCM frame synchronization"]
+      Long: [1, "Long PCM frame synchronization"]
+    I2SSTD:
+      Philips: [0, "I2S Philips standard"]
+      LeftAligned: [1, "MSB/left justified standard"]
+      RightAligned: [2, "LSB/right justified standard"]
+      Pcm: [3, "PCM standard"]
+    I2SCFG:
+      SlaveTransmit: [0, "Slave, transmit"]
+      SlaveReceive: [1, "Slave, recteive"]
+      MasterTransmit: [2, "Master, transmit"]
+      MasterReceive: [3, "Master, receive"]
+      SlaveFullDuplex: [4, "Slave, full duplex"]
+      MasterFullDuplex: [5, "Master, full duplex"]
+    I2SMOD:
+      SPI: [0, "SPI mode selected"]
+      I2S: [1, "I2S/PCM mode selected"]

--- a/peripherals/spi/spi_v3.yaml
+++ b/peripherals/spi/spi_v3.yaml
@@ -3,10 +3,10 @@
     IOLOCK:
       Unlocked: [0, "IO configuration unlocked"]
       Locked: [1, "IO configuration locked"]
-    TCRCI:
+    TCRCINI:
       AllZeros: [0, "All zeros TX CRC initialization pattern"]
       AllOnes: [1, "All ones TX CRC initialization pattern"]
-    RCRCI:
+    RCRCINI:
       AllZeros: [0, "All zeros RX CRC initialization pattern"]
       AllOnes: [1, "All ones RX CRC initialization pattern"]
     CRC33_17:
@@ -49,7 +49,7 @@
     CRCEN:
       Disabled: [0, "CRC calculation disabled"]
       Enabled: [1, "CRC calculation enabled"]
-    CRCSIZE: [3, 31]
+    CRCSIZE: [0, 31]
     TXDMAEN:
       Disabled: [0, "Tx buffer DMA disabled"]
       Enabled: [1, "Tx buffer DMA enabled"]
@@ -66,7 +66,7 @@
       RepeatTransmitted: [2, "Slave repeats last transmitted data frame"]
     FTHVL:
       OneFrame: [0, "1 frame"]
-      TwoFrames: [1, "3 frames"]
+      TwoFrames: [1, "2 frames"]
       ThreeFrames: [2, "3 frames"]
       FourFrames: [3, "4 frames"]
       FiveFrames: [4, "5 frames"]
@@ -81,7 +81,7 @@
       FourteenFrames: [13, "14 frames"]
       FifteenFrames: [14, "15 frames"]
       SixteenFrames: [15, "16 frames"]
-    DSIZE: [3, 31]
+    DSIZE: [0, 31]
 
   CFG2:
     AFCNTR:
@@ -89,11 +89,13 @@
       Controlled: [1, "Peripheral controls GPIOs while disabled"]
     SSOM:
       Asserted: [0, "SS is asserted until data transfer complete"]
-      NotAasserted: [1, "Data frames interleaved with SS not asserted during MIDI"]
+      NotAsserted: [1, "Data frames interleaved with SS not asserted during MIDI"]
     SSOE:
       Disabled: [0, "SS output is disabled in master mode"]
       Enabled: [1, "SS output is enabled in master mode"]
     SSIOP:
+      ActiveLow: [0, "Low level is active for SS signal"]
+      ActiveHigh: [1, "High level is active for SS signal"]
     SSM:
       Disabled: [0, "Software slave management disabled"]
       Enabled: [1, "Software slave management enabled"]
@@ -148,7 +150,7 @@
     EOTIE:
       Masked: [0, "End-of-transfer interrupt masked"]
       NotMasked: [1, "End-of-transfer interrupt not masked"]
-    DPXPIE:
+    DXPIE:
       Masked: [0, "Duplex transfer complete interrupt masked"]
       NotMasked: [1, "Duplex transfer complete interrupt not masked"]
     TXPIE:
@@ -184,8 +186,8 @@
       NoError: [0, "TI frame format error detected"]
       Error: [1, "TI frame format error detected"]
     CRCE:
-      Match: [0, "No CRC error detected"]
-      NoMatch: [1, "CRC error detected"]
+      NoError: [0, "No CRC error detected"]
+      Error: [1, "CRC error detected"]
     OVR:
       NoOverrun: [0, "No overrun occurred"]
       Overrun: [1, "Overrun occurred"]
@@ -214,14 +216,14 @@
         Clear: [1, "Clear interrupt flag"]
 
   TXDR:
-    TXDR: [0, 4294967295]
+    TXDR: [0, 0xFFFFFFFF]
 
   RXDR:
     _read:
       RXDR:
 
   CRCPOLY:
-    CRCPOLY: [0, 4294967295]
+    CRCPOLY: [0, 0xFFFFFFFF]
 
   TXCRC:
     _read:
@@ -232,9 +234,9 @@
       RXCRC:
 
   UDRDR:
-    UDRDR: [0, 4294967295]
+    UDRDR: [0, 0xFFFFFFFF]
 
-  CGFR:
+  I2SCFGR:
     MCKOE:
       Disabled: [0, "Master clock output disabled"]
       Enabled: [1, "Master clock output enabled"]
@@ -259,8 +261,8 @@
       Bits32: [1, "32 bit per channel"]
     DATLEN:
       Bits16: [0, "16 bit data length"]
-      Bits24: [1, "16 bit data length"]
-      Bits32: [2, "16 bit data length"]
+      Bits24: [1, "24 bit data length"]
+      Bits32: [2, "32 bit data length"]
     PCMSYNC:
       Short: [0, "Short PCM frame synchronization"]
       Long: [1, "Long PCM frame synchronization"]
@@ -268,7 +270,7 @@
       Philips: [0, "I2S Philips standard"]
       LeftAligned: [1, "MSB/left justified standard"]
       RightAligned: [2, "LSB/right justified standard"]
-      Pcm: [3, "PCM standard"]
+      PCM: [3, "PCM standard"]
     I2SCFG:
       SlaveTransmit: [0, "Slave, transmit"]
       SlaveReceive: [1, "Slave, recteive"]


### PR DESCRIPTION
Two things are not covered:

The SVD has all six SPI peripherals the same and derived from SPI1.
In reality only SPI123 are as documented. SPI456 have 16 bit wide TX and
RX registers and DSIZE is limited accordingly.

Furthermore, there should be explicit byte and half-word access to the
TX and RX data registers. This is how the access-transfer packing ratio
is determined.