### PR TITLE
HRTIM interrupt numbers for f334

### DIFF
--- a/devices/stm32f3x4.yaml
+++ b/devices/stm32f3x4.yaml
@@ -106,6 +106,7 @@ HRTIM_Common:
       name: BDMUPR
     _interrupts:
       HRTIM1_FLT:
+        name: HRTIM_FLT
         value: 73
   IER:
     _modify:
@@ -122,6 +123,7 @@ HRTIM_Master:
       name: MDIER
     _interrupts:
       HRTIM1_MST:
+        name: HRTIM_MST
         value: 67
   MCR:
     _modify:
@@ -139,6 +141,7 @@ HRTIM_TIMA:
     _interrupts:
       HRTIM1_TIMA:
         value: 68
+        name: HRTIM_TIMA
 HRTIM_TIMB:
   _modify:
     _interrupts:
@@ -148,11 +151,13 @@ HRTIM_TIMC:
   _modify:
     _interrupts:
       HRTIM1_TIMC:
+        name: HRTIM_TIMC
         value: 70
 HRTIM_TIMD:
   _modify:
     _interrupts:
       HRTIM1_TIMD:
+        name: HRTIM_TIMD
         value: 71
 HRTIM_TIME:
   _modify:

--- a/devices/stm32f3x4.yaml
+++ b/devices/stm32f3x4.yaml
@@ -104,6 +104,9 @@ HRTIM_Common:
   _modify:
     BDMUPDR:
       name: BDMUPR
+    _interrupts:
+      HRTIM1_FLT:
+        value: 73
   IER:
     _modify:
       SYSFLTE:
@@ -117,6 +120,9 @@ HRTIM_Master:
   _modify:
     MDIER4:
       name: MDIER
+    _interrupts:
+      HRTIM1_MST:
+        value: 67
   MCR:
     _modify:
       SYNC_SRC:
@@ -127,6 +133,32 @@ HRTIM_Master:
         name: SYNCIN
       CK_PSC:
         name: CKPSC
+
+HRTIM_TIMA:
+  _modify:
+    _interrupts:
+      HRTIM1_TIMA:
+        value: 68
+HRTIM_TIMB:
+  _modify:
+    _interrupts:
+      HRTIM_TIMB:
+        value: 69
+HRTIM_TIMC:
+  _modify:
+    _interrupts:
+      HRTIM1_TIMC:
+        value: 70
+HRTIM_TIMD:
+  _modify:
+    _interrupts:
+      HRTIM1_TIMD:
+        value: 71
+HRTIM_TIME:
+  _modify:
+    _interrupts:
+      HRTIM_TIME:
+        value: 72
 
 "HRTIM_TIM[ABCDE]":
   _modify:

--- a/devices/stm32f3x4.yaml
+++ b/devices/stm32f3x4.yaml
@@ -200,6 +200,25 @@ HRTIM_TIME:
       UDPCPT:
         name: UPDCPT
 
+CAN:
+  _delete:
+    _interrupts:
+      - CAN_SCE
+  _add:
+    _interrupts:
+      CAN_SCE:
+        description: CAN_SCE interrupt
+        value: 22
+
+FPU:
+  _delete:
+    _interrupts:
+      - FPU
+  _add:
+    _interrupts:
+      FPU:
+        description: Floating point unit
+        value: 81
 
 _include:
  - common_patches/4_nvic_prio_bits.yaml


### PR DESCRIPTION
Three changes for the stm32f334:

- Seven interrupt numbers for HRTIM are adjusted according the manual. 
- "HRTIM1" is changed to "HRTIM" in 5 of 7 interrupt names.
- Double definition of the interrupts "CAN_SCE" and "FPU" are squashed.
  Although it didn't seem to bother the build system.