### PR TITLE
improve copy_peripheral() to support copying from another svd file

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,13 @@ _copy:
     ADC3:
         from: ADC2
 
+# The new peripheral can also be copied from another svd file for a different
+# device. This is useful when a peripheral is missing in a device but the exact
+# same peripheral already exist in another device.
+_copy:
+    TIM1:
+        from: ../svd/stm32f302.svd:TIM1
+
 # Replace peripheral registers by a 'deriveFrom'.
 # This is used when e.g. UART4 and UART5 are both independently defined,
 # but you'd like to make UART5 be defined as derivedFrom UART4 instead.

--- a/devices/stm32f301.yaml
+++ b/devices/stm32f301.yaml
@@ -1,5 +1,9 @@
 _svd: ../svd/stm32f301.svd
 
+_copy:
+  TIM1:
+    from: ../svd/stm32f302.svd:TIM1
+
 _add:
   I2C3:
     derivedFrom: I2C1
@@ -84,6 +88,7 @@ _include:
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim2345_mixed.yaml
  - common_patches/tim/tim2345_mixed.yaml
+ - ../peripherals/tim/tim_advanced.yaml
  - ../peripherals/rcc/rcc_f3.yaml
  - ../peripherals/rcc/rcc_f3_i2s.yaml
  - ../peripherals/rcc/rcc_pllsrc_1bit.yaml

--- a/devices/stm32f3x8.yaml
+++ b/devices/stm32f3x8.yaml
@@ -1,5 +1,9 @@
 _svd: ../svd/stm32f3x8.svd
 
+_copy:
+  ADC1:
+    from: ../svd/stm32f303.svd:ADC1
+
 RCC:
   CFGR:
     _delete:
@@ -143,6 +147,7 @@ _include:
  - ./common_patches/merge_I2C_OAR1_OA1x_fields.yaml
  - ./common_patches/merge_USART_CR2_ADDx_fields.yaml
  - ./common_patches/merge_USART_BRR_fields.yaml
+ - ./common_patches/f3_adc.yaml
  - ./common_patches/f3_rcc.yaml
  - ./common_patches/f3_rcc_mco.yaml
  - ./common_patches/f3_rcc_usb.yaml
@@ -194,3 +199,4 @@ _include:
  - ../peripherals/tim/tim_ccm_v1.yaml
  - ../peripherals/comp/comp_f3.yaml
  - ../peripherals/opamp/opamp_f3.yaml
+ - ../peripherals/adc/adc_v3_f3.yaml


### PR DESCRIPTION
Some svd files are missing entirely a peripheral or contains a totally wrong description of a peripheral, while the correct peripheral already exists in another svd file.
This PR allows copying a peripheral from one svd file to another.
This new feature is applied to fix stm32f301 TIM1 and stm32f3x8 ADC1.