### PR TITLE
stm32l4x1: Fix incorrect label APB1ENR1 bit 14 as SPI1EN to SPI2EN

### DIFF
--- a/devices/stm32l4x1.yaml
+++ b/devices/stm32l4x1.yaml
@@ -1,12 +1,17 @@
 _svd: ../svd/stm32l4x1.svd
 
 # SVD incorrectly labels APB1ENR1 bit 18 as USART1EN instead of USART3EN.
+# SVD incorrectly labels APB1ENR1 bit 14 as SPI1EN instead of SPI2EN.
 RCC:
   APB1ENR1:
     _modify:
       USART1EN:
         name: USART3EN
         description: USART3 clock enable
+    _modify:
+      SPI1EN:
+        name: SPI2EN
+        description: SPI peripheral 2 clock enable
 
 # Merge the thousands of individal bit fields into a single field for each
 # CAN filter register. This is not only much easier to use but also saves


### PR DESCRIPTION
See [the reference manual](https://www.st.com/content/ccc/resource/technical/document/reference_manual/group0/b0/ac/3e/8f/6d/21/47/af/DM00151940/files/DM00151940.pdf/jcr:content/translations/en.DM00151940.pdf) on page 221, bit 14. In the SVD this is mislabeled as SPI1EN.