### PR TITLE
Correct bit offset for enabling TIM3 in RCC/APB1ENR

### DIFF
--- a/devices/stm32l0x1.yaml
+++ b/devices/stm32l0x1.yaml
@@ -84,6 +84,10 @@ RCC:
     _modify:
       CRYPTSMEN:
         name: CRYPSMEN
+  APB1ENR:
+    _modify:
+      TIM3EN:
+        bitOffset: 1
 
 WWDG:
   _modify:


### PR DESCRIPTION
The bit offset for enabling the clock for TIM3 in RCC is incorrect for stm32l0x1 targets. It should be bit 1 instead of bit 2. 

Tested on an stm32l051. 