### PR TITLE
stm32h7: split ethernet peripheral for dualcore parts

### DIFF
--- a/devices/common_patches/h7_ethernet_combined_desc.yaml
+++ b/devices/common_patches/h7_ethernet_combined_desc.yaml
@@ -1,0 +1,18 @@
+# Applies to H7 where MAC and MTL registers are combined under
+# the Ethernet_MAC peripheral
+
+# Create separate DMA and MTL periperhals
+_include:
+  - ./h7_ethernet_dma.yaml
+  - ./h7_ethernet_mtl.yaml
+
+Ethernet_MAC:
+  # Delete DMA and MTL parts from MAC
+  _delete:
+    _registers:
+      - DMA*
+      - MTL*
+
+  # Descriptions for MAC
+  _include:
+    - ./h7_ethernet_desc_mac.yaml

--- a/devices/common_patches/h7_ethernet_desc_combined.yaml
+++ b/devices/common_patches/h7_ethernet_desc_combined.yaml
@@ -1,7 +1,0 @@
-# Applies to H7 where MAC and MTL registers are combined under
-# the Ethernet_MAC peripheral
-
-Ethernet_MAC:
-  _include:
-    - ./h7_ethernet_desc_mac.yaml
-    - ./h7_ethernet_desc_mtl.yaml

--- a/devices/common_patches/h7_ethernet_dma.yaml
+++ b/devices/common_patches/h7_ethernet_dma.yaml
@@ -1,0 +1,380 @@
+# Add H7 Ethernet DMA peripheral
+
+_add:
+    Ethernet_DMA:
+        description: Ethernet DMA
+        baseAddress: 0x40029000
+        registers:
+          DMAMR:
+            description: DMA mode register
+            addressOffset: 0x0000
+            resetValue: 0x00000000
+            fields:
+              INTM:
+                description: Interrupt Mode
+                bitOffset: 16
+                bitWidth: 2
+              PR:
+                description: Priority ratio
+                bitOffset: 12
+                bitWidth: 3
+              TXPR:
+                description: Transmit priority
+                bitOffset: 11
+                bitWidth: 1
+              DA:
+                description: DMA Tx or Rx Arbitration Scheme
+                bitOffset: 1
+                bitWidth: 1
+              SWR:
+                description: Software Reset
+                bitOffset: 0
+                bitWidth: 1
+          DMASBMR:
+            description: System bus mode register
+            addressOffset: 0x0004
+            resetValue: 0x01010000
+            fields:
+              RB:
+                description: Rebuild INCRx Burst
+                bitOffset: 15
+                bitWidth: 1
+              MB:
+                description: Mixed Burst
+                bitOffset: 14
+                bitWidth: 1
+              AAL:
+                description: Address-Aligned Beats
+                bitOffset: 12
+                bitWidth: 1
+              FB:
+                description: Fixed Burst Length
+                bitOffset: 0
+                bitWidth: 1
+          DMAISR:
+            description: Interrupt status register
+            addressOffset: 0x0008
+            resetValue: 0x00000000
+            fields:
+              MACIS:
+                description: MAC Interrupt Status
+                bitOffset: 17
+                bitWidth: 1
+              MTLIS:
+                description: MTL Interrupt Status
+                bitOffset: 16
+                bitWidth: 1
+              DC0IS:
+                description: DMA Channel Interrupt Status
+                bitOffset: 0
+                bitWidth: 1
+          DMADSR:
+            description: Debug status register
+            addressOffset: 0x000C
+            resetValue: 0x00000000
+            fields:
+              TPS0:
+                description: DMA Channel Transmit Process State
+                bitOffset: 12
+                bitWidth: 4
+              RPS0:
+                description: DMA Channel Receive Process State
+                bitOffset: 8
+                bitWidth: 4
+              AXWHSTS:
+                description: AHB Master Write Channel
+                bitOffset: 0
+                bitWidth: 1
+          DMACCR:
+            description: Channel control register
+            addressOffset: 0x0100
+            resetValue: 0x00000000
+            fields:
+              DSL:
+                description: Descriptor Skip Length
+                bitOffset: 18
+                bitWidth: 3
+              PBLX8:
+                description: 8xPBL mode
+                bitOffset: 16
+                bitWidth: 1
+              MSS:
+                description: Maximum Segment Size
+                bitOffset: 0
+                bitWidth: 14
+          DMACTxCR:
+            description: Channel transmit control register
+            addressOffset: 0x0104
+            resetValue: 0x00000000
+            fields:
+              TXPBL:
+                description: Transmit Programmable Burst Length
+                bitOffset: 16
+                bitWidth: 6
+              TSE:
+                description: TCP Segmentation Enabled
+                bitOffset: 12
+                bitWidth: 1
+              OSF:
+                description: Operate on Second Packet
+                bitOffset: 4
+                bitWidth: 1
+              ST:
+                description: Start or Stop Transmission Command
+                bitOffset: 0
+                bitWidth: 1
+          DMACRxCR:
+            description: Channel receive control register
+            addressOffset: 0x0108
+            resetValue: 0x00000000
+            fields:
+              RPF:
+                description: DMA Rx Channel Packet Flush
+                bitOffset: 31
+                bitWidth: 1
+              RXPBL:
+                description: Receive Programmable Burst Length
+                bitOffset: 16
+                bitWidth: 6
+              RBSZ:
+                description: Receive Buffer size
+                bitOffset: 1
+                bitWidth: 14
+              SR:
+                description: Start or Stop Receive
+                bitOffset: 0
+                bitWidth: 1
+          DMACTxDLAR:
+            description: Channel Tx descriptor list address register
+            addressOffset: 0x0114
+            resetValue: 0x00000000
+            fields:
+              TDESLA:
+                description: Start of Transmit List
+                bitOffset: 2
+                bitWidth: 30
+          DMACRxDLAR:
+            description: Channel Rx descriptor list address register
+            addressOffset: 0x011C
+            resetValue: 0x00000000
+            fields:
+              RDESLA:
+                description: Start of Receive List
+                bitOffset: 2
+                bitWidth: 30
+          DMACTxDTPR:
+            description: Channel Tx descriptor tail pointer register
+            addressOffset: 0x0120
+            resetValue: 0x00000000
+            fields:
+              TDT:
+                description: Transmit Descriptor Tail Pointer
+                bitOffset: 2
+                bitWidth: 30
+          DMACRxDTPR:
+            description: Channel Rx descriptor tail pointer register
+            addressOffset: 0x0128
+            resetValue: 0x00000000
+            fields:
+              RDT:
+                description: Receive Descriptor Tail Pointer
+                bitOffset: 2
+                bitWidth: 30
+          DMACTxRLR:
+            description: Channel Tx descriptor ring length register
+            addressOffset: 0x012C
+            resetValue: 0x00000000
+            fields:
+              TDRL:
+                description: Transmit Descriptor Ring Length
+                bitOffset: 0
+                bitWidth: 10
+          DMACRxRLR:
+            description: Channel Rx descriptor ring length register
+            addressOffset: 0x0130
+            resetValue: 0x00000000
+            fields:
+              RDRL:
+                description: Receive Descriptor Ring Length
+                bitOffset: 0
+                bitWidth: 10
+          DMACIER:
+            description: Channel interrupt enable register
+            addressOffset: 0x0134
+            resetValue: 0x00000000
+            fields:
+              NIE:
+                description: Normal Interrupt Summary Enable
+                bitOffset: 15
+                bitWidth: 1
+              AIE:
+                description: Abnormal Interrupt Summary Enable
+                bitOffset: 14
+                bitWidth: 1
+              CDEE:
+                description: Context Descriptor Error Enable
+                bitOffset: 13
+                bitWidth: 1
+              FBEE:
+                description: Fatal Bus Error Enable
+                bitOffset: 12
+                bitWidth: 1
+              ERIE:
+                description: Early Receive Interrupt Enable
+                bitOffset: 11
+                bitWidth: 1
+              ETIE:
+                description: Early Transmit Interrupt Enable
+                bitOffset: 10
+                bitWidth: 1
+              RWTE:
+                description: Receive Watchdog Timeout Enable
+                bitOffset: 9
+                bitWidth: 1
+              RSE:
+                description: Receive Stopped Enable
+                bitOffset: 8
+                bitWidth: 1
+              RBUE:
+                description: Receive Buffer Unavailable Enable
+                bitOffset: 7
+                bitWidth: 1
+              RIE:
+                description: Receive Interrupt Enable
+                bitOffset: 6
+                bitWidth: 1
+              TBUE:
+                description: Transmit Buffer Unavailable Enable
+                bitOffset: 2
+                bitWidth: 1
+              TXSE:
+                description: Transmit Stopped Enable
+                bitOffset: 1
+                bitWidth: 1
+              TIE:
+                description: Transmit Interrupt Enable
+                bitOffset: 0
+                bitWidth: 1
+          DMACRxIWTR:
+            description: Channel Rx interrupt watchdog timer register
+            addressOffset: 0x0138
+            resetValue: 0x00000000
+            fields:
+              RWT:
+                description: Receive Interrupt Watchdog Timer Count
+                bitOffset: 0
+                bitWidth: 8
+          DMACCATxDR:
+            description: Channel current application transmit descriptor register
+            addressOffset: 0x0144
+            resetValue: 0x00000000
+            fields:
+              CURTDESAPTR:
+                description: Application Transmit Descriptor Address Pointer
+                bitOffset: 0
+                bitWidth: 32
+          DMACCARxDR:
+            description: Channel current application receive descriptor register
+            addressOffset: 0x014C
+            resetValue: 0x00000000
+            fields:
+              CURRDESAPTR:
+                description: Application Receive Descriptor Address Pointer
+                bitOffset: 0
+                bitWidth: 32
+          DMACCATxBR:
+            description: Channel current application transmit buffer register
+            addressOffset: 0x0154
+            resetValue: 0x00000000
+            fields:
+              CURTBUFAPTR:
+                description: Application Transmit Buffer Address Pointer
+                bitOffset: 0
+                bitWidth: 32
+          DMACCARxBR:
+            description: Channel current application receive buffer register
+            addressOffset: 0x015C
+            resetValue: 0x00000000
+            fields:
+              CURRBUFAPTR:
+                description: Application Receive Buffer Address Pointer
+                bitOffset: 0
+                bitWidth: 32
+          DMACSR:
+            description: Channel status register
+            addressOffset: 0x0160
+            resetValue: 0x00000000
+            fields:
+              REB:
+                description: Rx DMA Error Bits
+                bitOffset: 19
+                bitWidth: 3
+              TEB:
+                description: Tx DMA Error Bits
+                bitOffset: 16
+                bitWidth: 3
+              NIS:
+                description: Normal Interrupt Summary
+                bitOffset: 15
+                bitWidth: 1
+              AIS:
+                description: Abnormal Interrupt Summary
+                bitOffset: 14
+                bitWidth: 1
+              CDE:
+                description: Context Descriptor Error
+                bitOffset: 13
+                bitWidth: 1
+              FBE:
+                description: Fatal Bus Error
+                bitOffset: 12
+                bitWidth: 1
+              ERI:
+                description: Early Receive Interrupt
+                bitOffset: 11
+                bitWidth: 1
+              ETI:
+                description: Early Transmit Interrupt
+                bitOffset: 10
+                bitWidth: 1
+              RWT:
+                description: Receive Watchdog Timeout
+                bitOffset: 9
+                bitWidth: 1
+              RPS:
+                description: Receive Process Stopped
+                bitOffset: 8
+                bitWidth: 1
+              RBU:
+                description: Receive Buffer Unavailable
+                bitOffset: 7
+                bitWidth: 1
+              RI:
+                description: Receive Interrupt
+                bitOffset: 6
+                bitWidth: 1
+              TBU:
+                description: Transmit Buffer Unavailable
+                bitOffset: 2
+                bitWidth: 1
+              TPS:
+                description: Transmit Process Stopped
+                bitOffset: 1
+                bitWidth: 1
+              TI:
+                description: Transmit Interrupt
+                bitOffset: 0
+                bitWidth: 1
+          DMACMFCR:
+            description: Channel missed frame count register
+            addressOffset: 0x016C
+            resetValue: 0x00000000
+            fields:
+              MFCO:
+                description: Overflow status of the MFC Counter
+                bitOffset: 15
+                bitWidth: 1
+              MFC:
+                description: Dropped Packet Counters
+                bitOffset: 0
+                bitWidth: 11

--- a/devices/common_patches/h7_ethernet_mtl.yaml
+++ b/devices/common_patches/h7_ethernet_mtl.yaml
@@ -1,0 +1,208 @@
+# Add H7 Ethernet DMA peripheral
+
+_add:
+    Ethernet_MTL:
+        description: Ethernet MTL
+        baseAddress: 0x40028C00
+        registers:
+          MTLOMR:
+            description: Operating mode Register
+            addressOffset: 0x0000
+            resetValue: 0x00000000
+            fields:
+              CNTCLR:
+                description: Counters Reset
+                bitOffset: 9
+                bitWidth: 1
+              CNTPRST:
+                description: Counters Preset
+                bitOffset: 8
+                bitWidth: 1
+              DTXSTS:
+                description: Drop Transmit Status
+                bitOffset: 1
+                bitWidth: 1
+          MTLISR:
+            description: Interrupt status Register
+            addressOffset: 0x0020
+            resetValue: 0x00000000
+            fields:
+              Q0IS:
+                description: Queue interrupt status
+                bitOffset: 0
+                bitWidth: 1
+          MTLTxQOMR:
+            description: Tx queue operating mode Register
+            addressOffset: 0x0100
+            resetValue: 0x00070008
+            fields:
+              TQS:
+                description: Transmit Queue Size
+                bitOffset: 16
+                bitWidth: 9
+              TTC:
+                description: Transmit Threshold Control
+                bitOffset: 4
+                bitWidth: 3
+              TXQEN:
+                description: Transmit Queue Enable
+                bitOffset: 2
+                bitWidth: 2
+              TSF:
+                description: Transmit Store and Forward
+                bitOffset: 1
+                bitWidth: 1
+              FTQ:
+                description: Flush Transmit Queue
+                bitOffset: 0
+                bitWidth: 1
+          MTLTxQUR:
+            description: Tx queue underflow register
+            addressOffset: 0x0104
+            resetValue: 0x00000000
+            fields:
+              UFCNTOVF:
+                description: Overflow Bit for Underflow Packet Counter
+                bitOffset: 11
+                bitWidth: 1
+              UFFRMCNT:
+                description: Underflow Packet Counter
+                bitOffset: 0
+                bitWidth: 11
+          MTLTxQDR:
+            description: Tx queue debug Register
+            addressOffset: 0x0108
+            resetValue: 0x00000000
+            fields:
+              STXSTSF:
+                description: Number of Status Words in Tx Status FIFO of Queue
+                bitOffset: 20
+                bitWidth: 3
+              PTXQ:
+                description: Number of Packets in the Transmit Queue
+                bitOffset: 16
+                bitWidth: 3
+              TXSTSFSTS:
+                description: MTL Tx Status FIFO Full Status
+                bitOffset: 5
+                bitWidth: 1
+              TXQSTS:
+                description: MTL Tx Queue Not Empty Status
+                bitOffset: 4
+                bitWidth: 1
+              TWCSTS:
+                description: MTL Tx Queue Write Controller Status
+                bitOffset: 3
+                bitWidth: 1
+              TRCSTS:
+                description: MTL Tx Queue Read Controller Status
+                bitOffset: 1
+                bitWidth: 2
+              TXQPAUSED:
+                description: Transmit Queue in Pause
+                bitOffset: 0
+                bitWidth: 1
+          MTLQICSR:
+            description: Queue interrupt control status Register
+            addressOffset: 0x012C
+            resetValue: 0x00000000
+            fields:
+              RXOIE:
+                description: Receive Queue Overflow Interrupt Enable
+                bitOffset: 24
+                bitWidth: 1
+              RXOVFIS:
+                description: Receive Queue Overflow Interrupt Status
+                bitOffset: 16
+                bitWidth: 1
+              TXUIE:
+                description: Transmit Queue Underflow Interrupt Enable
+                bitOffset: 8
+                bitWidth: 1
+              TXUNFIS:
+                description: Transmit Queue Underflow Interrupt Status
+                bitOffset: 0
+                bitWidth: 1
+          MTLRxQOMR:
+            description: Rx queue operating mode register
+            addressOffset: 0x0130
+            resetValue: 0x00700000
+            fields:
+              RQS:
+                description: Receive Queue Size
+                bitOffset: 20
+                bitWidth: 3
+              RFD:
+                description: Threshold for Deactivating Flow Control
+                bitOffset: 14
+                bitWidth: 3
+              RFA:
+                description: Threshold for Activating Flow Control
+                bitOffset: 8
+                bitWidth: 3
+              EHFC:
+                description: Enable Hardware Flow Control
+                bitOffset: 7
+                bitWidth: 1
+              DIS_TCP_EF:
+                description: Disable Dropping of TCP
+                bitOffset: 6
+                bitWidth: 1
+              RSF:
+                description: Receive Queue Store and Forward
+                bitOffset: 5
+                bitWidth: 1
+              FEP:
+                description: Forward Error Packets
+                bitOffset: 4
+                bitWidth: 1
+              FUP:
+                description: Forward Undersized Good Packets
+                bitOffset: 3
+                bitWidth: 1
+              RTC:
+                description: Receive Queue Threshold Control
+                bitOffset: 0
+                bitWidth: 2
+          MTLRxQMPOCR:
+            description: Rx queue missed packet and overflow counter register
+            addressOffset: 0x0134
+            resetValue: 0x00000000
+            fields:
+              MISCNTOVF:
+                description: Missed Packet Counter Overflow Bit
+                bitOffset: 27
+                bitWidth: 1
+              MISPKTCNT:
+                description: Missed Packet Counter
+                bitOffset: 16
+                bitWidth: 11
+              OVFCNTOVF:
+                description: Overflow Counter Overflow Bit
+                bitOffset: 11
+                bitWidth: 1
+              OVFPKTCNT:
+                description: Overflow Packet Counter
+                bitOffset: 0
+                bitWidth: 11
+          MTLRxQDR:
+            description: Rx queue debug register
+            addressOffset: 0x0138
+            resetValue: 0x00000000
+            fields:
+              PRXQ:
+                description: Number of Packets in Receive Queue
+                bitOffset: 16
+                bitWidth: 14
+              RXQSTS:
+                description: MTL Rx Queue Fill-Level Status
+                bitOffset: 4
+                bitWidth: 2
+              RRCSTS:
+                description: MTL Rx Queue Read Controller State
+                bitOffset: 1
+                bitWidth: 2
+              RWCSTS:
+                description: MTL Rx Queue Write Controller Active Status
+                bitOffset: 0
+                bitWidth: 1

--- a/devices/stm32h747cm7.yaml
+++ b/devices/stm32h747cm7.yaml
@@ -12,7 +12,7 @@ _include:
  - common_patches/dma/dma_v3.yaml
  - common_patches/fsmc/fsmc_sdram_cluster.yaml
  - common_patches/h7_rcc_src_sel.yaml
- - common_patches/h7_ethernet_desc_combined.yaml
+ - common_patches/h7_ethernet_combined_desc.yaml
  - common_patches/h7_dbgmcu.yaml
  - common_patches/h7_dmamux.yaml
  - common_patches/h7_dsi.yaml

--- a/devices/stm32h757cm7.yaml
+++ b/devices/stm32h757cm7.yaml
@@ -19,7 +19,7 @@ _include:
  - common_patches/dma/dma_v3.yaml
  - common_patches/fsmc/fsmc_sdram_cluster.yaml
  - common_patches/h7_rcc_src_sel.yaml
- - common_patches/h7_ethernet_desc_combined.yaml
+ - common_patches/h7_ethernet_combined_desc.yaml
  - common_patches/h7_dbgmcu.yaml
  - common_patches/h7_dmamux.yaml
  - common_patches/h7_dsi.yaml


### PR DESCRIPTION
Split ethernet peripheral into (MAC, DMA, MTL).

This brings it in line with single core parts.