### PR TITLE
fix fpu double interrupt for new devices

### DIFF
--- a/devices/stm32l4r5.yaml
+++ b/devices/stm32l4r5.yaml
@@ -1,0 +1,4 @@
+_svd: ../svd/stm32l4r5.svd
+
+_include:
+ - common_patches/fpu_interrupt.yaml

--- a/devices/stm32l4r7.yaml
+++ b/devices/stm32l4r7.yaml
@@ -1,0 +1,4 @@
+_svd: ../svd/stm32l4r7.svd
+
+_include:
+ - common_patches/fpu_interrupt.yaml

--- a/devices/stm32l4r9.yaml
+++ b/devices/stm32l4r9.yaml
@@ -1,0 +1,4 @@
+_svd: ../svd/stm32l4r9.svd
+
+_include:
+ - common_patches/fpu_interrupt.yaml

--- a/devices/stm32l4s5.yaml
+++ b/devices/stm32l4s5.yaml
@@ -1,0 +1,4 @@
+_svd: ../svd/stm32l4s5.svd
+
+_include:
+ - common_patches/fpu_interrupt.yaml

--- a/devices/stm32l4s7.yaml
+++ b/devices/stm32l4s7.yaml
@@ -1,0 +1,4 @@
+_svd: ../svd/stm32l4s7.svd
+
+_include:
+ - common_patches/fpu_interrupt.yaml

--- a/devices/stm32l4s9.yaml
+++ b/devices/stm32l4s9.yaml
@@ -1,0 +1,4 @@
+_svd: ../svd/stm32l4s9.svd
+
+_include:
+ - common_patches/fpu_interrupt.yaml


### PR DESCRIPTION
As detailed in issue #352, a lot of microcontrollers svd have a duplicated FPU interrupt entry.

This problem has already been fixed for all the existing microcontrollers in #357.
This commit apply the same fix to all the **new** microcontrollers that need it.