### PR TITLE
Add missing crrcr reg for l4x3 series chips

### DIFF
--- a/devices/stm32l4x3.yaml
+++ b/devices/stm32l4x3.yaml
@@ -36,7 +36,7 @@ _include:
  - ./common_patches/rename_LPUART_CR2_DATAINV_field.yaml
  - ./common_patches/merge_LPUART_CR2_ADDx_fields.yaml
  - ./common_patches/merge_USART_BRR_fields.yaml
-   ./common_patches/l4_crrcr.yaml
+ - ./common_patches/l4_crrcr.yaml
  - common_patches/can/can.yaml
  - common_patches/can/can_filter_bank.yaml
  - common_patches/sai/sai_v1.yaml

--- a/devices/stm32l4x3.yaml
+++ b/devices/stm32l4x3.yaml
@@ -36,6 +36,7 @@ _include:
  - ./common_patches/rename_LPUART_CR2_DATAINV_field.yaml
  - ./common_patches/merge_LPUART_CR2_ADDx_fields.yaml
  - ./common_patches/merge_USART_BRR_fields.yaml
+   ./common_patches/l4_crrcr.yaml
  - common_patches/can/can.yaml
  - common_patches/can/can_filter_bank.yaml
  - common_patches/sai/sai_v1.yaml


### PR DESCRIPTION
It appears #141 missed the crrcr register for the L4x3 chips, this PR addresses that.