### PR TITLE
h7: Rename HDMICEC -> CEC in APB1Lxxx registers to match latest RM

### DIFF
--- a/devices/common_patches/h7_common_dualcore.yaml
+++ b/devices/common_patches/h7_common_dualcore.yaml
@@ -492,6 +492,8 @@ RCC:
       USART8RST:
         name: UART8RST
         description: UART8 block reset
+      HDMICECRST:
+        name: CECRST
   APB1LENR,C1_APB1LENR:
     _add:
       WWDG2EN:
@@ -505,6 +507,8 @@ RCC:
       USART8EN:
         name: UART8EN
         description: UART8 Peripheral Clocks Enable
+      HDMICECEN:
+        name: CECEN
   APB1LLPENR,C1_APB1LLPENR:
     _add:
       WWDG2LPEN:


### PR DESCRIPTION
Now matches singlecore parts as well as RM