### PR TITLE
sai: sai_v1 patch and sai peripheral apply to H7. Fix FSDEF

### DIFF
--- a/devices/common_patches/h7_sai.yaml
+++ b/devices/common_patches/h7_sai.yaml
@@ -3,14 +3,29 @@
     _modify:
       MCKDIV:
         bitWidth: 6
+      NOMCK:
+        name: NODIV
     _add:
       MCKEN:
         description: Master clock generation enable
         bitOffset: 27
         bitWidth: 1
+  AFRCR:
+    _modify:
+      FSDEF:
+        access: read-write
   BCR1:
+    _modify:
+      MCKDIV:
+        bitWidth: 6
+      NOMCK:
+        name: NODIV
     _add:
       MCKEN:
         description: Master clock generation enable
         bitOffset: 27
         bitWidth: 1
+  BFRCR:
+    _modify:
+      FSDEF:
+        access: read-write

--- a/devices/stm32h743.yaml
+++ b/devices/stm32h743.yaml
@@ -20,6 +20,8 @@ _include:
  - common_patches/merge_USART_CR2_ADDx_fields.yaml
  - common_patches/rename_USART_CR2_DATAINV_field.yaml
  - common_patches/merge_USART_BRR_fields.yaml
+ - common_patches/h7_sai.yaml
+ - common_patches/sai/sai_v1.yaml
  - common_patches/tim/tim_o24ce.yaml
  - ../peripherals/adc/adc_v3_h7.yaml
  - ../peripherals/adc/adc_v3_common_h7.yaml
@@ -50,3 +52,4 @@ _include:
  - ../peripherals/usart/usart_v2B1.yaml
  - common_patches/tim/tim_ccr.yaml
  - ../peripherals/tim/tim_ccm_v2.yaml
+ - ../peripherals/sai/sai.yaml

--- a/devices/stm32h743v.yaml
+++ b/devices/stm32h743v.yaml
@@ -22,6 +22,8 @@ _include:
  - common_patches/merge_USART_CR2_ADDx_fields.yaml
  - common_patches/rename_USART_CR2_DATAINV_field.yaml
  - common_patches/merge_USART_BRR_fields.yaml
+ - common_patches/h7_sai.yaml
+ - common_patches/sai/sai_v1.yaml
  - common_patches/tim/tim_o24ce.yaml
  - ../peripherals/adc/adc_v3_h7.yaml
  - ../peripherals/adc/adc_v3_common_h7.yaml
@@ -52,3 +54,4 @@ _include:
  - ../peripherals/usart/usart_v2B1.yaml
  - common_patches/tim/tim_ccr.yaml
  - ../peripherals/tim/tim_ccm_v2.yaml
+ - ../peripherals/sai/sai.yaml

--- a/devices/stm32h747cm4.yaml
+++ b/devices/stm32h747cm4.yaml
@@ -32,6 +32,7 @@ _include:
  - common_patches/h7_dualcore_flash.yaml
  - common_patches/h7_hsicfgr_csicfgr_rev_v.yaml
  - common_patches/h7_sai.yaml
+ - common_patches/sai/sai_v1.yaml
  - common_patches/flash/flash_dual_bank.yaml
  - common_patches/ltdc/ltdc.yaml
  - common_patches/merge_I2C_CR2_SADDx_fields.yaml
@@ -69,3 +70,4 @@ _include:
  - ../peripherals/usart/usart_v2B1.yaml
  - common_patches/tim/tim_ccr.yaml
  - ../peripherals/tim/tim_ccm_v2.yaml
+ - ../peripherals/sai/sai.yaml

--- a/devices/stm32h747cm7.yaml
+++ b/devices/stm32h747cm7.yaml
@@ -40,6 +40,7 @@ _include:
  - common_patches/merge_USART_CR2_ADDx_fields.yaml
  - common_patches/rename_USART_CR2_DATAINV_field.yaml
  - common_patches/merge_USART_BRR_fields.yaml
+ - common_patches/sai/sai_v1.yaml
  - common_patches/tim/tim_o24ce.yaml
  - ../peripherals/adc/adc_v3_h7.yaml
  - ../peripherals/adc/adc_v3_common_h7.yaml
@@ -70,3 +71,4 @@ _include:
  - ../peripherals/usart/usart_v2B1.yaml
  - common_patches/tim/tim_ccr.yaml
  - ../peripherals/tim/tim_ccm_v2.yaml
+ - ../peripherals/sai/sai.yaml

--- a/devices/stm32h753.yaml
+++ b/devices/stm32h753.yaml
@@ -30,6 +30,8 @@ _include:
  - common_patches/merge_USART_CR2_ADDx_fields.yaml
  - common_patches/rename_USART_CR2_DATAINV_field.yaml
  - common_patches/merge_USART_BRR_fields.yaml
+ - common_patches/h7_sai.yaml
+ - common_patches/sai/sai_v1.yaml
  - common_patches/tim/tim_o24ce.yaml
  - ../peripherals/adc/adc_v3_h7.yaml
  - ../peripherals/adc/adc_v3_common_h7.yaml
@@ -59,3 +61,4 @@ _include:
  - ../peripherals/usart/usart_v2B1.yaml
  - common_patches/tim/tim_ccr.yaml
  - ../peripherals/tim/tim_ccm_v2.yaml
+ - ../peripherals/sai/sai.yaml

--- a/devices/stm32h753v.yaml
+++ b/devices/stm32h753v.yaml
@@ -32,6 +32,8 @@ _include:
  - common_patches/merge_USART_CR2_ADDx_fields.yaml
  - common_patches/rename_USART_CR2_DATAINV_field.yaml
  - common_patches/merge_USART_BRR_fields.yaml
+ - common_patches/h7_sai.yaml
+ - common_patches/sai/sai_v1.yaml
  - common_patches/tim/tim_o24ce.yaml
  - ../peripherals/adc/adc_v3_h7.yaml
  - ../peripherals/adc/adc_v3_common_h7.yaml
@@ -62,3 +64,4 @@ _include:
  - ../peripherals/usart/usart_v2B1.yaml
  - common_patches/tim/tim_ccr.yaml
  - ../peripherals/tim/tim_ccm_v2.yaml
+ - ../peripherals/sai/sai.yaml


### PR DESCRIPTION
SAI peripheral applies to the H7 also. Note that we introduce the very slightest difference with RM0433 (single core 743/753) by setting `[AB]CR1.NOMCK` -> `[AB]CR1.NODIV`. Whilst RM0433 uses `NOMCK`, both RM0399 (later dual core parts) and `sai/sai.py` use `NODIV`.
The description in `sai/sai.py` has text from both the old and new definitions, and it appears the functionality of the bit is unchanged.

[AB]FRCR.FSDEF is marked as read only in the SVD and the register diagram in the RM. However, in the prose text in RM0399 it is clearly noted as read-write "This bit is set and cleared by software."