### PR TITLE
Update makecrates to tell docs.rs to only build for one target

### DIFF
--- a/scripts/makecrates.py
+++ b/scripts/makecrates.py
@@ -58,6 +58,7 @@ version = "0.6.10"
 
 [package.metadata.docs.rs]
 features = {docs_features}
+targets = []
 
 [features]
 default = []


### PR DESCRIPTION
This should significantly reduce resource usage on docs.rs, ref #303, #3, https://github.com/rust-lang/docs.rs/issues/608