### PR TITLE
Mark extracted SVDs as precious to prevent auto deletion by Make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 all: patch svd2rust
 
 .PHONY: patch svd2rust form check clean-rs clean-patch clean-html clean
+.PRECIOUS: svd/%.svd
 
 SHELL := /usr/bin/env bash
 


### PR DESCRIPTION
This prevents Make from deleting the SVD files it considers as intermediate, and then re-creating them using the extraction script.