### PR TITLE
Correcting STM32L4 RCC registers

### DIFF
--- a/devices/stm32l4x2.yaml
+++ b/devices/stm32l4x2.yaml
@@ -2,6 +2,9 @@ _svd: ../svd/stm32l4x2.svd
 
 # SVD incorrectly labels APB1ENR1 bit 18 as USART1EN instead of USART3EN.
 # SVD incorrectly labels APB1ENR1 bit 26 as USBF instead of USBFSEN.
+# SVD incorrectly labels APB1ENR1 bit 14 as SPI1EN instead of SPI2EN.
+# SVD incorrectly omits APB1ENR1 bit 1 (TIM3RST), which is present for
+# STM32L45xx and STM32L46xx devices.
 RCC:
   APB1ENR1:
     _modify:
@@ -11,11 +14,20 @@ RCC:
       USBF:
         name: USBFSEN
         description: USB FS clock enable
+      SPI1EN:
+        name: SPI3EN
+        description: SPI3 clock enable
   APB1RSTR1:
     _modify:
       USART1RST:
         name: USART3RST
         description: USART3 reset
+    _add:
+      TIM3RST:
+        description: TIM3 timer reset
+        bitOffset: 1
+        bitWidth: 1
+        access: read-write
 
 # cf. <https://github.com/adamgreig/stm32-rs/issues/37>
 # we call the resulting peripheral `USB` instead of `USB-FS`

--- a/devices/stm32l4x2.yaml
+++ b/devices/stm32l4x2.yaml
@@ -15,8 +15,8 @@ RCC:
         name: USBFSEN
         description: USB FS clock enable
       SPI1EN:
-        name: SPI3EN
-        description: SPI3 clock enable
+        name: SPI2EN
+        description: SPI2 clock enable
   APB1RSTR1:
     _modify:
       USART1RST:


### PR DESCRIPTION
This PR fixes #349 by renaming the SPI1EN bit of `RCC_APB1ENR1` to `SPI2EN` according to the datasheet. Additionally, it adds the `TIM3RST` as bit 1 of `RCC_APB1RSTR1`.

From the [datasheet](https://www.st.com/resource/en/reference_manual/dm00151940.pdf):
![image](https://user-images.githubusercontent.com/8771450/76162195-6a251000-613b-11ea-934f-a12e130bbf67.png)

![image](https://user-images.githubusercontent.com/8771450/76162199-8032d080-613b-11ea-955a-cf0b40b8d011.png)
