### PR TITLE
Split SOF in DMAMUX.CSR. Closes #317.

### DIFF
--- a/devices/common_patches/h7_dmamux.yaml
+++ b/devices/common_patches/h7_dmamux.yaml
@@ -10,3 +10,5 @@
     _split: [OF]
   RGCFR:
     _split: [COF]
+  CSR:
+    _split: [SOF]


### PR DESCRIPTION
@richardeoin, would you mind having a very quick look at this? #317 noticed that SOF is not split, and we already split a bunch of similar fields, so it seems OK.