### PR TITLE
fix fpu double interrupt

### DIFF
--- a/devices/common_patches/fpu_interrupt.yaml
+++ b/devices/common_patches/fpu_interrupt.yaml
@@ -1,0 +1,11 @@
+# different microcontrollers have duplicated FPU interrupt
+
+FPU:
+  _delete:
+    _interrupts:
+      - FPU
+  _add:
+    _interrupts:
+      FPU:
+        description: Floating point unit
+        value: 81

--- a/devices/stm32f303.yaml
+++ b/devices/stm32f303.yaml
@@ -123,6 +123,7 @@ _include:
  - common_patches/tim/tim_ccr.yaml
  - ../peripherals/usb/usb.yaml
  - common_patches/f3_dbgmcu.yaml
+ - common_patches/fpu_interrupt.yaml
  - ../peripherals/tim/tim_ccm_v1.yaml
  - ../peripherals/comp/comp_f3.yaml
  - ../peripherals/opamp/opamp_f3.yaml

--- a/devices/stm32f3x4.yaml
+++ b/devices/stm32f3x4.yaml
@@ -210,16 +210,6 @@ CAN:
         description: CAN_SCE interrupt
         value: 22
 
-FPU:
-  _delete:
-    _interrupts:
-      - FPU
-  _add:
-    _interrupts:
-      FPU:
-        description: Floating point unit
-        value: 81
-
 _include:
  - common_patches/4_nvic_prio_bits.yaml
  - ./common_patches/merge_I2C_CR2_SADDx_fields.yaml
@@ -264,6 +254,7 @@ _include:
  - common_patches/tsc/tsc.yaml
  - common_patches/tim/tim_ccr.yaml
  - common_patches/f3_dbgmcu.yaml
+ - common_patches/fpu_interrupt.yaml
  - ../peripherals/tim/tim_ccm_v1.yaml
  - ../peripherals/comp/comp_f3.yaml
  - ../peripherals/opamp/opamp_f3.yaml

--- a/devices/stm32f401.yaml
+++ b/devices/stm32f401.yaml
@@ -135,4 +135,5 @@ _include:
  - common_patches/usb_otg/otg_fs_fixes_v1.yaml
  - common_patches/tim/tim_ccr.yaml
  - common_patches/dbgmcu.yaml
+ - common_patches/fpu_interrupt.yaml
  - ../peripherals/tim/tim_ccm_v1.yaml

--- a/devices/stm32f405.yaml
+++ b/devices/stm32f405.yaml
@@ -111,6 +111,7 @@ _include:
  - common_patches/usb_otg/otg_hs_fixes_v1.yaml
  - common_patches/tim/tim_ccr.yaml
  - common_patches/dbgmcu.yaml
+ - common_patches/fpu_interrupt.yaml
  - ../peripherals/tim/tim_ccm_v1.yaml
  - ../peripherals/sai/sai.yaml
  - ../peripherals/rng/rng_v1.yaml

--- a/devices/stm32f407.yaml
+++ b/devices/stm32f407.yaml
@@ -117,6 +117,7 @@ _include:
  - common_patches/usb_otg/otg_hs_fixes_v1.yaml
  - common_patches/tim/tim_ccr.yaml
  - common_patches/dbgmcu.yaml
+ - common_patches/fpu_interrupt.yaml
  - ../peripherals/tim/tim_ccm_v1.yaml
  - ../peripherals/sai/sai.yaml
  - ../peripherals/rng/rng_v1.yaml

--- a/devices/stm32f410.yaml
+++ b/devices/stm32f410.yaml
@@ -80,4 +80,5 @@ _include:
  - common_patches/rtc/rtc_bkpr.yaml
  - common_patches/tim/tim_ccr.yaml
  - common_patches/dbgmcu.yaml
+ - common_patches/fpu_interrupt.yaml
  - ../peripherals/tim/tim_ccm_v1.yaml

--- a/devices/stm32f411.yaml
+++ b/devices/stm32f411.yaml
@@ -158,4 +158,5 @@ _include:
  - common_patches/usb_otg/otg_fs_fixes_v1.yaml
  - common_patches/tim/tim_ccr.yaml
  - common_patches/dbgmcu.yaml
+ - common_patches/fpu_interrupt.yaml
  - ../peripherals/tim/tim_ccm_v1.yaml

--- a/devices/stm32f412.yaml
+++ b/devices/stm32f412.yaml
@@ -233,4 +233,5 @@ _include:
  - common_patches/usb_otg/otg_fs_remove_prefix.yaml
  - common_patches/tim/tim_ccr.yaml
  - common_patches/dbgmcu.yaml
+ - common_patches/fpu_interrupt.yaml
  - ../peripherals/tim/tim_ccm_v1.yaml

--- a/devices/stm32f413.yaml
+++ b/devices/stm32f413.yaml
@@ -174,5 +174,6 @@ _include:
  - common_patches/usb_otg/otg_fs_remove_prefix.yaml
  - common_patches/tim/tim_ccr.yaml
  - common_patches/dbgmcu.yaml
+ - common_patches/fpu_interrupt.yaml
  - ../peripherals/tim/tim_ccm_v1.yaml
  - ../peripherals/sai/sai.yaml

--- a/devices/stm32f427.yaml
+++ b/devices/stm32f427.yaml
@@ -223,6 +223,7 @@ _include:
  - common_patches/usb_otg/otg_hs_fixes_v1.yaml
  - common_patches/tim/tim_ccr.yaml
  - common_patches/dbgmcu.yaml
+ - common_patches/fpu_interrupt.yaml
  - ../peripherals/tim/tim_ccm_v1.yaml
  - ../peripherals/sai/sai.yaml
  - ../peripherals/rng/rng_v1.yaml

--- a/devices/stm32f429.yaml
+++ b/devices/stm32f429.yaml
@@ -176,6 +176,7 @@ _include:
  - common_patches/usb_otg/otg_hs_fixes_v1.yaml
  - common_patches/tim/tim_ccr.yaml
  - common_patches/dbgmcu.yaml
+ - common_patches/fpu_interrupt.yaml
  - common_patches/fsmc/fsmc_sram.yaml
  - common_patches/fsmc/fsmc_sramfix_v3.yaml
  - common_patches/fsmc/fsmc_nand_v1.yaml

--- a/devices/stm32f446.yaml
+++ b/devices/stm32f446.yaml
@@ -125,6 +125,7 @@ _include:
  - common_patches/usb_otg/otg_hs_fixes_v1.yaml
  - common_patches/tim/tim_ccr.yaml
  - common_patches/dbgmcu.yaml
+ - common_patches/fpu_interrupt.yaml
  - common_patches/fsmc/fsmc_sram.yaml
  - common_patches/fsmc/fsmc_sramfix.yaml
  - common_patches/fsmc/fsmc_nand_v1.yaml

--- a/devices/stm32f469.yaml
+++ b/devices/stm32f469.yaml
@@ -140,5 +140,6 @@ _include:
  - common_patches/usb_otg/otg_fs_remove_prefix.yaml
  - common_patches/tim/tim_ccr.yaml
  - common_patches/dbgmcu.yaml
+ - common_patches/fpu_interrupt.yaml
  - ../peripherals/tim/tim_ccm_v1.yaml
  - ../peripherals/sai/sai.yaml

--- a/devices/stm32l4x1.yaml
+++ b/devices/stm32l4x1.yaml
@@ -71,7 +71,7 @@ _include:
  - common_patches/rtc/rtc_bkpr.yaml
  - common_patches/tsc/tsc.yaml
  - common_patches/tim/tim_ccr.yaml
+ - common_patches/fpu_interrupt.yaml
  - ./common_patches/flash/flash_boot0s.yaml
  - ../peripherals/tim/tim_ccm_v2.yaml
  - ../peripherals/sai/sai.yaml
-

--- a/devices/stm32l4x2.yaml
+++ b/devices/stm32l4x2.yaml
@@ -103,6 +103,7 @@ _include:
  - common_patches/rtc/rtc_bkpr.yaml
  - common_patches/tsc/tsc.yaml
  - common_patches/tim/tim_ccr.yaml
+ - common_patches/fpu_interrupt.yaml
  - ../peripherals/usb/usb_array.yaml
  - ../peripherals/usb/usb_with_LPM.yaml
  - ./common_patches/flash/flash_boot0s.yaml


### PR DESCRIPTION
As detailed in issue #352, a lot of microcontrollers svd have a duplicated FPU interrupt entry.

This problem has already been fixed for stm32f3x4.
This commit apply this fix to all the other microcontrollers that need it.