### PR TITLE
Fixed F0 line number of NVIC prio bits

### DIFF
--- a/devices/stm32f0x0.yaml
+++ b/devices/stm32f0x0.yaml
@@ -68,4 +68,4 @@ _include:
  - common_patches/f0_ram_parity_check.yaml
  - ../peripherals/flash/flash_f0.yaml
  - ../peripherals/tim/tim_ccm_v1.yaml
- 
+ - ./common_patches/2_nvic_prio_bits.yaml

--- a/devices/stm32f0x1.yaml
+++ b/devices/stm32f0x1.yaml
@@ -67,4 +67,4 @@ _include:
  - common_patches/f0_ram_parity_check.yaml
  - ../peripherals/flash/flash_f04x_f09x.yaml
  - ../peripherals/tim/tim_ccm_v1.yaml
- 
+ - ./common_patches/2_nvic_prio_bits.yaml

--- a/devices/stm32f0x2.yaml
+++ b/devices/stm32f0x2.yaml
@@ -85,3 +85,4 @@ _include:
  - common_patches/f0_ram_parity_check.yaml
  - ../peripherals/flash/flash_f04x_f09x.yaml
  - ../peripherals/tim/tim_ccm_v1.yaml
+ - ./common_patches/2_nvic_prio_bits.yaml

--- a/devices/stm32f0x8.yaml
+++ b/devices/stm32f0x8.yaml
@@ -60,3 +60,4 @@ _include:
  - common_patches/f0_ram_parity_check.yaml
  - ../peripherals/flash/flash_f04x_f09x.yaml
  - ../peripherals/tim/tim_ccm_v1.yaml
+ - ./common_patches/2_nvic_prio_bits.yaml


### PR DESCRIPTION
This is a fix of the number of NVIC prio bits in the F0 line of MCUs.
This breaks RTFM (related issue: https://github.com/rtfm-rs/cortex-m-rtfm/issues/287), but this PR should fix it.

Closes https://github.com/stm32-rs/stm32-rs/issues/324