### PR TITLE
stm32h7x3: fix CFG1.FTH{V<->L} spelling

### DIFF
--- a/devices/stm32h7x3.yaml
+++ b/devices/stm32h7x3.yaml
@@ -274,6 +274,10 @@ PWR:
   _modify:
     CGFR:
       name: I2SCFGR
+  CFG1:
+    _modify:
+      FTHVL:
+        name: FTHLV
 
 DMA1:
   _add:

--- a/peripherals/spi/spi_v3.yaml
+++ b/peripherals/spi/spi_v3.yaml
@@ -64,7 +64,7 @@
       Constant: [0, "Slave sends a constant underrun pattern"]
       RepeatReceived: [1, "Slave repeats last received data frame from master"]
       RepeatTransmitted: [2, "Slave repeats last transmitted data frame"]
-    FTHVL:
+    FTHLV:
       OneFrame: [0, "1 frame"]
       TwoFrames: [1, "2 frames"]
       ThreeFrames: [2, "3 frames"]


### PR DESCRIPTION
* The RM has FTHLV for "Fifo THreshold LeVel"
* This adopts the RM spelling
* This is presumably a breaking change as it renames a field.