### PR TITLE
stm32h7x3: flash access and usart/uart confusion

### DIFF
--- a/devices/stm32h7x3.yaml
+++ b/devices/stm32h7x3.yaml
@@ -235,6 +235,12 @@ FLASH:
     PRAR_PRG2:
       addressOffset: "0x12C"
       alternateRegister: ""
+    KEYR[12]:
+      access: write-only
+    OPTKEYR_?:
+      access: write-only
+    BOOT_PRGR:
+      access: read-write
 
 "SPI*":
   CR1:

--- a/devices/stm32h7x3.yaml
+++ b/devices/stm32h7x3.yaml
@@ -398,6 +398,30 @@ RCC:
         name: BDRST
       RTCSRC:
         name: RTCSEL
+  APB1LRSTR:
+    _modify:
+      USART7RST:
+        name: UART7RST
+        description: UART7 block reset
+      USART8RST:
+        name: UART8RST
+        description: UART8 block reset
+  APB1LENR,C1_APB1LENR:
+    _modify:
+      USART7EN:
+        name: UART7EN
+        description: UART7 Peripheral Clocks Enable
+      USART8EN:
+        name: UART8EN
+        description: UART8 Peripheral Clocks Enable
+  APB1LLPENR,C1_APB1LLPENR:
+    _modify:
+      USART7LPEN:
+        name: UART7LPEN
+        description: UART7 Peripheral Clocks Enable During CSleep Mode
+      USART8LPEN:
+        name: UART8LPEN
+        description: UART8 Peripheral Clocks Enable During CSleep Mode
   C1_APB1LENR:
     _modify:
       HDMICECEN:


### PR DESCRIPTION
Fix some subtle errors

* stm32h7: fix write-only and read-only registers in FLASH
* stm32h7: Fix confusion between USART and UART in RCC RSTR / ENR