### PR TITLE
Add descriptions for STM32G4 ADC registers

### DIFF
--- a/devices/common_patches/g4_adc.yaml
+++ b/devices/common_patches/g4_adc.yaml
@@ -1,0 +1,383 @@
+ADC?:
+  ISR:
+    _modify:
+      JQOVF:
+        description: Injected context queue overflow
+      AWD3:
+        description: Analog watchdog 3 flag
+      AWD2:
+        description: Analog watchdog 2 flag
+      AWD1:
+        description: Analog watchdog 1 flag
+      JEOS:
+        description: Injected channel end of sequence flag
+      JEOC: 
+        description: Injected channel end of conversion flag
+      OVR:
+        description: ADC overrun
+      EOS:
+        description: End of regular sequence flag
+      EOC:
+        description: End of conversion flag
+      EOSMP:
+        description: End of sampling flag
+      ADRDY:
+        description: ADC ready
+  
+  IER:
+    _modify:
+      JQOVFIE:
+        description: Injected context queue overflow interrupt enable
+      AWD3IE:
+        description: Analog watchdog 3 interrupt enable
+      AWD2IE:
+        description: Analog watchdog 2 interrupt enable
+      AWD1IE:
+        description: Analog watchdog 1 interrupt enable
+      JEOSIE:
+        description: End of injected sequence of conversions interrupt enable
+      JEOCIE: 
+        description: End of injected conversion interrupt enable
+      OVRIE:
+        description: Overrun interrupt enable
+      EOSIE:
+        description: End of regular sequence of conversions interrupt enable
+      EOCIE:
+        description: End of regular conversion interrupt enable
+      EOSMPIE:
+        description: End of sampling flag interrupt enable for regular conversions
+      ADRDYIE:
+        description: ADC ready interrupt enable
+  
+  CR:
+    _modify:
+      ADCAL:
+        description: ADC calibration
+      ADCALDIF:
+        description: Differential mode for calibration
+      DEEPPWD:
+        description: Deep-power-down enable
+      ADVREGEN:
+        description: ADC voltage regulator enable
+      JADSTP:
+        description: ADC stop of injected conversion command
+      ADSTP:
+        description: ADC stop of regular conversion command
+      JADSTART:
+        description: ADC start of injected conversion
+      ADSTART:
+        description: ADC start of regular conversion
+      ADDIS:
+        description: ADC disable command
+      ADEN:
+        description: ADC enable control
+
+  CFGR:
+    _delete:
+      - ALIGN_5
+    _modify:
+      AWDCH1CH:
+        name: AWD1CH
+        description: Analog watchdog 1 channel selection
+      JAUTO:
+        description: Automatic injected group conversion
+      JAWD1EN:
+        description: Analog watchdog 1 enable on injected channels
+      AWD1EN:
+        description: Analog watchdog 1 enable on regular channels
+      AWD1SGL:
+        description: Enable the watchdog 1 on a single channel or on all channels
+      JQM:
+        description: JSQR queue mode
+      JDISCEN:
+        description: Discontinuous mode on injected channels
+      DISCNUM:
+        description: Discontinuous mode channel count
+      DISCEN:
+        description: Discontinuous mode for regular channels
+      ALIGN:
+        description: Data alignment
+      AUTDLY:
+        description: Delayed conversion mode
+      CONT:
+        description: Single / continuous conversion mode for regular conversions
+      OVRMOD:
+        description: Overrun mode
+      EXTEN:
+        description: External trigger enable and polarity selection for regular channels
+      EXTSEL:
+        description: External trigger selection for regular group
+        bitOffset: 5
+        bitWidth: 5
+      RES:
+        description: Data resolution
+      DMACFG:
+        description: Direct memory access configuration
+      DMAEN:
+        description: Direct memory access enable
+  
+  CFGR2:
+    _modify:
+      SMPTRIG:
+        description: Sampling time control trigger mode
+      BULB:
+        description: Bulb sampling mode
+      SWTRIG:
+        description: Software trigger bit for sampling time control trigger mode
+      GCOMP:
+        description: Gain compensation mode
+      ROVSM:
+        description: Regular Oversampling mode
+      TROVS:
+        description: Triggered Regular Oversampling
+      OVSS:
+        description: Oversampling shift
+      OVSR:
+        description: Oversampling ratio
+      JOVSE:
+        description: Injected Oversampling Enable
+      ROVSE:
+        description: Regular Oversampling Enable
+
+  SMPR1:
+    _modify:
+      SMPPLUS:
+        description: Addition of one clock cycle to the sampling time
+      SMP9:
+        description: Channel 9 sampling time selection
+      SMP8:
+        description: Channel 8 sampling time selection
+      SMP7:
+        description: Channel 7 sampling time selection
+      SMP6:
+        description: Channel 6 sampling time selection
+      SMP5:
+        description: Channel 5 sampling time selection
+      SMP4:
+        description: Channel 4 sampling time selection
+      SMP3:
+        description: Channel 3 sampling time selection
+      SMP2:
+        description: Channel 2 sampling time selection
+      SMP1:
+        description: Channel 1 sampling time selection
+      SMP0:
+        description: Channel 0 sampling time selection
+
+  SMPR2:
+    _modify:
+      SMP18:
+        description: Channel 18 sampling time selection
+      SMP17:
+        description: Channel 17 sampling time selection
+      SMP16:
+        description: Channel 16 sampling time selection
+      SMP15:
+        description: Channel 15 sampling time selection
+      SMP14:
+        description: Channel 14 sampling time selection
+      SMP13:
+        description: Channel 13 sampling time selection
+      SMP11:
+        description: Channel 12 sampling time selection
+      SMP12:
+        description: Channel 11 sampling time selection
+      SMP10:
+        description: Channel 10 sampling time selection
+  
+  TR1:
+    _modify:
+      HT1:
+        description: Analog watchdog 1 higher threshold
+      AWDFILT:
+        description: Analog watchdog filtering parameter
+      LT1:
+        description: Analog watchdog 1 lower threshold
+  
+  TR2:
+    _modify:
+      HT2:
+        description: Analog watchdog 2 higher threshold
+      LT2:
+        description: Analog watchdog 2 lower threshold
+
+  TR3:
+    _modify:
+      HT3:
+        description: Analog watchdog 3 higher threshold
+      LT3:
+        description: Analog watchdog 3 lower threshold
+
+  SQR1:
+    _modify:
+      SQ4:
+        description: 4th conversion in regular sequence
+      SQ3:
+        description: 3rd conversion in regular sequence
+      SQ2:
+        description: 2nd conversion in regular sequence
+      SQ1:
+        description: 1st conversion in regular sequence
+      L:
+        description: Regular channel sequence length
+  
+  SQR2:
+    _modify:
+      SQ9:
+        description: 9th conversion in regular sequence
+      SQ8:
+        description: 8th conversion in regular sequence
+      SQ7:
+        description: 7th conversion in regular sequence
+      SQ6:
+        description: 6th conversion in regular sequence
+      SQ5:
+        description: 5th conversion in regular sequence
+
+  SQR3:
+    _modify:
+      SQ14:
+        description: 14th conversion in regular sequence
+      SQ13:
+        description: 13th conversion in regular sequence
+      SQ12:
+        description: 12th conversion in regular sequence
+      SQ11:
+        description: 11th conversion in regular sequence
+      SQ10:
+        description: 10th conversion in regular sequence
+
+  SQR4:
+    _modify:
+      SQ16:
+        description: 16th conversion in regular sequence
+      SQ15:
+        description: 15th conversion in regular sequence
+
+  JSQR:
+    _modify:
+      SQ4:
+        description: 4th conversion in the injected sequence
+      JSQ3:
+        description: 3rd conversion in the injected sequence
+      JSQ2:
+        description: 2nd conversion in the injected sequence
+      JSQ1:
+        description: 1st conversion in the injected sequence
+      JEXTEN:
+        description: External Trigger Enable and Polarity Selection for injected channels
+      JEXTSEL:
+        description: External Trigger Selection for injected group
+      JL:
+        description: Injected channel sequence length
+
+  OFR1:
+    _modify:
+      OFFSET1_EN:
+        description: Offset 1 Enable
+      OFFSET1_CH:
+        description: Channel selection for the data offset 1
+      SATEN:
+        description: Saturation enable
+      OFFSETPOS:
+        description: Positive offset
+      OFFSET1:
+        description: Data offset 1 for the channel programmed into bits OFFSET1_CH
+  
+  OFR2:
+    _modify:
+      OFFSET1_EN:
+        name: OFFSET2_EN
+        description: Offset 2 Enable
+      OFFSET1_CH:
+        name: OFFSET2_CH
+        description: Channel selection for the data offset 2
+      SATEN:
+        description: Saturation enable
+      OFFSETPOS:
+        description: Positive offset
+      OFFSET1:
+        name: OFFSET2
+        description: Data offset 2 for the channel programmed into bits OFFSET2_CH
+  
+  OFR3:
+    _modify:
+      OFFSET1_EN:
+        name: OFFSET3_EN
+        description: Offset 3 Enable
+      OFFSET1_CH:
+        name: OFFSET3_CH
+        description: Channel selection for the data offset 3
+      SATEN:
+        description: Saturation enable
+      OFFSETPOS:
+        description: Positive offset
+      OFFSET1:
+        name: OFFSET3
+        description: Data offset 3 for the channel programmed into bits OFFSET3_CH
+
+  OFR4:
+    _modify:
+      OFFSET1_EN:
+        name: OFFSET4_EN
+        description: Offset 4 Enable
+      OFFSET1_CH:
+        name: OFFSET4_CH
+        description: Channel selection for the data offset 4
+      SATEN:
+        description: Saturation enable
+      OFFSETPOS:
+        description: Positive offset
+      OFFSET1:
+        name: OFFSET4
+        description: Data offset 4 for the channel programmed into bits OFFSET4_CH
+
+  JDR1:
+    _modify:
+      JDATA1:
+        name: JDATA
+        description: Injected data
+  JDR2:
+    _modify:
+      JDATA2:
+        name: JDATA
+        description: Injected data
+  
+  JDR3:
+    _modify:
+      JDATA3:
+        name: JDATA
+        description: Injected data
+
+  JDR4:
+    _modify:
+      JDATA4:
+        name: JDATA
+        description: Injected data
+  
+  AWD2CR:
+    _modify:
+      AWD2CH:
+        description: Analog watchdog 2 channel selection
+
+  AWD3CR:
+    _modify:
+      AWD3CH:
+        description: Analog watchdog 3 channel selection
+
+  DIFSEL:
+    _modify:
+      DIFSEL:
+        description: Differential mode for channels 18 to 0
+  
+  CALFACT:
+    _modify:
+      CALFACT_D:
+        description: Calibration Factors in differential mode
+      CALFACT_S:
+        description: Calibration Factors In single-ended mode
+
+  GCOMP:
+    _modify:
+      GCOMPCOEFF:
+        description: Gain compensation coefficient

--- a/devices/common_patches/g4_adc_common.yaml
+++ b/devices/common_patches/g4_adc_common.yaml
@@ -1,11 +1,9 @@
 ADC*_*:
   CCR:
-    _add:
-      VBATEN:
-        description: V_BAT battery voltage channel selection
-        bitWidth: 1
-        bitOffset: 24
-      VSENSEEN:
+    _modify:
+      CH17SEL:
+        name: VSENSESEL
         description: V_TS temperature sensor channel selection
-        bitWidth: 1
-        bitOffset: 23
+      CH18SEL:
+        name: VBATSEL
+        description: V_BAT battery voltage channel selection

--- a/devices/common_patches/g4_adc_common.yaml
+++ b/devices/common_patches/g4_adc_common.yaml
@@ -1,0 +1,11 @@
+ADC*_*:
+  CCR:
+    _add:
+      VBATEN:
+        description: V_BAT battery voltage channel selection
+        bitWidth: 1
+        bitOffset: 24
+      VSENSEEN:
+        description: V_TS temperature sensor channel selection
+        bitWidth: 1
+        bitOffset: 23

--- a/devices/stm32g431.yaml
+++ b/devices/stm32g431.yaml
@@ -3,5 +3,10 @@ _svd: ../svd/stm32g431.svd
 _include:
  - ./common_patches/g4_rcc.yaml
  - ./common_patches/g4_exti.yaml
+ - ./common_patches/g4_adc_common.yaml
  - ../peripherals/exti/exti.yaml
+ - ../peripherals/adc/adc_v3_g4.yaml
+ - ../peripherals/adc/adc_v3_common_g4.yaml
  - ./common_patches/g4_comp.yaml
+ - ./common_patches/g4_adc.yaml
+ 

--- a/devices/stm32g431.yaml
+++ b/devices/stm32g431.yaml
@@ -9,4 +9,3 @@ _include:
  - ../peripherals/adc/adc_v3_common_g4.yaml
  - ./common_patches/g4_comp.yaml
  - ./common_patches/g4_adc.yaml
- 

--- a/devices/stm32g441.yaml
+++ b/devices/stm32g441.yaml
@@ -3,5 +3,10 @@ _svd: ../svd/stm32g441.svd
 _include:
  - ./common_patches/g4_rcc.yaml
  - ./common_patches/g4_exti.yaml
+ - ./common_patches/g4_adc_common.yaml
  - ../peripherals/exti/exti.yaml
+ - ../peripherals/adc/adc_v3_g4.yaml
+ - ../peripherals/adc/adc_v3_common_g4.yaml
  - ./common_patches/g4_comp.yaml
+ - ./common_patches/g4_adc.yaml
+ 

--- a/devices/stm32g471.yaml
+++ b/devices/stm32g471.yaml
@@ -3,5 +3,10 @@ _svd: ../svd/stm32g471.svd
 _include:
  - ./common_patches/g4_rcc.yaml
  - ./common_patches/g4_exti.yaml
+ - ./common_patches/g4_adc_common.yaml
  - ../peripherals/exti/exti.yaml
+ - ../peripherals/adc/adc_v3_g4.yaml
+ - ../peripherals/adc/adc_v3_common_g4.yaml
  - ./common_patches/g4_comp.yaml
+ - ./common_patches/g4_adc.yaml
+ 

--- a/devices/stm32g473.yaml
+++ b/devices/stm32g473.yaml
@@ -3,5 +3,10 @@ _svd: ../svd/stm32g473.svd
 _include:
  - ./common_patches/g4_rcc.yaml
  - ./common_patches/g4_exti.yaml
+ - ./common_patches/g4_adc_common.yaml
  - ../peripherals/exti/exti.yaml
+ - ../peripherals/adc/adc_v3_g4.yaml
+ - ../peripherals/adc/adc_v3_common_g4.yaml
  - ./common_patches/g4_comp.yaml
+ - ./common_patches/g4_adc.yaml
+ 

--- a/devices/stm32g474.yaml
+++ b/devices/stm32g474.yaml
@@ -3,5 +3,10 @@ _svd: ../svd/stm32g474.svd
 _include:
  - ./common_patches/g4_rcc.yaml
  - ./common_patches/g4_exti.yaml
+ - ./common_patches/g4_adc_common.yaml
  - ../peripherals/exti/exti.yaml
+ - ../peripherals/adc/adc_v3_g4.yaml
+ - ../peripherals/adc/adc_v3_common_g4.yaml
  - ./common_patches/g4_comp.yaml
+ - ./common_patches/g4_adc.yaml
+ 

--- a/devices/stm32g483.yaml
+++ b/devices/stm32g483.yaml
@@ -3,5 +3,10 @@ _svd: ../svd/stm32g483.svd
 _include:
  - ./common_patches/g4_rcc.yaml
  - ./common_patches/g4_exti.yaml
+ - ./common_patches/g4_adc_common.yaml
  - ../peripherals/exti/exti.yaml
+ - ../peripherals/adc/adc_v3_g4.yaml
+ - ../peripherals/adc/adc_v3_common_g4.yaml
  - ./common_patches/g4_comp.yaml
+ - ./common_patches/g4_adc.yaml
+ 

--- a/devices/stm32g484.yaml
+++ b/devices/stm32g484.yaml
@@ -3,5 +3,10 @@ _svd: ../svd/stm32g484.svd
 _include:
  - ./common_patches/g4_rcc.yaml
  - ./common_patches/g4_exti.yaml
+ - ./common_patches/g4_adc_common.yaml
  - ../peripherals/exti/exti.yaml
+ - ../peripherals/adc/adc_v3_g4.yaml
+ - ../peripherals/adc/adc_v3_common_g4.yaml
  - ./common_patches/g4_comp.yaml
+ - ./common_patches/g4_adc.yaml
+ 

--- a/peripherals/adc/adc_v3_common_f3_single.yaml
+++ b/peripherals/adc/adc_v3_common_f3_single.yaml
@@ -3,6 +3,9 @@
 
 "ADC*_*":
   CCR:
+    VBATEN:
+      Disabled: [0, "V_BAT channel disabled"]
+      Enabled: [1, "V_BAT channel enabled"]
     TSEN:
       Disabled: [0, "Temperature sensor channel disabled"]
       Enabled: [1, "Temperature sensor channel enabled"]

--- a/peripherals/adc/adc_v3_common_g4.yaml
+++ b/peripherals/adc/adc_v3_common_g4.yaml
@@ -1,0 +1,10 @@
+# ADC_Common with G4 specific fields
+
+_include:
+  - "adc_v3_common.yaml"
+
+"ADC*_*":
+  CCR:
+    VSENSEEN:
+      Disabled: [0, "Temperature sensor channel disabled"]
+      Enabled: [1, "Temperature sensor channel enabled"]

--- a/peripherals/adc/adc_v3_common_g4.yaml
+++ b/peripherals/adc/adc_v3_common_g4.yaml
@@ -5,6 +5,9 @@ _include:
 
 "ADC*_*":
   CCR:
-    VSENSEEN:
+    VBATSEL:
+      Disabled: [0, "V_BAT channel disabled"]
+      Enabled: [1, "V_BAT channel enabled"]
+    VSENSESEL:
       Disabled: [0, "Temperature sensor channel disabled"]
       Enabled: [1, "Temperature sensor channel enabled"]

--- a/peripherals/adc/adc_v3_common_h7.yaml
+++ b/peripherals/adc/adc_v3_common_h7.yaml
@@ -8,6 +8,9 @@ _include:
     VSENSEEN:
       Disabled: [0, "Temperature sensor channel disabled"]
       Enabled: [1, "Temperature sensor channel enabled"]
+    VBATEN:
+      Disabled: [0, "V_BAT channel disabled"]
+      Enabled: [1, "V_BAT channel enabled"]
     PRESC:
       Div1: [0, "adc_ker_ck_input not divided"]
       Div2: [1, "adc_ker_ck_input divided by 2"]

--- a/peripherals/adc/adc_v3_common_single.yaml
+++ b/peripherals/adc/adc_v3_common_single.yaml
@@ -31,9 +31,6 @@
       NotReady: [0, "ADC is not ready to start conversion"]
       Ready: [1, "ADC is ready to start conversion"]
   CCR:
-    VBATEN:
-      Disabled: [0, "V_BAT channel disabled"]
-      Enabled: [1, "V_BAT channel enabled"]
     VREFEN:
       Disabled: [0, "V_REFINT channel disabled"]
       Enabled: [1, "V_REFINT channel enabled"]

--- a/peripherals/adc/adc_v3_g4.yaml
+++ b/peripherals/adc/adc_v3_g4.yaml
@@ -9,9 +9,8 @@ _include:
       - "DIFSEL*"
   CR:
     ADVREGEN:
-      Intermediate: [0, "Intermediate state required when moving the ADC voltage regulator between states"]
+      Disabled: [0, "ADC voltage regulator disabled"]
       Enabled: [1, "ADC voltage regulator enabled"]
-      Disabled: [2, "ADC voltage regulator disabled"]
     DEEPPWD:
       Disabled: [0, ADC not in Deep-power down]
       Enabled: [1, ADC in Deep-power-down (default reset state)]
@@ -40,17 +39,14 @@ _include:
       Enabled: [1, "DMA enabled"]
   "CFGR2":
     SMPTRIG:
-      Disabled: [0, Sampling time not controlled by trigger]
-      Enabled: [1, Sampling time controlled by hardware or software trigger]
+      Disabled: [0, Sampling time control trigger mode disabled]
+      Enabled: [1, Sampling time control trigger mode enabled]
     BULB:
       Disabled: [0, Bulb sampling mode disabled]
       Enabled: [1, "Bulb sampling mode enabled. Immediately start sampling after last conversion finishes."]
     SWTRIG:
       Disabled: [0, End sampling period and start conversion]
       Enabled: [1, Start sampling period]
-    SMPTRIG:
-      Disabled: [0, Sampling time not controlled by HW or SW trigger]
-      Enabled: [1, Sampling time controlled by HW or SW trigger]
     GCOMP:
       Disabled: [0, Regular ADC operating mode]
       Enabled: [1, Gain compensation enabled and applies to all channels]
@@ -60,8 +56,25 @@ _include:
     TROVS:
       Automatic: [0, "All oversampled conversions for a channel are run following a trigger"]
       Triggered: [1, "Each oversampled conversion for a channel needs a new trigger"]
-    OVSS: [0, 11]
-    OVSR: [0, 7]
+    OVSS:
+      NoShift: [0, "No right shift applied to oversampling result"]
+      Shift1: [1, "Shift oversampling result right by 1 bit"]
+      Shift2: [2, "Shift oversampling result right by 2 bits"]
+      Shift3: [3, "Shift oversampling result right by 3 bits"]
+      Shift4: [4, "Shift oversampling result right by 4 bits"]
+      Shift5: [5, "Shift oversampling result right by 5 bits"]
+      Shift6: [6, "Shift oversampling result right by 6 bits"]
+      Shift7: [7, "Shift oversampling result right by 7 bits"]
+      Shift8: [8, "Shift oversampling result right by 8 bits"]
+    OVSR:
+      OS2: [0, "Oversampling ratio of 2"]
+      OS4: [1, "Oversampling ratio of 4"]
+      OS8: [2, "Oversampling ratio of 8"]
+      OS16: [3, "Oversampling ratio of 16"]
+      OS32: [4, "Oversampling ratio of 32"]
+      OS64: [5, "Oversampling ratio of 64"]
+      OS128: [6, "Oversampling ratio of 128"]
+      OS256: [7, "Oversampling ratio of 256"]
     JOVSE:
       Disabled: [0, "Injected oversampling disabled"]
       Enabled: [1, "Injected oversampling enabled"]
@@ -70,18 +83,18 @@ _include:
       Enabled: [1, "Regular oversampling enabled"]
   "SMPR1":
     "SMPPLUS":
-      Cycles2_5: [0, "2.5 ADC clock cycles"]
-      Cycles3_5: [1, "3.5 ADC clock cycles"]
+      Normal: [0, "2.5 in SMPR remains 2.5 cycles"]
+      Plus1: [1, "2.5 in SMPR becomes 3.5 cycles"]
   "SMPR?":
     "SMP*":
-      Cycles1_5: [0, "1.5 ADC clock cycles"]
-      Cycles2_5: [1, "2.5 ADC clock cycles"]
-      Cycles4_5: [2, "4.5 ADC clock cycles"]
-      Cycles7_5: [3, "7.5 ADC clock cycles"]
-      Cycles19_5: [4, "19.5 ADC clock cycles"]
-      Cycles61_5: [5, "61.5 ADC clock cycles"]
-      Cycles181_5: [6, "181.5 ADC clock cycles"]
-      Cycles601_5: [7, "601.5 ADC clock cycles"]
+      Cycles2_5: [0, "2.5 ADC clock cycles"]
+      Cycles6_5: [1, "6.5 ADC clock cycles"]
+      Cycles12_5: [2, "12.5 ADC clock cycles"]
+      Cycles24_5: [3, "24.5 ADC clock cycles"]
+      Cycles47_5: [4, "47.5 ADC clock cycles"]
+      Cycles92_5: [5, "92.5 ADC clock cycles"]
+      Cycles247_5: [6, "247.5 ADC clock cycles"]
+      Cycles640_5: [7, "640.5 ADC clock cycles"]
   "TR?":
     "HT?": [0, 0xFFF]
     "LT?": [0, 0xFFF]

--- a/peripherals/adc/adc_v3_g4.yaml
+++ b/peripherals/adc/adc_v3_g4.yaml
@@ -1,0 +1,95 @@
+# ADC v3 with G4 specific fields
+
+_include:
+  - "adc_v3.yaml"
+
+"ADC,ADC?":
+  DIFSEL:
+    _merge:
+      - "DIFSEL*"
+  CR:
+    ADVREGEN:
+      Intermediate: [0, "Intermediate state required when moving the ADC voltage regulator between states"]
+      Enabled: [1, "ADC voltage regulator enabled"]
+      Disabled: [2, "ADC voltage regulator disabled"]
+    DEEPPWD:
+      Disabled: [0, ADC not in Deep-power down]
+      Enabled: [1, ADC in Deep-power-down (default reset state)]
+
+  CFGR:
+    JQDIS:
+      Enabled: [0, Injected Queue enabled]
+      Disabled: [1, Injected Queue disabled]
+    AWD1CH: [0, 18]
+    EXTSEL:
+      HRTIM_ADCTRG1: [7, "HRTIM_ADCTRG1 event"]
+      HRTIM_ADCTRG3: [8, "HRTIM_ADCTRG3 event"]
+    ALIGN:
+      Right: [0, "Right alignment"]
+      Left: [1, "Left alignment"]
+    RES:
+      Bits12: [0, "12-bit"]
+      Bits10: [1, "10-bit"]
+      Bits8: [2, "8-bit"]
+      Bits6: [3, "6-bit"]
+    DMACFG:
+      OneShot: [0, "DMA One Shot Mode selected"]
+      Circular: [1, "DMA circular mode selected"]
+    DMAEN:
+      Disabled: [0, "DMA disabled"]
+      Enabled: [1, "DMA enabled"]
+  "CFGR2":
+    SMPTRIG:
+      Disabled: [0, Sampling time not controlled by trigger]
+      Enabled: [1, Sampling time controlled by hardware or software trigger]
+    BULB:
+      Disabled: [0, Bulb sampling mode disabled]
+      Enabled: [1, "Bulb sampling mode enabled. Immediately start sampling after last conversion finishes."]
+    SWTRIG:
+      Disabled: [0, End sampling period and start conversion]
+      Enabled: [1, Start sampling period]
+    SMPTRIG:
+      Disabled: [0, Sampling time not controlled by HW or SW trigger]
+      Enabled: [1, Sampling time controlled by HW or SW trigger]
+    GCOMP:
+      Disabled: [0, Regular ADC operating mode]
+      Enabled: [1, Gain compensation enabled and applies to all channels]
+    ROVSM:
+      Continued: [0, "Oversampling is temporary stopped and continued after injection sequence"]
+      Resumed: [1, "Oversampling is aborted and resumed from start after injection sequence"]
+    TROVS:
+      Automatic: [0, "All oversampled conversions for a channel are run following a trigger"]
+      Triggered: [1, "Each oversampled conversion for a channel needs a new trigger"]
+    OVSS: [0, 11]
+    OVSR: [0, 7]
+    JOVSE:
+      Disabled: [0, "Injected oversampling disabled"]
+      Enabled: [1, "Injected oversampling enabled"]
+    ROVSE:
+      Disabled: [0, "Regular oversampling disabled"]
+      Enabled: [1, "Regular oversampling enabled"]
+  "SMPR1":
+    "SMPPLUS":
+      Cycles2_5: [0, "2.5 ADC clock cycles"]
+      Cycles3_5: [1, "3.5 ADC clock cycles"]
+  "SMPR?":
+    "SMP*":
+      Cycles1_5: [0, "1.5 ADC clock cycles"]
+      Cycles2_5: [1, "2.5 ADC clock cycles"]
+      Cycles4_5: [2, "4.5 ADC clock cycles"]
+      Cycles7_5: [3, "7.5 ADC clock cycles"]
+      Cycles19_5: [4, "19.5 ADC clock cycles"]
+      Cycles61_5: [5, "61.5 ADC clock cycles"]
+      Cycles181_5: [6, "181.5 ADC clock cycles"]
+      Cycles601_5: [7, "601.5 ADC clock cycles"]
+  "TR?":
+    "HT?": [0, 0xFFF]
+    "LT?": [0, 0xFFF]
+  "OFR?":
+    "OFFSET?_EN":
+      Disabled: [0, "Offset disabled"]
+      Enabled: [1, "Offset enabled"]
+    "OFFSET?_CH": [0, 31]
+    "OFFSET?": [0, 0xFFF]
+  CALFACT:
+    "CALFACT_?": [0, 0x7F]


### PR DESCRIPTION
This adds the register descriptions for each of the ADCs in the STM32G4 series.
For now it only matches ADC1 and ADC3 because 2, 4 and 5 are sometimes and sometimes not derived from 1 and 2. Though technically they are the same peripheral.

Is there any preferred way to work around this?

Register names are not exactly as in RM0440 and lack the universal "ADC_" prefix, others seemed to omit them too so I tried to match that.