### PR TITLE
Add RAMECC registers across the H7 family

### DIFF
--- a/devices/common_patches/h7_common_dualcore.yaml
+++ b/devices/common_patches/h7_common_dualcore.yaml
@@ -321,6 +321,7 @@ EXTI:
 
 _delete:
   - DMA2
+  - RAMECC?                         # RAMECC definitions are so terrible
 
 _add:
   DMA2:

--- a/devices/common_patches/ramecc/ramecc.yaml
+++ b/devices/common_patches/ramecc/ramecc.yaml
@@ -1,0 +1,83 @@
+# RAMECC
+# Strip all monitor registers of their fields, then add the correct fields
+
+"RAMECC,RAMECC?":
+  "M?CR":
+    _delete:
+      ?*:
+    _add:
+      ECCELEN:
+        description: ECC error context latching enable
+        bitOffset: 5
+        bitWidth: 1
+        access: read-write
+      ECCDEBWIE:
+        description: ECC double error on byte write interrupt enable
+        bitOffset: 4
+        bitWidth: 1
+        access: read-write
+      ECCDEIE:
+        description: ECC double error interrupt enable
+        bitOffset: 3
+        bitWidth: 1
+        access: read-write
+      ECCSEIE:
+        description: ECC single error interrupt enable
+        bitOffset: 2
+        bitWidth: 1
+        access: read-write
+  "M?SR":
+    _delete:
+      ?*:
+    _add:
+      DEBWDF:
+        description: ECC double error on byte write flag
+        bitOffset: 2
+        bitWidth: 1
+        access: read-write
+      DEDF:
+        description: ECC double error detected flag
+        bitOffset: 1
+        bitWidth: 1
+        access: read-write
+      SEDCF:
+        description: ECC single error detected flag
+        bitOffset: 0
+        bitWidth: 1
+        access: read-write
+  "M?FAR":
+    _delete:
+      ?*:
+    _add:
+      FADD:
+        description: ECC failing address
+        bitOffset: 0
+        bitWidth: 32
+        access: read-only
+  "M?FDRL":
+    _delete:
+      ?*:
+    _add:
+      FDATAL:
+        description: ECC failing data low
+        bitOffset: 0
+        bitWidth: 32
+        access: read-only
+  "M?FDRH":
+    _delete:
+      ?*:
+    _add:
+      FDATAH:
+        description: ECC failing data high
+        bitOffset: 0
+        bitWidth: 32
+        access: read-only
+  "M?FECR":
+    _delete:
+      ?*:
+    _add:
+      FEC:
+        description: ECC failing code
+        bitOffset: 0
+        bitWidth: 32
+        access: read-only

--- a/devices/common_patches/ramecc/ramecc_new.yaml
+++ b/devices/common_patches/ramecc/ramecc_new.yaml
@@ -1,0 +1,198 @@
+# RAMECC peripheral from scratch
+
+# ramecc.yaml adds monitor fields
+_include:
+  - ramecc.yaml
+
+_add:
+  RAMECC1:
+    description: RAM ECC monitoring
+    groupName: RAMECC
+    baseAddress: 0x52009000
+    interrupts:
+      RAMECC:
+        description: ECC diagnostic global interrupt for all RAMECC controllers
+        value: 145
+    registers:
+      IER:
+        description: RAMECC interrupt enable register
+        addressOffset: 0x0
+        access: read-write
+        resetValue: 0x00000000
+        fields:
+          GECCDEBWIE:
+            description: Global ECC double error on byte write interrupt enable
+            bitOffset: 3
+            bitWidth: 1
+            access: read-write
+          GECCDEIE:
+            description: Global ECC double error interrupt enable
+            bitOffset: 2
+            bitWidth: 1
+            access: read-write
+          GECCSEIE:
+            description: Global ECC single error interrupt enable
+            bitOffset: 1
+            bitWidth: 1
+            access: read-write
+          GIE:
+            description: Global interrupt enable
+            bitOffset: 0
+            bitWidth: 1
+            access: read-write
+      M1CR:
+        description: RAMECC monitor 1 configuration register
+        addressOffset: 0x20
+        access: read-write
+        resetValue: 0x00000000
+      M1SR:
+        description: RAMECC monitor 1 status register
+        addressOffset: 0x24
+        access: read-write
+        resetValue: 0x00000000
+      M1FAR:
+        description: RAMECC monitor 1 failing address register
+        addressOffset: 0x28
+        access: read-write
+        resetValue: 0x00000000
+      M1FDRL:
+        description: RAMECC monitor 1 failing data low register
+        addressOffset: 0x2C
+        access: read-write
+        resetValue: 0x00000000
+      M1FDRH:
+        description: RAMECC monitor 1 failing data high register
+        addressOffset: 0x30
+        access: read-write
+        resetValue: 0x00000000
+      M1FECR:
+        description: RAMECC monitor 1 failing error code register
+        addressOffset: 0x34
+        access: read-write
+        resetValue: 0x00000000
+      M2CR:
+        description: RAMECC monitor 2 configuration register
+        addressOffset: 0x40
+        access: read-write
+        resetValue: 0x00000000
+      M2SR:
+        description: RAMECC monitor 2 status register
+        addressOffset: 0x44
+        access: read-write
+        resetValue: 0x00000000
+      M2FAR:
+        description: RAMECC monitor 2 failing address register
+        addressOffset: 0x48
+        access: read-write
+        resetValue: 0x00000000
+      M2FDRL:
+        description: RAMECC monitor 2 failing data low register
+        addressOffset: 0x4C
+        access: read-write
+        resetValue: 0x00000000
+      M2FDRH:
+        description: RAMECC monitor 2 failing data high register
+        addressOffset: 0x50
+        access: read-write
+        resetValue: 0x00000000
+      M2FECR:
+        description: RAMECC monitor 2 failing error code register
+        addressOffset: 0x54
+        access: read-write
+        resetValue: 0x00000000
+      M3CR:
+        description: RAMECC monitor 3 configuration register
+        addressOffset: 0x60
+        access: read-write
+        resetValue: 0x00000000
+      M3SR:
+        description: RAMECC monitor 3 status register
+        addressOffset: 0x64
+        access: read-write
+        resetValue: 0x00000000
+      M3FAR:
+        description: RAMECC monitor 3 failing address register
+        addressOffset: 0x68
+        access: read-write
+        resetValue: 0x00000000
+      M3FDRL:
+        description: RAMECC monitor 3 failing data low register
+        addressOffset: 0x6C
+        access: read-write
+        resetValue: 0x00000000
+      M3FDRH:
+        description: RAMECC monitor 3 failing data high register
+        addressOffset: 0x70
+        access: read-write
+        resetValue: 0x00000000
+      M3FECR:
+        description: RAMECC monitor 3 failing error code register
+        addressOffset: 0x74
+        access: read-write
+        resetValue: 0x00000000
+      M4CR:
+        description: RAMECC monitor 4 configuration register
+        addressOffset: 0x80
+        access: read-write
+        resetValue: 0x00000000
+      M4SR:
+        description: RAMECC monitor 4 status register
+        addressOffset: 0x84
+        access: read-write
+        resetValue: 0x00000000
+      M4FAR:
+        description: RAMECC monitor 4 failing address register
+        addressOffset: 0x88
+        access: read-write
+        resetValue: 0x00000000
+      M4FDRL:
+        description: RAMECC monitor 4 failing data low register
+        addressOffset: 0x8C
+        access: read-write
+        resetValue: 0x00000000
+      M4FDRH:
+        description: RAMECC monitor 4 failing data high register
+        addressOffset: 0x90
+        access: read-write
+        resetValue: 0x00000000
+      M4FECR:
+        description: RAMECC monitor 4 failing error code register
+        addressOffset: 0x94
+        access: read-write
+        resetValue: 0x00000000
+      M5CR:
+        description: RAMECC monitor 5 configuration register
+        addressOffset: 0xA0
+        access: read-write
+        resetValue: 0x00000000
+      M5SR:
+        description: RAMECC monitor 5 status register
+        addressOffset: 0xA4
+        access: read-write
+        resetValue: 0x00000000
+      M5FAR:
+        description: RAMECC monitor 5 failing address register
+        addressOffset: 0xA8
+        access: read-write
+        resetValue: 0x00000000
+      M5FDRL:
+        description: RAMECC monitor 5 failing data low register
+        addressOffset: 0xAC
+        access: read-write
+        resetValue: 0x00000000
+      M5FDRH:
+        description: RAMECC monitor 5 failing data high register
+        addressOffset: 0xB0
+        access: read-write
+        resetValue: 0x00000000
+      M5FECR:
+        description: RAMECC monitor 5 failing error code register
+        addressOffset: 0xB4
+        access: read-write
+        resetValue: 0x00000000
+  RAMECC2:
+    derivedFrom: RAMECC1
+    baseAddress: 0x48023000
+  RAMECC3:
+    derivedFrom: RAMECC1
+    baseAddress: 0x58027000

--- a/devices/common_patches/ramecc/ramecc_new.yaml
+++ b/devices/common_patches/ramecc/ramecc_new.yaml
@@ -194,5 +194,93 @@ _add:
     derivedFrom: RAMECC1
     baseAddress: 0x48023000
   RAMECC3:
-    derivedFrom: RAMECC1
+    description: RAM ECC monitoring
+    groupName: RAMECC
     baseAddress: 0x58027000
+    registers:
+      IER:
+        description: RAMECC interrupt enable register
+        addressOffset: 0x0
+        access: read-write
+        resetValue: 0x00000000
+        fields:
+          GECCDEBWIE:
+            description: Global ECC double error on byte write interrupt enable
+            bitOffset: 3
+            bitWidth: 1
+            access: read-write
+          GECCDEIE:
+            description: Global ECC double error interrupt enable
+            bitOffset: 2
+            bitWidth: 1
+            access: read-write
+          GECCSEIE:
+            description: Global ECC single error interrupt enable
+            bitOffset: 1
+            bitWidth: 1
+            access: read-write
+          GIE:
+            description: Global interrupt enable
+            bitOffset: 0
+            bitWidth: 1
+            access: read-write
+      M1CR:
+        description: RAMECC monitor 1 configuration register
+        addressOffset: 0x20
+        access: read-write
+        resetValue: 0x00000000
+      M1SR:
+        description: RAMECC monitor 1 status register
+        addressOffset: 0x24
+        access: read-write
+        resetValue: 0x00000000
+      M1FAR:
+        description: RAMECC monitor 1 failing address register
+        addressOffset: 0x28
+        access: read-write
+        resetValue: 0x00000000
+      M1FDRL:
+        description: RAMECC monitor 1 failing data low register
+        addressOffset: 0x2C
+        access: read-write
+        resetValue: 0x00000000
+      M1FDRH:
+        description: RAMECC monitor 1 failing data high register
+        addressOffset: 0x30
+        access: read-write
+        resetValue: 0x00000000
+      M1FECR:
+        description: RAMECC monitor 1 failing error code register
+        addressOffset: 0x34
+        access: read-write
+        resetValue: 0x00000000
+      M2CR:
+        description: RAMECC monitor 2 configuration register
+        addressOffset: 0x40
+        access: read-write
+        resetValue: 0x00000000
+      M2SR:
+        description: RAMECC monitor 2 status register
+        addressOffset: 0x44
+        access: read-write
+        resetValue: 0x00000000
+      M2FAR:
+        description: RAMECC monitor 2 failing address register
+        addressOffset: 0x48
+        access: read-write
+        resetValue: 0x00000000
+      M2FDRL:
+        description: RAMECC monitor 2 failing data low register
+        addressOffset: 0x4C
+        access: read-write
+        resetValue: 0x00000000
+      M2FDRH:
+        description: RAMECC monitor 2 failing data high register
+        addressOffset: 0x50
+        access: read-write
+        resetValue: 0x00000000
+      M2FECR:
+        description: RAMECC monitor 2 failing error code register
+        addressOffset: 0x54
+        access: read-write
+        resetValue: 0x00000000

--- a/devices/stm32h743.yaml
+++ b/devices/stm32h743.yaml
@@ -23,6 +23,7 @@ _include:
  - common_patches/h7_sai.yaml
  - common_patches/sai/sai_v1.yaml
  - common_patches/tim/tim_o24ce.yaml
+ - common_patches/ramecc/ramecc_new.yaml
  - ../peripherals/adc/adc_v3_h7.yaml
  - ../peripherals/adc/adc_v3_common_h7.yaml
  - ../peripherals/adc/adc_h7_revision_y.yaml

--- a/devices/stm32h743v.yaml
+++ b/devices/stm32h743v.yaml
@@ -25,6 +25,7 @@ _include:
  - common_patches/h7_sai.yaml
  - common_patches/sai/sai_v1.yaml
  - common_patches/tim/tim_o24ce.yaml
+ - common_patches/ramecc/ramecc_new.yaml
  - ../peripherals/adc/adc_v3_h7.yaml
  - ../peripherals/adc/adc_v3_common_h7.yaml
  - ../peripherals/adc/adc_h7_revision_v.yaml

--- a/devices/stm32h747cm4.yaml
+++ b/devices/stm32h747cm4.yaml
@@ -43,6 +43,7 @@ _include:
  - common_patches/rename_USART_CR2_DATAINV_field.yaml
  - common_patches/merge_USART_BRR_fields.yaml
  - common_patches/tim/tim_o24ce.yaml
+ - common_patches/ramecc/ramecc_new.yaml
  - ../peripherals/adc/adc_v3_h7.yaml
  - ../peripherals/adc/adc_v3_common_h7.yaml
  - ../peripherals/adc/adc_h7_revision_v.yaml

--- a/devices/stm32h747cm7.yaml
+++ b/devices/stm32h747cm7.yaml
@@ -42,6 +42,7 @@ _include:
  - common_patches/merge_USART_BRR_fields.yaml
  - common_patches/sai/sai_v1.yaml
  - common_patches/tim/tim_o24ce.yaml
+ - common_patches/ramecc/ramecc_new.yaml
  - ../peripherals/adc/adc_v3_h7.yaml
  - ../peripherals/adc/adc_v3_common_h7.yaml
  - ../peripherals/adc/adc_h7_revision_v.yaml

--- a/devices/stm32h753.yaml
+++ b/devices/stm32h753.yaml
@@ -33,6 +33,7 @@ _include:
  - common_patches/h7_sai.yaml
  - common_patches/sai/sai_v1.yaml
  - common_patches/tim/tim_o24ce.yaml
+ - common_patches/ramecc/ramecc_new.yaml
  - ../peripherals/adc/adc_v3_h7.yaml
  - ../peripherals/adc/adc_v3_common_h7.yaml
  - ../peripherals/adc/adc_h7_revision_y.yaml

--- a/devices/stm32h753v.yaml
+++ b/devices/stm32h753v.yaml
@@ -35,6 +35,7 @@ _include:
  - common_patches/h7_sai.yaml
  - common_patches/sai/sai_v1.yaml
  - common_patches/tim/tim_o24ce.yaml
+ - common_patches/ramecc/ramecc_new.yaml
  - ../peripherals/adc/adc_v3_h7.yaml
  - ../peripherals/adc/adc_v3_common_h7.yaml
  - ../peripherals/adc/adc_h7_revision_v.yaml


### PR DESCRIPTION
RAMECC was 'added' to the single core parts in RM0433 Rev 7. For the dual core parts there are definitions in the SVD, but they are so terrible it's worth starting over (there are registers with the wrong address, and the wrong fields)

For a use case, there is at least one set of commercial spaceflight hardware using the H7:
(no affiliation, no endorsement intended)

- [Nanoavionics OBC](https://nanoavionics.com/cubesat-components/cubesat-on-board-computer-main-bus-unit-satbus-3c2/)