### PR TITLE
Fix stm32f3 README about what module to use for STM32F318 and STM32F378

### DIFF
--- a/stm32_part_table.yaml
+++ b/stm32_part_table.yaml
@@ -125,6 +125,7 @@ stm32f3:
     rm_url: https://www.st.com/resource/en/reference_manual/dm00094350.pdf
     members:
       - STM32F301
+      - STM32F318
 
   stm32f302:
     url: https://www.st.com/en/microcontrollers-microprocessors/stm32f302.html
@@ -149,6 +150,7 @@ stm32f3:
     rm_url: https://www.st.com/resource/en/reference_manual/dm00041563.pdf
     members:
       - STM32F373
+      - STM32F378
 
   stm32f3x4:
     url: https://www.st.com/en/microcontrollers-microprocessors/stm32f334.html
@@ -164,10 +166,8 @@ stm32f3:
     rm_title: STM32F303xB/C/D/E, STM32F303x6/8, STM32F328x8, STM32F358xC, STM32F398xE
     rm_url: https://www.st.com/resource/en/reference_manual/dm00043574.pdf
     members:
-      - STM32F318
       - STM32F328
       - STM32F358
-      - STM32F378
       - STM32F398
 
 

--- a/stm32f3/README.md
+++ b/stm32f3/README.md
@@ -38,9 +38,9 @@ https://docs.rs/svd2rust/0.15.0/svd2rust/#peripheral-api
 
 | Module | Devices | Links |
 |:------:|:-------:|:-----:|
-| stm32f301 | STM32F301 | [RM0366](https://www.st.com/resource/en/reference_manual/dm00094350.pdf), [st.com](https://www.st.com/en/microcontrollers-microprocessors/stm32f301.html) |
+| stm32f301 | STM32F301, STM32F318 | [RM0366](https://www.st.com/resource/en/reference_manual/dm00094350.pdf), [st.com](https://www.st.com/en/microcontrollers-microprocessors/stm32f301.html) |
 | stm32f302 | STM32F302 | [RM0365](https://www.st.com/resource/en/reference_manual/dm00094349.pdf), [st.com](https://www.st.com/en/microcontrollers-microprocessors/stm32f302.html) |
 | stm32f303 | STM32F303 | [RM0316](https://www.st.com/resource/en/reference_manual/dm00043574.pdf), [st.com](https://www.st.com/en/microcontrollers-microprocessors/stm32f303.html) |
-| stm32f373 | STM32F373 | [RM0313](https://www.st.com/resource/en/reference_manual/dm00041563.pdf), [st.com](https://www.st.com/en/microcontrollers-microprocessors/stm32f373.html) |
+| stm32f373 | STM32F373, STM32F378 | [RM0313](https://www.st.com/resource/en/reference_manual/dm00041563.pdf), [st.com](https://www.st.com/en/microcontrollers-microprocessors/stm32f373.html) |
 | stm32f3x4 | STM32F334 | [RM0364](https://www.st.com/resource/en/reference_manual/dm00093941.pdf), [st.com](https://www.st.com/en/microcontrollers-microprocessors/stm32f334.html) |
-| stm32f3x8 | STM32F318, STM32F328, STM32F358, STM32F378, STM32F398 | [RM0316](https://www.st.com/resource/en/reference_manual/dm00043574.pdf), [st.com](https://www.st.com/en/microcontrollers-microprocessors/stm32f3x8.html) |
+| stm32f3x8 | STM32F328, STM32F358, STM32F398 | [RM0316](https://www.st.com/resource/en/reference_manual/dm00043574.pdf), [st.com](https://www.st.com/en/microcontrollers-microprocessors/stm32f3x8.html) |


### PR DESCRIPTION
STM32F318 is documented in RM0366 and not in RM0316 so it should use
the stm32f301 module.

STM32F378 is documented in RM0313 and not in RM0316 so it should use
the stm32f373 module.

This was already applied in ef858ad but was missing the
stm32_part_table.yaml change so it was overwritten when
makecrates.py was executed again.