### PR TITLE
[RFC] rcc: Use largest integer instead of 0 when possible

### DIFF
--- a/peripherals/rcc/rcc_common.yaml
+++ b/peripherals/rcc/rcc_common.yaml
@@ -19,13 +19,13 @@ RCC:
       "On": [1, "Clock On"]
   CFGR:
     PPRE*:
-      Div1: [0, "HCLK not divided"] # Same for [0, 8]
+      Div1: [3, "HCLK not divided"] # Same for [0, 8]
       Div2: [4, "HCLK divided by 2"]
       Div4: [5, "HCLK divided by 4"]
       Div8: [6, "HCLK divided by 8"]
       Div16: [7, "HCLK divided by 16"]
     HPRE:
-      Div1: [0, "SYSCLK not divided"] # Same for [0, 7]
+      Div1: [7, "SYSCLK not divided"] # Same for [0, 7]
       Div2: [8, "SYSCLK divided by 2"]
       Div4: [9, "SYSCLK divided by 4"]
       Div8: [10, "SYSCLK divided by 8"]

--- a/peripherals/rcc/rcc_f3.yaml
+++ b/peripherals/rcc/rcc_f3.yaml
@@ -12,7 +12,7 @@ _include:
 RCC:
   CFGR2:
     "ADC*PRES":
-      NoClock: [0, "No clock"] # Same for [0, 15]
+      NoClock: [15, "No clock"] # Same for [0, 15]
       Div1: [16, "PLL clock not divided"]
       Div2: [17, "PLL clock divided by 2"]
       Div4: [18, "PLL clock divided by 4"]

--- a/peripherals/rcc/rcc_f373.yaml
+++ b/peripherals/rcc/rcc_f373.yaml
@@ -16,7 +16,7 @@ RCC:
       Div6: [2, "PCLK divided by 6"]
       Div8: [3, "PCLK divided by 8"]
     SDPRE:
-      Div2: [0, "SYSCLK divided by 2"] # Same for [0, 16]
+      Div2: [16, "SYSCLK divided by 2"] # Same for [0, 16]
       Div4: [17, "SYSCLK divided by 4"]
       Div6: [18, "SYSCLK divided by 6"]
       Div8: [19, "SYSCLK divided by 8"]

--- a/peripherals/rcc/rcc_v2.yaml
+++ b/peripherals/rcc/rcc_v2.yaml
@@ -24,7 +24,7 @@ RCC:
       HSE: [2, "HSE oscillator clock selected"]
       PLL: [3, "PLL clock selected"]
     "MCO*PRE":
-      Div1: [0, "No division"]
+      Div1: [3, "No division"] # Same for [0, 3]
       Div2: [4, "Division by 2"]
       Div3: [5, "Division by 3"]
       Div4: [6, "Division by 4"]

--- a/peripherals/rcc/rcc_v3_h7_ccip.yaml
+++ b/peripherals/rcc/rcc_v3_h7_ccip.yaml
@@ -6,7 +6,7 @@
 RCC:
   D1CFGR:
     "D?CPRE,HPRE":
-      Div1: [0, "sys_ck not divided"]
+      Div1: [7, "sys_ck not divided"] # Same for [0, 7]
       Div2: [8, "sys_ck divided by 2"]
       Div4: [9, "sys_ck divided by 4"]
       Div8: [10, "sys_ck divided by 8"]


### PR DESCRIPTION
Often times, PLL values are used to calculate the clock frequency in HAL
implementation. See:

https://github.com/stm32-rs/stm32f1xx-hal/blob/bd54507245dcff38319a055e35ac70e22e1724ad/src/rcc.rs#L191-L211

or

https://github.com/stm32-rs/stm32f3xx-hal/blob/668bae491d13a4e31d1a309ad9c40b180247724a/src/rcc.rs#L252-L266

This is done, with subtracting the offset first, and then using the resulting PLL as the divisor.

Porting this, using the variants, introduced with version `0.9.0`, could look
like this:

https://github.com/Sh3Rm4n/stm32f3xx-hal/blob/717b54dd0a2b4787d85fd6d09cdffd3caea88f3b/src/rcc.rs#L293-L313

With this change, it could be written like this:

```rust
let hpre_div_value = u8::from(hpre_div) - 7;
```

And without having to track the offset, this would also be possible:

```rust
let hpre_div_value = u8::from(hpre_div) - u8::from(rcc::cfgr::HPRE_A::DIV1);
```

This makes the enumeration and conversion to `u8` more consistent, imo.