### PR TITLE
Add missing DMA interrupts for stm32f0x2

### DIFF
--- a/devices/stm32f0x2.yaml
+++ b/devices/stm32f0x2.yaml
@@ -14,6 +14,17 @@ RCC:
         bitOffset: 20
         bitWidth: 1
 
+DMA1:
+  _add:
+    _interrupts:
+      DMA1_CH2_3:
+        description: "DMA channel 2 and 3 interrupts"
+        value: 10
+
+      DMA1_CH4_5_6_7:
+        description: "DMA channel 4, 5, 6 and 7 interrupts"
+        value: 11
+
 _include:
  - ./common_patches/rename_RCC_CIR_HSI14RDYIE_field.yaml
  - ./common_patches/rename_f0_SPI_registers.yaml


### PR DESCRIPTION
According to the reference manual chapter 11.1.3 the
interrupt vector positions 9-12 should be:

- 9 - DMA_CH1
- 10 - DMA_CH2_3
- 11 - DMA_CH4_5_6_7
- 12 - ADC_COMP

but positions 10 and 11 are missing in the .svd.