### PR TITLE
Fix SVD unzip matching

### DIFF
--- a/svd/extract.sh
+++ b/svd/extract.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 for f in vendor/*.zip; do
-    unzip -juLL $f '*.svd'
+    unzip -juLL $f '**.svd'
 done
 
 ln -s stm32h743x.svd stm32h743.svd || true


### PR DESCRIPTION
This should fix unzipping on platforms where asterisk doesn't match path separators.