### PR TITLE
Use UTF-8 for opening YAML files

### DIFF
--- a/scripts/group.py
+++ b/scripts/group.py
@@ -21,7 +21,7 @@ def main(devices, output):
     peripherals = {}
     for device_path in tqdm(glob.glob(os.path.join(devices, "*.yaml"))):
         device_name = os.path.splitext(os.path.basename(device_path))[0]
-        with open(device_path) as f:
+        with open(device_path, encoding='utf-8') as f:
             device = yaml.safe_load(f)
             device["_path"] = device_path
         if "_svd" not in device:

--- a/scripts/makecrates.py
+++ b/scripts/makecrates.py
@@ -156,7 +156,7 @@ def read_device_table():
     path = os.path.join(
         os.path.abspath(os.path.split(__file__)[0]), os.pardir,
         "stm32_part_table.yaml")
-    with open(path) as f:
+    with open(path, encoding='utf-8') as f:
         table = yaml.safe_load(f)
     return table
 

--- a/scripts/makedeps.py
+++ b/scripts/makedeps.py
@@ -17,7 +17,7 @@ def main():
     parser.add_argument("devices", nargs="*")
     args = parser.parse_args()
     for dpath in args.devices:
-        with open(dpath) as f:
+        with open(dpath, encoding='utf-8') as f:
             device = yaml.safe_load(f)
         device["_path"] = dpath
         deps = svdpatch.yaml_includes(device)

--- a/scripts/matchperipherals.py
+++ b/scripts/matchperipherals.py
@@ -19,7 +19,7 @@ import svdpatch
 
 
 def process_yamlfile(svd, yamlpath, quiet):
-    with open(yamlpath) as f:
+    with open(yamlpath, encoding='utf-8') as f:
         peripheral = yaml.safe_load(f)
     peripheral["_path"] = yamlpath
     svdpatch.yaml_includes(peripheral)
@@ -72,7 +72,7 @@ def process_device(device, ppath, quiet):
 
 
 def main(dpath, ppath, update, quiet):
-    with open(dpath) as f:
+    with open(dpath, encoding='utf-8') as f:
         device = yaml.safe_load(f)
     if "_svd" not in device:
         print("Could not find _svd in device YAML, cannot proceed.")

--- a/scripts/svdpatch.py
+++ b/scripts/svdpatch.py
@@ -75,7 +75,7 @@ def yaml_includes(parent):
         path = abspath(parent["_path"], relpath)
         if path in included:
             continue
-        with open(path) as f:
+        with open(path, encoding='utf-8') as f:
             child = yaml.safe_load(f)
         child["_path"] = path
         included.append(path)
@@ -858,7 +858,7 @@ def process_device(svd, device, update_fields=True):
 def main():
     # Load the specified YAML root file
     args = parseargs()
-    with open(args.yaml) as f:
+    with open(args.yaml, encoding='utf-8') as f:
         root = yaml.safe_load(f)
         root["_path"] = args.yaml
 


### PR DESCRIPTION
By default Python uses default system encoding for opening files, which might cause parsing errors, because all the YAML files are UTF-8 (at least to my knowledge).