### PR TITLE
Set correct number of nvic priority bits available on stm32l0xx

### DIFF
--- a/devices/common_patches/l0_nvic_prio_bits.yaml
+++ b/devices/common_patches/l0_nvic_prio_bits.yaml
@@ -1,0 +1,3 @@
+_modify:
+  cpu:
+    nvicPrioBits: 2

--- a/devices/stm32l0x1.yaml
+++ b/devices/stm32l0x1.yaml
@@ -160,6 +160,7 @@ _include:
  - ./common_patches/l0_rtc.yaml
  - ./common_patches/l0_tim.yaml
  - ./common_patches/l0_syscfg_cfgr.yaml
+ - ./common_patches/l0_nvic_prio_bits.yaml
  - ./common_patches/merge_USART_CR1_DEATx_fields.yaml
  - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
  - ./common_patches/merge_USART_CR2_ABRMODx_fields.yaml

--- a/devices/stm32l0x2.yaml
+++ b/devices/stm32l0x2.yaml
@@ -7,6 +7,7 @@ _modify:
 
 _include:
  - ./common_patches/l0_pwr_wakeup.yaml
+ - ./common_patches/l0_nvic_prio_bits.yaml
  - ./common_patches/merge_USART_CR1_DEATx_fields.yaml
  - ./common_patches/merge_USART_CR1_DEDTx_fields.yaml
  - ./common_patches/merge_USART_CR2_ADDx_fields.yaml

--- a/devices/stm32l0x3.yaml
+++ b/devices/stm32l0x3.yaml
@@ -8,6 +8,7 @@ _modify:
 
 _include:
  - ./common_patches/l0_pwr_wakeup.yaml
+ - ./common_patches/l0_nvic_prio_bits.yaml
  - ./common_patches/merge_USART_CR1_DEATx_fields.yaml
  - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
  - ./common_patches/merge_USART_CR2_ABRMODx_fields.yaml


### PR DESCRIPTION
I was using the stm32l0 crate with RTFM and noticed some funky behavior. The number of NVIC priority bits are two on the m0/m0+, and it was wrong in the SVD file. 