### PR TITLE
stm32h7: fix EXTI access for single core parts

### DIFF
--- a/devices/common_patches/h7_exti_singlecore.yaml
+++ b/devices/common_patches/h7_exti_singlecore.yaml
@@ -1,0 +1,6 @@
+# H7 EXTI module, for single core parts
+
+EXTI:
+  _modify:
+    CPUPR2,CPUIMR3,CPUEMR3,CPUPR3:
+      access: read-write

--- a/devices/stm32h743.yaml
+++ b/devices/stm32h743.yaml
@@ -8,6 +8,7 @@ _include:
  - common_patches/fsmc/fsmc_sdram_cluster.yaml
  - common_patches/h7_rcc_src_sel.yaml
  - common_patches/h7_ethernet_desc.yaml
+ - common_patches/h7_exti_singlecore.yaml
  - common_patches/h7_dbgmcu.yaml
  - common_patches/h7_dmamux.yaml
  - common_patches/h7_adc.yaml

--- a/devices/stm32h743v.yaml
+++ b/devices/stm32h743v.yaml
@@ -8,6 +8,7 @@ _include:
  - common_patches/fsmc/fsmc_sdram_cluster.yaml
  - common_patches/h7_rcc_src_sel.yaml
  - common_patches/h7_ethernet_desc.yaml
+ - common_patches/h7_exti_singlecore.yaml
  - common_patches/h7_dbgmcu.yaml
  - common_patches/h7_dmamux.yaml
  - common_patches/h7_adc.yaml

--- a/devices/stm32h753.yaml
+++ b/devices/stm32h753.yaml
@@ -18,6 +18,7 @@ _include:
  - common_patches/fsmc/fsmc_sdram_cluster.yaml
  - common_patches/h7_rcc_src_sel.yaml
  - common_patches/h7_ethernet_desc.yaml
+ - common_patches/h7_exti_singlecore.yaml
  - common_patches/h7_dbgmcu.yaml
  - common_patches/h7_dmamux.yaml
  - common_patches/h7_adc.yaml

--- a/devices/stm32h753v.yaml
+++ b/devices/stm32h753v.yaml
@@ -18,6 +18,7 @@ _include:
  - common_patches/fsmc/fsmc_sdram_cluster.yaml
  - common_patches/h7_rcc_src_sel.yaml
  - common_patches/h7_ethernet_desc.yaml
+ - common_patches/h7_exti_singlecore.yaml
  - common_patches/h7_dbgmcu.yaml
  - common_patches/h7_dmamux.yaml
  - common_patches/h7_adc.yaml


### PR DESCRIPTION
See RM0433 19.6.24 onwards