### PR TITLE
Correct stm32g4 comparator register offsets.

### DIFF
--- a/devices/common_patches/g4_comp.yaml
+++ b/devices/common_patches/g4_comp.yaml
@@ -1,0 +1,10 @@
+COMP:
+  _modify:
+    COMP_C4CSR:
+      addressOffset: '0x0C'
+    COMP_C5CSR:
+      addressOffset: '0x10'
+    COMP_C6CSR:
+      addressOffset: '0x14'
+    COMP_C7CSR:
+      addressOffset: '0x18'

--- a/devices/stm32g431.yaml
+++ b/devices/stm32g431.yaml
@@ -4,3 +4,4 @@ _include:
  - ./common_patches/g4_rcc.yaml
  - ./common_patches/g4_exti.yaml
  - ../peripherals/exti/exti.yaml
+ - ./common_patches/g4_comp.yaml

--- a/devices/stm32g441.yaml
+++ b/devices/stm32g441.yaml
@@ -4,3 +4,4 @@ _include:
  - ./common_patches/g4_rcc.yaml
  - ./common_patches/g4_exti.yaml
  - ../peripherals/exti/exti.yaml
+ - ./common_patches/g4_comp.yaml

--- a/devices/stm32g471.yaml
+++ b/devices/stm32g471.yaml
@@ -4,3 +4,4 @@ _include:
  - ./common_patches/g4_rcc.yaml
  - ./common_patches/g4_exti.yaml
  - ../peripherals/exti/exti.yaml
+ - ./common_patches/g4_comp.yaml

--- a/devices/stm32g473.yaml
+++ b/devices/stm32g473.yaml
@@ -4,3 +4,4 @@ _include:
  - ./common_patches/g4_rcc.yaml
  - ./common_patches/g4_exti.yaml
  - ../peripherals/exti/exti.yaml
+ - ./common_patches/g4_comp.yaml

--- a/devices/stm32g474.yaml
+++ b/devices/stm32g474.yaml
@@ -4,3 +4,4 @@ _include:
  - ./common_patches/g4_rcc.yaml
  - ./common_patches/g4_exti.yaml
  - ../peripherals/exti/exti.yaml
+ - ./common_patches/g4_comp.yaml

--- a/devices/stm32g483.yaml
+++ b/devices/stm32g483.yaml
@@ -4,3 +4,4 @@ _include:
  - ./common_patches/g4_rcc.yaml
  - ./common_patches/g4_exti.yaml
  - ../peripherals/exti/exti.yaml
+ - ./common_patches/g4_comp.yaml

--- a/devices/stm32g484.yaml
+++ b/devices/stm32g484.yaml
@@ -4,3 +4,4 @@ _include:
  - ./common_patches/g4_rcc.yaml
  - ./common_patches/g4_exti.yaml
  - ../peripherals/exti/exti.yaml
+ - ./common_patches/g4_comp.yaml


### PR DESCRIPTION
Thanks for all your work on this project, it's really cool to be able to write Rust on microcontrollers!

In my YAML patch I quoted the offsets so they're written out as hex in the generated SVD to match section 23.6.2 in STM reference manual RM440:

![image](https://user-images.githubusercontent.com/147919/74368849-41526a80-4d89-11ea-9c80-9ceb40c3d52d.png)

I've verified that the patch works to correct COMP6 on an stm32g474 nucleo board.