### PR TITLE
stm32f0x0 TIM1, 14-17 are all 16-bit; patch.

### DIFF
--- a/devices/common_patches/tim/tim14_16bit_l.yaml
+++ b/devices/common_patches/tim/tim14_16bit_l.yaml
@@ -1,0 +1,8 @@
+# TIM14 is 16 bit
+# tim2_common_16bit assumes four channels; TIM14 only has one
+
+# For devices where the SVD names 16bit timer fields ending "L" or "_L"
+
+TIM14:
+  _include:
+    - ./tim_1ch_16bit_l.yaml

--- a/devices/common_patches/tim/tim15_16bit_l.yaml
+++ b/devices/common_patches/tim/tim15_16bit_l.yaml
@@ -1,0 +1,8 @@
+# TIM15 is 16 bit
+# tim2_common_16bit assumes four channels; TIM15 only has two
+
+# For devices where the SVD names 16bit timer fields ending "L" or "_L"
+
+TIM15:
+  _include:
+    - ./tim_2ch_16bit_l.yaml

--- a/devices/common_patches/tim/tim16_16bit_l.yaml
+++ b/devices/common_patches/tim/tim16_16bit_l.yaml
@@ -1,0 +1,8 @@
+# TIM16 is 16 bit
+# tim2_common_16bit assumes four channels; TIM16 only has one
+
+# For devices where the SVD names 16bit timer fields ending "L" or "_L"
+
+TIM16:
+  _include:
+    - ./tim_1ch_16bit_l.yaml

--- a/devices/common_patches/tim/tim1_16bit_l.yaml
+++ b/devices/common_patches/tim/tim1_16bit_l.yaml
@@ -1,0 +1,7 @@
+# TIM1 is 16 bit
+
+# For devices where the SVD names 16bit timer fields ending "L" or "_L"
+
+TIM1:
+  _include:
+    - ./tim2_common_16bit_l.yaml

--- a/devices/common_patches/tim/tim_1ch_16bit_l.yaml
+++ b/devices/common_patches/tim/tim_1ch_16bit_l.yaml
@@ -1,0 +1,19 @@
+# 16bit timer peripheral with one channel
+# For 16bit timers where the SVD names fields ending "L" or "_L"
+# Applies to Advanced-control (ac) and General-purpose (gp) timers
+
+CNT:
+  _modify:
+    "CNT_L,CNTL":
+      name: CNT
+      description: Counter value
+ARR:
+  _modify:
+    "ARR_L,ARRL":
+      name: ARR
+      description: "Auto-reload value"
+CCR1:
+  _modify:
+    "CCR1_L,CCR1L":
+      name: CCR1
+      description: "Capture/Compare 1 value"

--- a/devices/common_patches/tim/tim_2ch_16bit_l.yaml
+++ b/devices/common_patches/tim/tim_2ch_16bit_l.yaml
@@ -1,0 +1,24 @@
+# 16bit timer peripheral with two channels
+# For 16bit timers where the SVD names fields ending "L" or "_L"
+# Applies to Advanced-control (ac) and General-purpose (gp) timers
+
+CNT:
+  _modify:
+    "CNT_L,CNTL":
+      name: CNT
+      description: Counter value
+ARR:
+  _modify:
+    "ARR_L,ARRL":
+      name: ARR
+      description: "Auto-reload value"
+CCR1:
+  _modify:
+    "CCR1_L,CCR1L":
+      name: CCR1
+      description: "Capture/Compare 1 value"
+CCR2:
+  _modify:
+    "CCR2_L,CCR2L":
+      name: CCR2
+      description: "Capture/Compare 2 value"

--- a/devices/stm32f0x0.yaml
+++ b/devices/stm32f0x0.yaml
@@ -43,8 +43,16 @@ _include:
  - ./common_patches/rename_USART_CR1_M0_field.yaml
  - ./common_patches/merge_USART_BRR_fields.yaml
  - ../peripherals/tim/tim_basic.yaml
+ - ../peripherals/tim/tim1_16bit.yaml
  - ../peripherals/tim/tim2345_16bit.yaml
+ - ../peripherals/tim/tim14_16bit.yaml
+ - ../peripherals/tim/tim15_16bit.yaml
+ - ../peripherals/tim/tim16_16bit.yaml
+ - common_patches/tim/tim1_16bit_l.yaml
  - common_patches/tim/tim2345_16bit_l.yaml
+ - common_patches/tim/tim14_16bit_l.yaml
+ - common_patches/tim/tim15_16bit_l.yaml
+ - common_patches/tim/tim16_16bit_l.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/gpio/gpio_with_brr.yaml
  - ../peripherals/crc/crc_advanced.yaml

--- a/peripherals/tim/tim14_16bit.yaml
+++ b/peripherals/tim/tim14_16bit.yaml
@@ -1,0 +1,4 @@
+# TIM14 is 16-bit with one channel
+TIM14:
+  _include:
+    - ./tim_1ch_16bit.yaml

--- a/peripherals/tim/tim15_16bit.yaml
+++ b/peripherals/tim/tim15_16bit.yaml
@@ -1,0 +1,4 @@
+# TIM15 is 16-bit with 2 channels
+TIM15:
+  _include:
+    - ./tim_2ch_16bit.yaml

--- a/peripherals/tim/tim16_16bit.yaml
+++ b/peripherals/tim/tim16_16bit.yaml
@@ -1,0 +1,4 @@
+# TIM16 is 16-bit with one channel
+TIM16:
+  _include:
+    - ./tim_1ch_16bit.yaml

--- a/peripherals/tim/tim1_16bit.yaml
+++ b/peripherals/tim/tim1_16bit.yaml
@@ -1,0 +1,4 @@
+# TIM1 is 16-bit
+TIM1:
+  _include:
+    - ./tim2_common_16bit.yaml

--- a/peripherals/tim/tim_1ch_16bit.yaml
+++ b/peripherals/tim/tim_1ch_16bit.yaml
@@ -1,0 +1,9 @@
+# 16bit timer peripheral with 1 channel
+# Applies to Advanced-control (ac) and General-purpose (gp) timers
+
+CNT:
+  CNT: [0, 65535]
+ARR:
+  ARR: [0, 65535]
+CCR1:
+  CCR1: [0, 65535]

--- a/peripherals/tim/tim_2ch_16bit.yaml
+++ b/peripherals/tim/tim_2ch_16bit.yaml
@@ -1,0 +1,11 @@
+# 16bit timer peripheral with 1 channel
+# Applies to Advanced-control (ac) and General-purpose (gp) timers
+
+CNT:
+  CNT: [0, 65535]
+ARR:
+  ARR: [0, 65535]
+CCR1:
+  CCR1: [0, 65535]
+CCR2:
+  CCR2: [0, 65535]


### PR DESCRIPTION
TIM2 through 5 already have a patch like this, but those timers (like
TIM1) have four channels.  For the 2-channel TIM15 and the 1-channel
TIM14/16/17, create a new 2ch and 1ch generic patch, and include it from
the right per-timer patch file.

This all matches the reference manual.

(I could have tried to combine all the 1-channel timers into a single
timx_16bit.yaml file, but x becomes hard to read.  141617 doesn't make
nearly as much sense as 2345 does; 1467 makes even less sense.  So I
just put them each into their own file.)