### PR TITLE
Fix access of FLASH_SR.EOP in STM32L0

### DIFF
--- a/devices/common_patches/l0_flash.yaml
+++ b/devices/common_patches/l0_flash.yaml
@@ -1,5 +1,5 @@
-# Fix Write Protection for L0 Flash
 "FLASH":
+  # Fix Write Protection for L0 Flash
   _delete:
     - WRPR
   _add:
@@ -25,3 +25,8 @@
           description: Write Protection
           bitOffset: 0
           bitWidth: 16
+  # Fix write permissions of EOP field
+  SR:
+    _modify:
+      EOP:
+        access: read-write


### PR DESCRIPTION
I need some help getting this over the finish line. When I try to build the crates according to the instructions in README, I get this when executing `make svd2rust`:
```
python3 scripts/makedeps.py devices/stm32l0x1.yaml > .deps/stm32l0x1.d
python3 scripts/makedeps.py devices/stm32l0x3.yaml > .deps/stm32l0x3.d
python3 scripts/makedeps.py devices/stm32l0x2.yaml > .deps/stm32l0x2.d
python3 scripts/svdpatch.py devices/stm32l0x3.yaml
python3 scripts/svdpatch.py devices/stm32l0x1.yaml
python3 scripts/svdpatch.py devices/stm32l0x2.yaml
Traceback (most recent call last):
  File "scripts/svdpatch.py", line 893, in <module>
    main()
  File "scripts/svdpatch.py", line 889, in main
    svd.write(svdpath_out)
  File "/usr/lib/python3.8/xml/etree/ElementTree.py", line 772, in write
    serialize(write, self._root, qnames, namespaces,
  File "/usr/lib/python3.8/xml/etree/ElementTree.py", line 937, in _serialize_xml
    _serialize_xml(write, e, qnames, None,
  File "/usr/lib/python3.8/xml/etree/ElementTree.py", line 937, in _serialize_xml
    _serialize_xml(write, e, qnames, None,
  File "/usr/lib/python3.8/xml/etree/ElementTree.py", line 937, in _serialize_xml
    _serialize_xml(write, e, qnames, None,
  [Previous line repeated 2 more times]
  File "/usr/lib/python3.8/xml/etree/ElementTree.py", line 935, in _serialize_xml
    write(_escape_cdata(text))
TypeError: write() argument must be str, not collections.OrderedDict
make: *** [Makefile:39: svd/stm32l0x1.svd.patched] Error 1
make: *** Waiting for unfinished jobs....
Traceback (most recent call last):
  File "scripts/svdpatch.py", line 893, in <module>
    main()
  File "scripts/svdpatch.py", line 889, in main
    svd.write(svdpath_out)
  File "/usr/lib/python3.8/xml/etree/ElementTree.py", line 772, in write
    serialize(write, self._root, qnames, namespaces,
  File "/usr/lib/python3.8/xml/etree/ElementTree.py", line 937, in _serialize_xml
    _serialize_xml(write, e, qnames, None,
  File "/usr/lib/python3.8/xml/etree/ElementTree.py", line 937, in _serialize_xml
    _serialize_xml(write, e, qnames, None,
  File "/usr/lib/python3.8/xml/etree/ElementTree.py", line 937, in _serialize_xml
    _serialize_xml(write, e, qnames, None,
  [Previous line repeated 2 more times]
  File "/usr/lib/python3.8/xml/etree/ElementTree.py", line 935, in _serialize_xml
    write(_escape_cdata(text))
TypeError: write() argument must be str, not collections.OrderedDict
make: *** [Makefile:39: svd/stm32l0x2.svd.patched] Error 1
Traceback (most recent call last):
  File "scripts/svdpatch.py", line 893, in <module>
    main()
  File "scripts/svdpatch.py", line 889, in main
    svd.write(svdpath_out)
  File "/usr/lib/python3.8/xml/etree/ElementTree.py", line 772, in write
    serialize(write, self._root, qnames, namespaces,
  File "/usr/lib/python3.8/xml/etree/ElementTree.py", line 937, in _serialize_xml
    _serialize_xml(write, e, qnames, None,
  File "/usr/lib/python3.8/xml/etree/ElementTree.py", line 937, in _serialize_xml
    _serialize_xml(write, e, qnames, None,
  File "/usr/lib/python3.8/xml/etree/ElementTree.py", line 937, in _serialize_xml
    _serialize_xml(write, e, qnames, None,
  [Previous line repeated 2 more times]
  File "/usr/lib/python3.8/xml/etree/ElementTree.py", line 935, in _serialize_xml
    write(_escape_cdata(text))
TypeError: write() argument must be str, not collections.OrderedDict
make: *** [Makefile:39: svd/stm32l0x3.svd.patched] Error 1
```

I have no idea what's happening. To the best of my knowledge, what I'm doing follows what I've seen in the other YAML files. Does someone know what I'm doing wrong here?