### PR TITLE
Fix DMA CR CHSEL bitWidth

### DIFF
--- a/devices/common_patches/dma/dma_v21.yaml
+++ b/devices/common_patches/dma/dma_v21.yaml
@@ -5,4 +5,4 @@ _include:
   S?CR:
     _modify:
       CHSEL:
-        bitWidth: 3
+        bitWidth: 4

--- a/devices/stm32f413.yaml
+++ b/devices/stm32f413.yaml
@@ -151,8 +151,8 @@ _include:
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/adc/adc_v2_single.yaml
- - common_patches/dma/dma_v2.yaml
- - ../peripherals/dma/dma_v2.yaml
+ - common_patches/dma/dma_v21.yaml
+ - ../peripherals/dma/dma_v21.yaml
  - ../peripherals/spi/spi_v1.yaml
  - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/usart/uart_common.yaml

--- a/devices/stm32f765.yaml
+++ b/devices/stm32f765.yaml
@@ -161,8 +161,8 @@ _include:
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/adc/adc_v2_multi.yaml
- - common_patches/dma/dma_v2.yaml
- - ../peripherals/dma/dma_v2.yaml
+ - common_patches/dma/dma_v21.yaml
+ - ../peripherals/dma/dma_v21.yaml
  - ../peripherals/spi/spi_v2.yaml
  - ../peripherals/eth/eth_dma.yaml
  - ../peripherals/eth/eth_mmc.yaml

--- a/devices/stm32f7x2.yaml
+++ b/devices/stm32f7x2.yaml
@@ -39,8 +39,8 @@ _include:
  - ../peripherals/spi/spi_v2.yaml
  - ../peripherals/adc/adc_v2_smpr.yaml
  - ../peripherals/adc/adc_v2_multi.yaml
- - common_patches/dma/dma_v2.yaml
- - ../peripherals/dma/dma_v2.yaml
+ - common_patches/dma/dma_v21.yaml
+ - ../peripherals/dma/dma_v21.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_f7.yaml
  - ../peripherals/pwr/pwr_v2.yaml

--- a/devices/stm32f7x3.yaml
+++ b/devices/stm32f7x3.yaml
@@ -49,8 +49,8 @@ _include:
  - ../peripherals/spi/spi_v2.yaml
  - ../peripherals/adc/adc_v2_smpr.yaml
  - ../peripherals/adc/adc_v2_multi.yaml
- - common_patches/dma/dma_v2.yaml
- - ../peripherals/dma/dma_v2.yaml
+ - common_patches/dma/dma_v21.yaml
+ - ../peripherals/dma/dma_v21.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_f7.yaml
  - ../peripherals/pwr/pwr_v2.yaml

--- a/devices/stm32f7x7.yaml
+++ b/devices/stm32f7x7.yaml
@@ -309,8 +309,8 @@ _include:
  - ../peripherals/spi/spi_v2.yaml
  - ../peripherals/adc/adc_v2_smpr.yaml
  - ../peripherals/adc/adc_v2_multi.yaml
- - common_patches/dma/dma_v2.yaml
- - ../peripherals/dma/dma_v2.yaml
+ - common_patches/dma/dma_v21.yaml
+ - ../peripherals/dma/dma_v21.yaml
  - ../peripherals/eth/eth_dma.yaml
  - ../peripherals/eth/eth_mmc.yaml
  - ../peripherals/eth/eth_mac.yaml

--- a/devices/stm32f7x9.yaml
+++ b/devices/stm32f7x9.yaml
@@ -304,8 +304,8 @@ _include:
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/spi/spi_v2.yaml
  - ../peripherals/adc/adc_v2_multi.yaml
- - common_patches/dma/dma_v2.yaml
- - ../peripherals/dma/dma_v2.yaml
+ - common_patches/dma/dma_v21.yaml
+ - ../peripherals/dma/dma_v21.yaml
  - ../peripherals/eth/eth_dma.yaml
  - ../peripherals/eth/eth_mmc.yaml
  - ../peripherals/eth/eth_mac.yaml

--- a/peripherals/dma/dma_v21.yaml
+++ b/peripherals/dma/dma_v21.yaml
@@ -1,0 +1,8 @@
+# DMA as used on F4 and F7
+
+_include:
+ - dma_v3.yaml
+
+"DMA?":
+  "S?CR":
+    CHSEL: [0, 15]


### PR DESCRIPTION
Some F4 and F7 have a 3 bits CHSEL and others have a 4 bits CHSEL.
This provides separate patches for the different bitWidth.