### PR TITLE
Fix typo in TIM22RST field name

### DIFF
--- a/devices/stm32l0x2.yaml
+++ b/devices/stm32l0x2.yaml
@@ -5,6 +5,12 @@ _modify:
   LPUSART1:
     name: LPUART1
 
+RCC:
+  APB2RSTR:
+    _modify:
+      TM12RST:
+        name: TIM22RST
+
 _include:
  - ./common_patches/l0_pwr_wakeup.yaml
  - ./common_patches/l0_nvic_prio_bits.yaml

--- a/devices/stm32l0x3.yaml
+++ b/devices/stm32l0x3.yaml
@@ -5,6 +5,11 @@ _modify:
   LPUSART1:
     name: LPUART1
 
+RCC:
+  APB2RSTR:
+    _modify:
+      TM12RST:
+        name: TIM22RST
 
 _include:
  - ./common_patches/l0_pwr_wakeup.yaml


### PR DESCRIPTION
This is why the HAL had to disable TIM22 on the x2 and x3 chips. I wasn't able to fully test the HAL now since the generated Rust code changed too much (presumably due to a newer svd2rust version), but the "no method named `tim22rst` error is gone now.