### PR TITLE
stm32h7x3: spi `DXPIE`/`TXPIE` enables are in fact read-write

### DIFF
--- a/devices/stm32h7x3.yaml
+++ b/devices/stm32h7x3.yaml
@@ -249,6 +249,9 @@ FLASH:
     _modify:
       DPXPIE:
         name: DXPIE
+        access: read-write
+      TXPIE:
+        access: read-write
   _modify:
     CGFR:
       name: I2SCFGR


### PR DESCRIPTION
These two bits may be written by software, although they may also be
cleared by hardware. The RM says "TXPIE is set by software and cleared
by TXTF flag set event."

The bitfield in the RM describes these bits as `rs`, rather than
`rw`. Perhaps why they are mis-classified as read-only in the SVD.