### PR TITLE
Add COMP2 and COMP4_6 interrupts for STM32F3x4

### DIFF
--- a/devices/common_patches/f3_comp1234567.yaml
+++ b/devices/common_patches/f3_comp1234567.yaml
@@ -4,6 +4,10 @@ _include:
 
 COMP:
   _add:
+    _interrupts:
+      COMP7:
+        description: COMP7 interrupt combined with EXTI line 33
+        value: 66
     COMP3_CSR:
       description: control and status register
       addressOffset: 0x24

--- a/devices/common_patches/f3_comp246.yaml
+++ b/devices/common_patches/f3_comp246.yaml
@@ -6,6 +6,13 @@ _add:
       offset: 0
       size: 0x400
       usage: registers
+    interrupts:
+      COMP1_2_3:
+        description: COMP1_2_3 interrupt combined with EXTI lines 21, 22, 29
+        value: 64
+      COMP4_5_6:
+        description: COMP4_5_6 interrupt combined with EXTI lines 30, 31, 32
+        value: 65
     registers:
       COMP2_CSR:
         description: control and status register

--- a/devices/stm32f303.yaml
+++ b/devices/stm32f303.yaml
@@ -22,6 +22,11 @@ RCC:
         name: UART5EN
 
 SYSCFG:
+  _delete:
+    _interrupts:
+      - "COMP*"
+
+SYSCFG:
   _strip:
     - SYSCFG_
   _add:

--- a/devices/stm32f373.yaml
+++ b/devices/stm32f373.yaml
@@ -46,6 +46,11 @@ SYSCFG:
       - BYP_ADD_PAR
 
 COMP:
+  _add:
+    _interrupts:
+      COMP1_2_3:
+        description: COMP1_2_3 interrupt combined with EXTI lines 21, 22
+        value: 64
   CSR:
     _add:
       COMP1_INP_DAC:
@@ -53,6 +58,11 @@ COMP:
         bitOffset: 1
         bitWidth: 1
         access: read-write
+
+CAN:
+  _delete:
+    _interrupts:
+      - COMP1_2
 
 _include:
  - common_patches/4_nvic_prio_bits.yaml

--- a/devices/stm32f3x8.yaml
+++ b/devices/stm32f3x8.yaml
@@ -232,6 +232,11 @@ SYSCFG:
         bitOffset: 8
         bitWidth: 2
 
+EXTI:
+  _delete:
+    _interrupts:
+      - COMP7
+
 _include:
  - common_patches/4_nvic_prio_bits.yaml
  - ./common_patches/merge_I2C_CR2_SADDx_fields.yaml


### PR DESCRIPTION
To-do: check other devices using `common_patches/f3_comp246` to see if they also require these interrupts.