### PR TITLE
rtc f1

### DIFF
--- a/devices/stm32f101.yaml
+++ b/devices/stm32f101.yaml
@@ -60,6 +60,7 @@ _include:
  - ../peripherals/usart/uart_uart.yaml
  - ../peripherals/usart/uart_usart.yaml
  - ../peripherals/rcc/rcc_f1.yaml
+ - ../peripherals/rtc/rtc_f1.yaml
  - common_patches/dma/dma_v1.yaml
  - ../peripherals/dma/dma_v1.yaml
  - ../peripherals/iwdg/iwdg.yaml

--- a/devices/stm32f102.yaml
+++ b/devices/stm32f102.yaml
@@ -101,6 +101,7 @@ _include:
  - ../peripherals/usart/uart_uart.yaml
  - ../peripherals/usart/uart_usart.yaml
  - ../peripherals/rcc/rcc_f1.yaml
+ - ../peripherals/rtc/rtc_f1.yaml
  - common_patches/dma/dma_v1.yaml
  - ../peripherals/dma/dma_v1.yaml
  - ../peripherals/iwdg/iwdg.yaml

--- a/devices/stm32f103.yaml
+++ b/devices/stm32f103.yaml
@@ -67,6 +67,7 @@ _include:
  - ../peripherals/usart/uart_usart.yaml
  - ../peripherals/rcc/rcc_f1.yaml
  - ../peripherals/rcc/rcc_f1_f3_usb.yaml
+ - ../peripherals/rtc/rtc_f1.yaml
  - common_patches/dma/dma_v1.yaml
  - ../peripherals/dma/dma_v1.yaml
  - ../peripherals/iwdg/iwdg.yaml

--- a/devices/stm32f107.yaml
+++ b/devices/stm32f107.yaml
@@ -57,6 +57,7 @@ _include:
  - ../peripherals/rcc/rcc_f1.yaml
  - ../peripherals/rcc/rcc_f1_f3_usb.yaml
  - ../peripherals/rcc/rcc_cfgr2_f107.yaml
+ - ../peripherals/rtc/rtc_f1.yaml
  - common_patches/dma/dma_v1.yaml
  - ../peripherals/dma/dma_v1.yaml
  - ../peripherals/iwdg/iwdg.yaml

--- a/peripherals/rtc/rtc_f1.yaml
+++ b/peripherals/rtc/rtc_f1.yaml
@@ -1,18 +1,18 @@
 RTC:
   CRH:
     OWIE:
-      Unlisten: [0, "Overflow interrupt is masked"]
-      Listen: [1, "Overflow interrupt is enabled"]
+      Disabled: [0, "Overflow interrupt is masked"]
+      Enabled: [1, "Overflow interrupt is enabled"]
     ALRIE:
-      Unlisten: [0, "Alarm interrupt is masked"]
-      Listen: [1, "Alarm interrupt is enabled"]
+      Disabled: [0, "Alarm interrupt is masked"]
+      Enabled: [1, "Alarm interrupt is enabled"]
     SECIE:
-      Unlisten: [0, "Second interrupt is masked"]
-      Listen: [1, "Second interrupt is enabled"]
+      Disabled: [0, "Second interrupt is masked"]
+      Enabled: [1, "Second interrupt is enabled"]
   CRL:
     RTOFF:
-      "On": [0, "Last write operation on RTC registers is still ongoing"]
-      "Off": [1, "Last write operation on RTC registers terminated"]
+      Enabled: [0, "Last write operation on RTC registers is still ongoing"]
+      Disabled: [1, "Last write operation on RTC registers terminated"]
     CNF:
       Exit: [0, "Exit configuration mode (start update of RTC registers)"]
       Enter: [1, "Enter configuration mode"]

--- a/peripherals/rtc/rtc_f1.yaml
+++ b/peripherals/rtc/rtc_f1.yaml
@@ -1,0 +1,58 @@
+RTC:
+  CRH:
+    OWIE:
+      Unlisten: [0, "Overflow interrupt is masked"]
+      Listen: [1, "Overflow interrupt is enabled"]
+    ALRIE:
+      Unlisten: [0, "Alarm interrupt is masked"]
+      Listen: [1, "Alarm interrupt is enabled"]
+    SECIE:
+      Unlisten: [0, "Second interrupt is masked"]
+      Listen: [1, "Second interrupt is enabled"]
+  CRL:
+    RTOFF:
+      "On": [0, "Last write operation on RTC registers is still ongoing"]
+      "Off": [1, "Last write operation on RTC registers terminated"]
+    CNF:
+      Exit: [0, "Exit configuration mode (start update of RTC registers)"]
+      Enter: [1, "Enter configuration mode"]
+    RSF:
+      _read:
+        NotSynchronized: [0, "Registers not yet synchronized"]
+        Synchronized: [1, "Registers synchronized"]
+      _write:
+        Clear: [0, "Clear flag"]
+    OWF:
+      _read:
+        NoOverflow: [0, "Overflow not detected"]
+        Overflow: [1, "32-bit programmable counter overflow occurred"]
+      _write:
+        Clear: [0, "Clear flag"]
+    ALRF:
+      _read:
+        NoAlarm: [0, "Alarm not detected"]
+        Alarm: [1, "Alarm detected"]
+      _write:
+        Clear: [0, "Clear flag"]
+    SECF:
+      _read:
+        NoPrescalerOverflow: [0, "Second flag condition not met"]
+        PrescalerOverflow: [1, "Second flag condition met"]
+      _write:
+        Clear: [0, "Clear flag"]
+  PRLH:
+    PRLH: [0, 0xF]
+  PRLL:
+    PRLL: [0, 0xFFFF]
+  DIVH:
+    DIVH: [0, 0xF]
+  DIVL:
+    DIVL: [0, 0xFFFF]
+  CNTH:
+    CNTH: [0, 0xFFFF]
+  CNTL:
+    CNTL: [0, 0xFFFF]
+  ALRH:
+    ALRH: [0, 0xFFFF]
+  ALRL:
+    ALRL: [0, 0xFFFF]


### PR DESCRIPTION
I made enums for `interrupt enable` fields listen/unlisten.
I suggest to make an exception for such type of fields (I mean interrupt control) to distinguish them from others.