### PR TITLE
Add PAR to dmav2 cluster

### DIFF
--- a/devices/common_patches/dma/dma_v2.yaml
+++ b/devices/common_patches/dma/dma_v2.yaml
@@ -7,11 +7,13 @@
         bitWidth: 4
   _cluster:
     "ST%s":
-      description: "Stream cluster: S?CR, S?NDTR, S?M0AR, S?M1AR and S?FCR registers"
+      description: "Stream cluster: S?CR, S?NDTR, S?PAR, S?M0AR, S?M1AR and S?FCR registers"
       "S?CR":
         name: CR
       "S?NDTR":
         name: NDTR
+      "S?PAR":
+        name: PAR
       "S?M0AR":
         name: M0AR
       "S?M1AR":


### PR DESCRIPTION
Fixes #213 

@burrbull I think you added this `dma_v2.yaml` the first time, was this just a mistake or is there a reason to not have PAR?