### PR TITLE
stm32h7: Rename stm32h7x3: ADC CR boost field is wider for rev v

### DIFF
--- a/devices/common_patches/h7_adc_boost_rev_v.yaml
+++ b/devices/common_patches/h7_adc_boost_rev_v.yaml
@@ -1,0 +1,9 @@
+# ADC fields different on H7 Rev V
+
+"ADC?":
+  CR:
+    _modify:
+      # See RM0433 Section 24.6.3
+      BOOST:
+        bitOffset: 8
+        bitWidth: 2

--- a/devices/stm32h743v.yaml
+++ b/devices/stm32h743v.yaml
@@ -9,6 +9,7 @@ _include:
  - common_patches/h7_ethernet_desc.yaml
  - common_patches/h7_dbgmcu.yaml
  - common_patches/h7_dmamux.yaml
+ - common_patches/h7_adc_boost_rev_v.yaml
  - common_patches/h7_hsicfgr_csicfgr_rev_v.yaml
  - common_patches/merge_I2C_CR2_SADDx_fields.yaml
  - common_patches/merge_USART_CR1_DEATx_fields.yaml

--- a/devices/stm32h753v.yaml
+++ b/devices/stm32h753v.yaml
@@ -19,6 +19,7 @@ _include:
  - common_patches/h7_ethernet_desc.yaml
  - common_patches/h7_dbgmcu.yaml
  - common_patches/h7_dmamux.yaml
+ - common_patches/h7_adc_boost_rev_v.yaml
  - common_patches/h7_hsicfgr_csicfgr_rev_v.yaml
  - common_patches/merge_I2C_CR2_SADDx_fields.yaml
  - common_patches/merge_USART_CR1_DEATx_fields.yaml


### PR DESCRIPTION
Documented in RM0433 Section 24.6.3