### PR TITLE
stm32h7 dma and dmamux fixes

### DIFF
--- a/devices/stm32h7x3.yaml
+++ b/devices/stm32h7x3.yaml
@@ -356,6 +356,16 @@ DMA1:
         description: DMA1 Stream6
       # DMA1_STR7 is correct
 
+"DMAMUX*":
+  _strip:
+    - DMAMUX1_
+    - DMAMUX2_
+  _array:
+    "C*CR":
+      name: "CCR%s"
+    "RG*CR":
+      name: "RGCR%s"
+
 _include:
  - common_patches/4_nvic_prio_bits.yaml
  - common_patches/dma_fcr_wo.yaml

--- a/devices/stm32h7x3.yaml
+++ b/devices/stm32h7x3.yaml
@@ -330,6 +330,32 @@ PWR:
       CSTART:
         access: read-write
 
+DMA1:
+  _add:
+    _interrupts:
+      DMA1_STR0:
+        value: 11
+        description: DMA1 Stream0
+      DMA1_STR1:
+        value: 12
+        description: DMA1 Stream1
+      DMA1_STR2:
+        value: 13
+        description: DMA1 Stream2
+      DMA1_STR3:
+        value: 14
+        description: DMA1 Stream3
+      DMA1_STR4:
+        value: 15
+        description: DMA1 Stream4
+      DMA1_STR5:
+        value: 16
+        description: DMA1 Stream5
+      DMA1_STR6:
+        value: 17
+        description: DMA1 Stream6
+      # DMA1_STR7 is correct
+
 _include:
  - common_patches/4_nvic_prio_bits.yaml
  - common_patches/dma_fcr_wo.yaml


### PR DESCRIPTION
* Maybe the prefix stripping could be automated in `svdpatch`. It would also apply to a bunch of other peripherals in that stm32h7 SVD.
* ~~DMAMUX1/DMAMUX2 are handled individually and not by pattern match because the README states that renames must not use pattern matches.~~ Pattern renames seem to work just fine in this case.
* The DMA1 interrupts are in fact listed the SVD, but under wrong names (e.g. `DMA_STR0`) ~~and they don't appear in the crate output~~. AFAICT `svdpatch` does not support renaming interrupts (#163 #170) and therefore they are just added with the correct names/description/values and override the wrong ones.