### PR TITLE
Cleanup needless nvicPrioBits patching

### DIFF
--- a/devices/stm32f745.yaml
+++ b/devices/stm32f745.yaml
@@ -110,7 +110,6 @@ CRYP:
       - "IV*"
 
 _include:
- - common_patches/4_nvic_prio_bits.yaml
  - common_patches/f7_interrupts.yaml
  - common_patches/f7_lptim_interrupt.yaml
  - common_patches/f7_ltdc_interrupts.yaml

--- a/devices/stm32f765.yaml
+++ b/devices/stm32f765.yaml
@@ -119,7 +119,6 @@ CRYP:
       - "IV*"
 
 _include:
- - common_patches/4_nvic_prio_bits.yaml
  - common_patches/f7_interrupts.yaml
  - common_patches/f7_lptim_interrupt.yaml
  - common_patches/f7_ltdc_interrupts.yaml

--- a/devices/stm32f7x2.yaml
+++ b/devices/stm32f7x2.yaml
@@ -13,7 +13,6 @@ _modify:
     name: ADC_Common
 
 _include:
- - common_patches/4_nvic_prio_bits.yaml
  - common_patches/f7x23_pllsai.yaml
  - common_patches/dma_fcr_wo.yaml
  - ./common_patches/merge_USART_CR1_DEATx_fields.yaml

--- a/devices/stm32f7x3.yaml
+++ b/devices/stm32f7x3.yaml
@@ -23,7 +23,6 @@ WWDG:
       name: SR
 
 _include:
- - common_patches/4_nvic_prio_bits.yaml
  - common_patches/f7x23_pllsai.yaml
  - common_patches/dma_fcr_wo.yaml
  - ./common_patches/merge_USART_CR1_DEATx_fields.yaml

--- a/devices/stm32f7x6.yaml
+++ b/devices/stm32f7x6.yaml
@@ -101,7 +101,6 @@ CRYP:
       - "IV*"
 
 _include:
- - common_patches/4_nvic_prio_bits.yaml
  - common_patches/f7_interrupts.yaml
  - common_patches/f7_lptim_interrupt.yaml
  - common_patches/f7_ltdc_interrupts.yaml

--- a/devices/stm32f7x7.yaml
+++ b/devices/stm32f7x7.yaml
@@ -265,7 +265,6 @@ CRYP:
       - "IV*"
 
 _include:
- - common_patches/4_nvic_prio_bits.yaml
  - common_patches/rename_ltcd.yaml
  - common_patches/f7_interrupts.yaml
  - common_patches/f7_ltdc_interrupts.yaml

--- a/devices/stm32f7x9.yaml
+++ b/devices/stm32f7x9.yaml
@@ -260,7 +260,6 @@ LTDC:
         value: 89
 
 _include:
- - common_patches/4_nvic_prio_bits.yaml
  - common_patches/rename_ltcd.yaml
  - common_patches/f7_interrupts.yaml
  - common_patches/f7_lptim_interrupt.yaml

--- a/devices/stm32h743.yaml
+++ b/devices/stm32h743.yaml
@@ -2,7 +2,6 @@ _svd: ../svd/stm32h743.svd
 
 _include:
  - common_patches/h7_common_singlecore.yaml
- - common_patches/4_nvic_prio_bits.yaml
  - common_patches/dma_fcr_wo.yaml
  - common_patches/dma/dma_v3.yaml
  - common_patches/fsmc/fsmc_sdram_cluster.yaml

--- a/devices/stm32h743v.yaml
+++ b/devices/stm32h743v.yaml
@@ -2,7 +2,6 @@ _svd: ../svd/stm32h743v.svd
 
 _include:
  - common_patches/h7_common_singlecore.yaml
- - common_patches/4_nvic_prio_bits.yaml
  - common_patches/dma_fcr_wo.yaml
  - common_patches/dma/dma_v3.yaml
  - common_patches/fsmc/fsmc_sdram_cluster.yaml

--- a/devices/stm32h747cm7.yaml
+++ b/devices/stm32h747cm7.yaml
@@ -7,7 +7,6 @@ _delete:
 
 _include:
  - common_patches/h7_common_dualcore.yaml
- - common_patches/4_nvic_prio_bits.yaml
  - common_patches/dma_fcr_wo.yaml
  - common_patches/dma/dma_v3.yaml
  - common_patches/fsmc/fsmc_sdram_cluster.yaml

--- a/devices/stm32h753.yaml
+++ b/devices/stm32h753.yaml
@@ -12,7 +12,6 @@ CRYP:
 
 _include:
  - common_patches/h7_common_singlecore.yaml
- - common_patches/4_nvic_prio_bits.yaml
  - common_patches/dma_fcr_wo.yaml
  - common_patches/dma/dma_v3.yaml
  - common_patches/fsmc/fsmc_sdram_cluster.yaml

--- a/devices/stm32h753v.yaml
+++ b/devices/stm32h753v.yaml
@@ -12,7 +12,6 @@ CRYP:
 
 _include:
  - common_patches/h7_common_singlecore.yaml
- - common_patches/4_nvic_prio_bits.yaml
  - common_patches/dma_fcr_wo.yaml
  - common_patches/dma/dma_v3.yaml
  - common_patches/fsmc/fsmc_sdram_cluster.yaml

--- a/devices/stm32h757cm7.yaml
+++ b/devices/stm32h757cm7.yaml
@@ -14,7 +14,6 @@ CRYP:
 
 _include:
  - common_patches/h7_common_dualcore.yaml
- - common_patches/4_nvic_prio_bits.yaml
  - common_patches/dma_fcr_wo.yaml
  - common_patches/dma/dma_v3.yaml
  - common_patches/fsmc/fsmc_sdram_cluster.yaml


### PR DESCRIPTION
All those SVDs already have their nvicPrioBits set to 4 so there is no
need to patch them.