### PR TITLE
fix stm32f4 links to st website

### DIFF
--- a/stm32_part_table.yaml
+++ b/stm32_part_table.yaml
@@ -181,7 +181,7 @@ stm32f4:
       - STM32F401
 
   stm32f405:
-    url: https://www.st.com/en/microcontrollers/stm32f405-415.html
+    url: https://www.st.com/en/microcontrollers-microprocessors/stm32f405-415.html
     rm: RM0090
     rm_title: STM32F405/415, STM32F407/417, STM32F427/437 and STM32F429/439
     rm_url: https://www.st.com/resource/en/reference_manual/dm00031020.pdf
@@ -190,7 +190,7 @@ stm32f4:
       - STM32F415
 
   stm32f407:
-    url: https://www.st.com/en/microcontrollers/stm32f407-417.html
+    url: https://www.st.com/en/microcontrollers-microprocessors/stm32f407-417.html
     rm: RM0090
     rm_title: STM32F405/415, STM32F407/417, STM32F427/437 and STM32F429/439
     rm_url: https://www.st.com/resource/en/reference_manual/dm00031020.pdf
@@ -223,7 +223,7 @@ stm32f4:
       - STM32F412
 
   stm32f413:
-    url: https://www.st.com/en/microcontrollers/stm32f413-423.html
+    url: https://www.st.com/en/microcontrollers-microprocessors/stm32f413-423.html
     rm: RM0430
     rm_title: STM32F413/423
     rm_url: https://www.st.com/resource/en/reference_manual/dm00305666.pdf
@@ -232,7 +232,7 @@ stm32f4:
       - STM32F423
 
   stm32f427:
-    url: https://www.st.com/en/microcontrollers/stm32f427-437.html
+    url: https://www.st.com/en/microcontrollers-microprocessors/stm32f427-437.html
     rm: RM0090
     rm_title: STM32F405/415, STM32F407/417, STM32F427/437 and STM32F429/439
     rm_url: https://www.st.com/resource/en/reference_manual/dm00031020.pdf
@@ -241,7 +241,7 @@ stm32f4:
       - STM32F437
 
   stm32f429:
-    url: https://www.st.com/en/microcontrollers/stm32f429-439.html
+    url: https://www.st.com/en/microcontrollers-microprocessors/stm32f429-439.html
     rm: RM0090
     rm_title: STM32F405/415, STM32F407/417, STM32F427/437 and STM32F429/439
     rm_url: https://www.st.com/resource/en/reference_manual/dm00031020.pdf
@@ -258,7 +258,7 @@ stm32f4:
       - STM32F446
 
   stm32f469:
-    url: https://www.st.com/en/microcontrollers/stm32f469-479.html
+    url: https://www.st.com/en/microcontrollers-microprocessors/stm32f469-479.html
     rm: RM0386
     rm_title: STM32F469xx and STM32F479xx
     rm_url: https://www.st.com/resource/en/reference_manual/dm00127514.pdf

--- a/stm32_part_table.yaml
+++ b/stm32_part_table.yaml
@@ -181,7 +181,7 @@ stm32f4:
       - STM32F401
 
   stm32f405:
-    url: https://www.st.com/en/microcontrollers/stm32f405-microprocessors-415.html
+    url: https://www.st.com/en/microcontrollers/stm32f405-415.html
     rm: RM0090
     rm_title: STM32F405/415, STM32F407/417, STM32F427/437 and STM32F429/439
     rm_url: https://www.st.com/resource/en/reference_manual/dm00031020.pdf
@@ -190,7 +190,7 @@ stm32f4:
       - STM32F415
 
   stm32f407:
-    url: https://www.st.com/en/microcontrollers/stm32f407-microprocessors-417.html
+    url: https://www.st.com/en/microcontrollers/stm32f407-417.html
     rm: RM0090
     rm_title: STM32F405/415, STM32F407/417, STM32F427/437 and STM32F429/439
     rm_url: https://www.st.com/resource/en/reference_manual/dm00031020.pdf
@@ -223,7 +223,7 @@ stm32f4:
       - STM32F412
 
   stm32f413:
-    url: https://www.st.com/en/microcontrollers/stm32f413-microprocessors-423.html
+    url: https://www.st.com/en/microcontrollers/stm32f413-423.html
     rm: RM0430
     rm_title: STM32F413/423
     rm_url: https://www.st.com/resource/en/reference_manual/dm00305666.pdf
@@ -232,7 +232,7 @@ stm32f4:
       - STM32F423
 
   stm32f427:
-    url: https://www.st.com/en/microcontrollers/stm32f427-microprocessors-437.html
+    url: https://www.st.com/en/microcontrollers/stm32f427-437.html
     rm: RM0090
     rm_title: STM32F405/415, STM32F407/417, STM32F427/437 and STM32F429/439
     rm_url: https://www.st.com/resource/en/reference_manual/dm00031020.pdf
@@ -241,7 +241,7 @@ stm32f4:
       - STM32F437
 
   stm32f429:
-    url: https://www.st.com/en/microcontrollers/stm32f429-microprocessors-439.html
+    url: https://www.st.com/en/microcontrollers/stm32f429-439.html
     rm: RM0090
     rm_title: STM32F405/415, STM32F407/417, STM32F427/437 and STM32F429/439
     rm_url: https://www.st.com/resource/en/reference_manual/dm00031020.pdf
@@ -258,7 +258,7 @@ stm32f4:
       - STM32F446
 
   stm32f469:
-    url: https://www.st.com/en/microcontrollers/stm32f469-microprocessors-479.html
+    url: https://www.st.com/en/microcontrollers/stm32f469-479.html
     rm: RM0386
     rm_title: STM32F469xx and STM32F479xx
     rm_url: https://www.st.com/resource/en/reference_manual/dm00127514.pdf

--- a/stm32f4/README.md
+++ b/stm32f4/README.md
@@ -39,13 +39,13 @@ https://docs.rs/svd2rust/0.17.0/svd2rust/#peripheral-api
 | Module | Devices | Links |
 |:------:|:-------:|:-----:|
 | stm32f401 | STM32F401 | [RM0368](https://www.st.com/resource/en/reference_manual/dm00096844.pdf), [st.com](https://www.st.com/en/microcontrollers-microprocessors/stm32f401.html) |
-| stm32f405 | STM32F405, STM32F415 | [RM0090](https://www.st.com/resource/en/reference_manual/dm00031020.pdf), [st.com](https://www.st.com/en/microcontrollers/stm32f405-microprocessors-415.html) |
-| stm32f407 | STM32F407, STM32F417 | [RM0090](https://www.st.com/resource/en/reference_manual/dm00031020.pdf), [st.com](https://www.st.com/en/microcontrollers/stm32f407-microprocessors-417.html) |
+| stm32f405 | STM32F405, STM32F415 | [RM0090](https://www.st.com/resource/en/reference_manual/dm00031020.pdf), [st.com](https://www.st.com/en/microcontrollers-microprocessors/stm32f405-415.html) |
+| stm32f407 | STM32F407, STM32F417 | [RM0090](https://www.st.com/resource/en/reference_manual/dm00031020.pdf), [st.com](https://www.st.com/en/microcontrollers-microprocessors/stm32f407-417.html) |
 | stm32f410 | STM32F410 | [RM0401](https://www.st.com/resource/en/reference_manual/dm00180366.pdf), [st.com](https://www.st.com/en/microcontrollers-microprocessors/stm32f410.html) |
 | stm32f411 | STM32F411 | [RM0383](https://www.st.com/resource/en/reference_manual/dm00119316.pdf), [st.com](https://www.st.com/en/microcontrollers-microprocessors/stm32f411.html) |
 | stm32f412 | STM32F412 | [RM0402](https://www.st.com/resource/en/reference_manual/dm00180369.pdf), [st.com](https://www.st.com/en/microcontrollers-microprocessors/stm32f412.html) |
-| stm32f413 | STM32F413, STM32F423 | [RM0430](https://www.st.com/resource/en/reference_manual/dm00305666.pdf), [st.com](https://www.st.com/en/microcontrollers/stm32f413-microprocessors-423.html) |
-| stm32f427 | STM32F427, STM32F437 | [RM0090](https://www.st.com/resource/en/reference_manual/dm00031020.pdf), [st.com](https://www.st.com/en/microcontrollers/stm32f427-microprocessors-437.html) |
-| stm32f429 | STM32F429, STM32F439 | [RM0090](https://www.st.com/resource/en/reference_manual/dm00031020.pdf), [st.com](https://www.st.com/en/microcontrollers/stm32f429-microprocessors-439.html) |
+| stm32f413 | STM32F413, STM32F423 | [RM0430](https://www.st.com/resource/en/reference_manual/dm00305666.pdf), [st.com](https://www.st.com/en/microcontrollers-microprocessors/stm32f413-423.html) |
+| stm32f427 | STM32F427, STM32F437 | [RM0090](https://www.st.com/resource/en/reference_manual/dm00031020.pdf), [st.com](https://www.st.com/en/microcontrollers-microprocessors/stm32f427-437.html) |
+| stm32f429 | STM32F429, STM32F439 | [RM0090](https://www.st.com/resource/en/reference_manual/dm00031020.pdf), [st.com](https://www.st.com/en/microcontrollers-microprocessors/stm32f429-439.html) |
 | stm32f446 | STM32F446 | [RM0390](https://www.st.com/resource/en/reference_manual/dm00135183.pdf), [st.com](https://www.st.com/en/microcontrollers-microprocessors/stm32f446.html) |
-| stm32f469 | STM32F469, STM32F479 | [RM0386](https://www.st.com/resource/en/reference_manual/dm00127514.pdf), [st.com](https://www.st.com/en/microcontrollers/stm32f469-microprocessors-479.html) |
+| stm32f469 | STM32F469, STM32F479 | [RM0386](https://www.st.com/resource/en/reference_manual/dm00127514.pdf), [st.com](https://www.st.com/en/microcontrollers-microprocessors/stm32f469-479.html) |


### PR DESCRIPTION
Should I also update links in the [README](https://github.com/stm32-rs/stm32-rs/blob/master/stm32f4/README.md) or they are automatically generated in some way?