### PR TITLE
Correct the incorrect FSMC peripheral base address on the F412/F413

### DIFF
--- a/devices/stm32f412.yaml
+++ b/devices/stm32f412.yaml
@@ -17,6 +17,10 @@ _modify:
   I2C4:
     name: FMPI2C4
 
+  FSMC:
+     # ST got the base address of the FSMC peripheral wrong
+     baseAddress: "0xA0000000"
+
 CRC:
   # The SVD calls the RESET field "CR", fix per RM0402
   CR:

--- a/devices/stm32f413.yaml
+++ b/devices/stm32f413.yaml
@@ -6,6 +6,11 @@ _rebase:
   SPI1: SPI5
   USART1: USART3
 
+_modify:
+  FSMC:
+     # ST got the base address of the FSMC peripheral wrong
+     baseAddress: "0xA0000000"
+
 "SPI*":
   SR:
     _modify:


### PR DESCRIPTION
Signed-off-by: Daniel Egger <daniel@eggers-club.de>