### PR TITLE
h7: Apply flash bank grouping to all parts

### DIFF
--- a/devices/common_patches/flash/flash_dual_bank.yaml
+++ b/devices/common_patches/flash/flash_dual_bank.yaml
@@ -1,6 +1,40 @@
 # Cluster bank-specific registers
 
 "FLASH":
+  KEYR1:
+    _strip_end:
+      - '1'
+  CR1:
+    _strip_end:
+      - '1'
+  SR1:
+    _strip_end:
+      - '1'
+  CCR1:
+    _strip_end:
+      - '1'
+  PRAR_CUR1:
+    _strip_end:
+      - '1'
+  PRAR_PRG1:
+    _strip_end:
+      - '1'
+  SCAR_CUR1:
+    _strip_end:
+      - '1'
+  SCAR_PRG1:
+    _strip_end:
+      - '1'
+  WPSN_CUR1R:
+    _strip_end:
+      - '1'
+  WPSN_PRG1R:
+    _strip_end:
+      - '1'
+  ECC_FA?R:
+    _strip_end:
+      - '1'
+
   _cluster:
     "BANK%s":
       "KEYR?":

--- a/devices/stm32h743.yaml
+++ b/devices/stm32h743.yaml
@@ -12,6 +12,7 @@ _include:
  - common_patches/h7_dmamux.yaml
  - common_patches/dma/dma2d_v2.yaml
  - common_patches/h7_adc.yaml
+ - common_patches/flash/flash_dual_bank.yaml
  - common_patches/ltdc/ltdc.yaml
  - common_patches/merge_I2C_CR2_SADDx_fields.yaml
  - common_patches/merge_USART_CR1_DEATx_fields.yaml

--- a/devices/stm32h743v.yaml
+++ b/devices/stm32h743v.yaml
@@ -13,6 +13,7 @@ _include:
  - common_patches/dma/dma2d_v2.yaml
  - common_patches/h7_adc.yaml
  - common_patches/h7_adc_boost_rev_v.yaml
+ - common_patches/flash/flash_dual_bank.yaml
  - common_patches/h7_hsicfgr_csicfgr_rev_v.yaml
  - common_patches/ltdc/ltdc.yaml
  - common_patches/merge_I2C_CR2_SADDx_fields.yaml

--- a/devices/stm32h753.yaml
+++ b/devices/stm32h753.yaml
@@ -22,6 +22,7 @@ _include:
  - common_patches/h7_dmamux.yaml
  - common_patches/dma/dma2d_v2.yaml
  - common_patches/h7_adc.yaml
+ - common_patches/flash/flash_dual_bank.yaml
  - common_patches/ltdc/ltdc.yaml
  - common_patches/merge_I2C_CR2_SADDx_fields.yaml
  - common_patches/merge_USART_CR1_DEATx_fields.yaml

--- a/devices/stm32h753v.yaml
+++ b/devices/stm32h753v.yaml
@@ -23,6 +23,7 @@ _include:
  - common_patches/dma/dma2d_v2.yaml
  - common_patches/h7_adc.yaml
  - common_patches/h7_adc_boost_rev_v.yaml
+ - common_patches/flash/flash_dual_bank.yaml
  - common_patches/h7_hsicfgr_csicfgr_rev_v.yaml
  - common_patches/ltdc/ltdc.yaml
  - common_patches/merge_I2C_CR2_SADDx_fields.yaml


### PR DESCRIPTION
The goal here is to unify the naming of the common flash registers accross all h7 parts. Sadly this solution still leaves the register fields themselves named with a trailing 1, unlike the 747cm7/4 parts where we delete the flash peripheral and start over.