### PR TITLE
Fix SYSCFG CFGR3 register fields

### DIFF
--- a/devices/common_patches/l0_syscfg_cfgr.yaml
+++ b/devices/common_patches/l0_syscfg_cfgr.yaml
@@ -36,12 +36,12 @@ SYSCFG:
       - ENBUF_BGAP_ADC
       - EN_BGAP
     _add:
-      # REF_LOCK is wrongly marked as writeable
+      # REF_LOCK is wrongly marked as write-only, but it's "rs" - read/set
       REF_LOCK:
         description: SYSCFG_CFGR3 lock bit
         bitOffset: 31
         bitWidth: 1
-        access: read-only
+        access: read-write
       ENBUF_VREFINT_COMP2:
         description: VREFINT reference for COMP2 scaler enable bit
         bitOffset: 12

--- a/devices/common_patches/l0_syscfg_cfgr.yaml
+++ b/devices/common_patches/l0_syscfg_cfgr.yaml
@@ -26,6 +26,7 @@ SYSCFG:
       - FWDISEN
   CFGR3:
     _delete:
+      - REF_LOCK
       - VREFINT_COMP_RDYF
       - VREFINT_ADC_RDYF
       - SENSOR_ADC_RDYF
@@ -35,6 +36,12 @@ SYSCFG:
       - ENBUF_BGAP_ADC
       - EN_BGAP
     _add:
+      # REF_LOCK is wrongly marked as writeable
+      REF_LOCK:
+        description: SYSCFG_CFGR3 lock bit
+        bitOffset: 31
+        bitWidth: 1
+        access: read-only
       ENBUF_VREFINT_COMP2:
         description: VREFINT reference for COMP2 scaler enable bit
         bitOffset: 12

--- a/devices/stm32l0x1.yaml
+++ b/devices/stm32l0x1.yaml
@@ -67,7 +67,7 @@ RCC:
       I2C3:
         name: I2C3RST
   CCIPR:
-    _merge: 
+    _merge:
       - "LPTIM1SEL*"
       - "I2C3SEL*"
       - "I2C1SEL*"

--- a/devices/stm32l0x2.yaml
+++ b/devices/stm32l0x2.yaml
@@ -63,7 +63,7 @@ RCC:
       CSSLSEON:
         name: CSSHSEON
   CCIPR:
-    _merge: 
+    _merge:
       - "LPTIM1SEL*"
       - "I2C1SEL*"
       - "LPUART1SEL*"
@@ -77,6 +77,14 @@ RCC:
     _modify:
       TM12RST:
         name: TIM22RST
+
+SYSCFG:
+  CFGR3:
+    _add:
+      ENREF_HSI48:
+        description: VREFINT reference for HSI48 oscillator enable bit
+        bitOffset: 13
+        bitWidth: 1
 
 PWR:
   CR:

--- a/devices/stm32l0x3.yaml
+++ b/devices/stm32l0x3.yaml
@@ -89,6 +89,14 @@ RCC:
       TM12RST:
         name: TIM22RST
 
+SYSCFG:
+  CFGR3:
+    _add:
+      ENREF_HSI48:
+        description: VREFINT reference for HSI48 oscillator enable bit
+        bitOffset: 13
+        bitWidth: 1
+
 PWR:
   CR:
     _add:


### PR DESCRIPTION
I have compared the result against all 3 reference manuals and it looks
correct.

`ENREF_HSI48` was accidentally removed in #293, but it's only absent from the l0x1, not the others.