### PR TITLE
Document syscfg for stm32f3 devices

### DIFF
--- a/devices/common_patches/f3_syscfg.yaml
+++ b/devices/common_patches/f3_syscfg.yaml
@@ -26,5 +26,38 @@ SYSCFG:
         name: I2C1_FMP
       I2C2_FM:
         name: I2C2_FMP
-      FPU_IT:
-        name: FPU_IE
+    _delete:
+      - FPU_IT
+    _add:
+      FPU_IE5:
+        description: Inexact interrupt enable
+        bitOffset: 31
+        bitWidth: 1
+        access: read-write
+      FPU_IE4:
+        description: Input denormal interrupt enable
+        bitOffset: 30
+        bitWidth: 1
+        access: read-write
+      FPU_IE3:
+        description: Overflow interrupt enable
+        bitOffset: 29
+        bitWidth: 1
+        access: read-write
+      FPU_IE2:
+        description: Underflow interrupt enable
+        bitOffset: 28
+        bitWidth: 1
+        access: read-write
+      FPU_IE1:
+        description: Devide-by-zero interrupt enable
+        bitOffset: 27
+        bitWidth: 1
+        access: read-write
+      FPU_IE0:
+        description: Invalid operation interrupt enable
+        bitOffset: 26
+        bitWidth: 1
+        access: read-write
+
+

--- a/devices/common_patches/f3_syscfg_cfgr1_adc2_dac1_rmp.yaml
+++ b/devices/common_patches/f3_syscfg_cfgr1_adc2_dac1_rmp.yaml
@@ -1,0 +1,9 @@
+# Modify names to fit the name in the register documentation
+# instead of the register map name.
+SYSCFG:
+  CFGR1:
+    _modify:
+      ADC24_DMA_RMP:
+        name: ADC2_DMA_RMP
+      DAC_TRIG_RMP:
+        name: DAC1_TRIG_RMP

--- a/devices/common_patches/f3_syscfg_cfgr1_timx_dacx_chx_dma_rmp.yaml
+++ b/devices/common_patches/f3_syscfg_cfgr1_timx_dacx_chx_dma_rmp.yaml
@@ -1,0 +1,9 @@
+# Modify names to fit the name in the register documentation
+# instead of the register map name.
+SYSCFG:
+  CFGR1:
+    _modify:
+      TIM7_DAC2_DMA_RMP:
+        name: TIM7_DAC1_CH2_DMA_RMP
+      TIM6_DAC1_DMA_RMP:
+        name: TIM6_DAC1_CH1_DMA_RMP

--- a/devices/stm32f301.yaml
+++ b/devices/stm32f301.yaml
@@ -103,6 +103,7 @@ _include:
  - ./common_patches/f3_opamp2.yaml
  - ./common_patches/f3_comp246.yaml
  - ./common_patches/f3_comp2_inp_dac.yaml
+ - ../peripherals/syscfg/syscfg_f3.yaml
  - common_patches/can/can.yaml
  - common_patches/can/can_filter_bank.yaml
  - ../peripherals/can/can.yaml

--- a/devices/stm32f301.yaml
+++ b/devices/stm32f301.yaml
@@ -105,6 +105,7 @@ _include:
  - ./common_patches/f3_comp2_inp_dac.yaml
  - ../peripherals/syscfg/syscfg_f3.yaml
  - ../peripherals/syscfg/syscfg_f301.yaml
+ - ../peripherals/syscfg/syscfg_f3_cfgr2_pvd_lock.yaml
  - common_patches/can/can.yaml
  - common_patches/can/can_filter_bank.yaml
  - ../peripherals/can/can.yaml

--- a/devices/stm32f301.yaml
+++ b/devices/stm32f301.yaml
@@ -104,6 +104,7 @@ _include:
  - ./common_patches/f3_comp246.yaml
  - ./common_patches/f3_comp2_inp_dac.yaml
  - ../peripherals/syscfg/syscfg_f3.yaml
+ - ../peripherals/syscfg/syscfg_f301.yaml
  - common_patches/can/can.yaml
  - common_patches/can/can_filter_bank.yaml
  - ../peripherals/can/can.yaml

--- a/devices/stm32f302.yaml
+++ b/devices/stm32f302.yaml
@@ -107,6 +107,7 @@ _include:
  - ./common_patches/f3_syscfg_cfgr1_mem_mode_3.yaml
  - ./common_patches/f3_syscfg_cfgr1_i2c3_fmp.yaml
  - ./common_patches/f3_syscfg_cfgr2.yaml
+ - ./common_patches/f3_syscfg_cfgr1_adc2_dac1_rmp.yaml
  - ./common_patches/f3_opamp12.yaml
  - ./common_patches/f3_comp1246.yaml
  - ./common_patches/f3_comp2_inp_dac.yaml

--- a/devices/stm32f302.yaml
+++ b/devices/stm32f302.yaml
@@ -111,6 +111,7 @@ _include:
  - ./common_patches/f3_comp1246.yaml
  - ./common_patches/f3_comp2_inp_dac.yaml
  - ../peripherals/syscfg/syscfg_f3.yaml
+ - ../peripherals/syscfg/syscfg_f302.yaml
  - ../peripherals/syscfg/syscfg_f3_cfgr2_pvd_lock.yaml
  - common_patches/can/can.yaml
  - common_patches/can/can_filter_bank.yaml

--- a/devices/stm32f302.yaml
+++ b/devices/stm32f302.yaml
@@ -110,6 +110,7 @@ _include:
  - ./common_patches/f3_opamp12.yaml
  - ./common_patches/f3_comp1246.yaml
  - ./common_patches/f3_comp2_inp_dac.yaml
+ - ../peripherals/syscfg/syscfg_f3.yaml
  - common_patches/can/can.yaml
  - common_patches/can/can_filter_bank.yaml
  - ../peripherals/can/can.yaml

--- a/devices/stm32f302.yaml
+++ b/devices/stm32f302.yaml
@@ -111,6 +111,7 @@ _include:
  - ./common_patches/f3_comp1246.yaml
  - ./common_patches/f3_comp2_inp_dac.yaml
  - ../peripherals/syscfg/syscfg_f3.yaml
+ - ../peripherals/syscfg/syscfg_f3_cfgr2_pvd_lock.yaml
  - common_patches/can/can.yaml
  - common_patches/can/can_filter_bank.yaml
  - ../peripherals/can/can.yaml

--- a/devices/stm32f303.yaml
+++ b/devices/stm32f303.yaml
@@ -93,6 +93,7 @@ _include:
  - ./common_patches/f3_syscfg_cfgr4.yaml
  - ./common_patches/f3_syscfg_rcr_page8-15.yaml
  - ../peripherals/syscfg/syscfg_f3.yaml
+ - ../peripherals/syscfg/syscfg_f303_3x8.yaml
  - ./common_patches/f3_opamp1234.yaml
  - ./common_patches/f3_comp1234567.yaml
  - common_patches/can/can.yaml

--- a/devices/stm32f303.yaml
+++ b/devices/stm32f303.yaml
@@ -93,6 +93,7 @@ _include:
  - ./common_patches/f3_syscfg_cfgr4.yaml
  - ./common_patches/f3_syscfg_rcr_page8-15.yaml
  - ../peripherals/syscfg/syscfg_f3.yaml
+ - ../peripherals/syscfg/syscfg_f3_cfgr2_pvd_lock.yaml
  - ../peripherals/syscfg/syscfg_f303_3x8.yaml
  - ./common_patches/f3_opamp1234.yaml
  - ./common_patches/f3_comp1234567.yaml

--- a/devices/stm32f303.yaml
+++ b/devices/stm32f303.yaml
@@ -89,6 +89,7 @@ _include:
  - ./common_patches/f3_syscfg_cfgr1_dac2_ch1_dma_rmp.yaml
  - ./common_patches/f3_syscfg_cfgr1_i2c3_fmp.yaml
  - ./common_patches/f3_syscfg_cfgr1_timx_dacx_chx_dma_rmp.yaml
+ - ./common_patches/f3_syscfg_cfgr1_adc2_dac1_rmp.yaml
  - ./common_patches/f3_syscfg_cfgr2.yaml
  - ./common_patches/f3_syscfg_cfgr4.yaml
  - ./common_patches/f3_syscfg_rcr_page8-15.yaml

--- a/devices/stm32f303.yaml
+++ b/devices/stm32f303.yaml
@@ -88,6 +88,7 @@ _include:
  - ./common_patches/f3_syscfg_cfgr1_mem_mode_3.yaml
  - ./common_patches/f3_syscfg_cfgr1_dac2_ch1_dma_rmp.yaml
  - ./common_patches/f3_syscfg_cfgr1_i2c3_fmp.yaml
+ - ./common_patches/f3_syscfg_cfgr1_timx_dacx_chx_dma_rmp.yaml
  - ./common_patches/f3_syscfg_cfgr2.yaml
  - ./common_patches/f3_syscfg_cfgr4.yaml
  - ./common_patches/f3_syscfg_rcr_page8-15.yaml

--- a/devices/stm32f303.yaml
+++ b/devices/stm32f303.yaml
@@ -92,6 +92,7 @@ _include:
  - ./common_patches/f3_syscfg_cfgr2.yaml
  - ./common_patches/f3_syscfg_cfgr4.yaml
  - ./common_patches/f3_syscfg_rcr_page8-15.yaml
+ - ../peripherals/syscfg/syscfg_f3.yaml
  - ./common_patches/f3_opamp1234.yaml
  - ./common_patches/f3_comp1234567.yaml
  - common_patches/can/can.yaml

--- a/devices/stm32f373.yaml
+++ b/devices/stm32f373.yaml
@@ -44,6 +44,11 @@ SYSCFG:
         bitOffset: 24
         bitWidth: 1
         access: read-write
+    _modify:
+      TIM7_DAC2_DMA_RMP:
+        name: TIM7_DAC1_OUT2_DMA_RMP
+      TIM6_DAC1_DMA_RMP:
+        name: TIM6_DAC1_OUT1_DMA_RMP
   CFGR2:
     _delete:
       - BYP_ADD_PAR

--- a/devices/stm32f373.yaml
+++ b/devices/stm32f373.yaml
@@ -98,6 +98,7 @@ _include:
  - ./common_patches/f3_rcc_dac3_dac2.yaml
  - ./common_patches/f3_syscfg.yaml
  - ./common_patches/f3_syscfg_cfgr2.yaml
+ - ../peripherals/syscfg/syscfg_f3.yaml
  - ./common_patches/f0_comp_common.yaml
  - common_patches/can/can.yaml
  - common_patches/can/can_filter_bank.yaml

--- a/devices/stm32f373.yaml
+++ b/devices/stm32f373.yaml
@@ -104,6 +104,7 @@ _include:
  - ./common_patches/f3_syscfg.yaml
  - ./common_patches/f3_syscfg_cfgr2.yaml
  - ../peripherals/syscfg/syscfg_f3.yaml
+ - ../peripherals/syscfg/syscfg_f3_cfgr2_pvd_lock.yaml
  - ../peripherals/syscfg/syscfg_f37x.yaml
  - ./common_patches/f0_comp_common.yaml
  - common_patches/can/can.yaml

--- a/devices/stm32f373.yaml
+++ b/devices/stm32f373.yaml
@@ -44,6 +44,11 @@ SYSCFG:
         bitOffset: 24
         bitWidth: 1
         access: read-write
+      TIM18_DAC2_OUT1_DMA_RMP:
+        description: TIM18 and DAC2_OUT1 DMA request remapping bit
+        bitOffset: 15
+        bitWidth: 1
+        access: read-write
     _modify:
       TIM7_DAC2_DMA_RMP:
         name: TIM7_DAC1_OUT2_DMA_RMP
@@ -99,6 +104,7 @@ _include:
  - ./common_patches/f3_syscfg.yaml
  - ./common_patches/f3_syscfg_cfgr2.yaml
  - ../peripherals/syscfg/syscfg_f3.yaml
+ - ../peripherals/syscfg/syscfg_f37x.yaml
  - ./common_patches/f0_comp_common.yaml
  - common_patches/can/can.yaml
  - common_patches/can/can_filter_bank.yaml

--- a/devices/stm32f3x4.yaml
+++ b/devices/stm32f3x4.yaml
@@ -231,6 +231,7 @@ _include:
  - ./common_patches/f3_syscfg_cfgr1_timx_dacx_chx_dma_rmp.yaml
  - ./common_patches/f3_syscfg_cfgr2.yaml
  - ../peripherals/syscfg/syscfg_f3.yaml
+ - ../peripherals/syscfg/syscfg_f3_cfgr2_pvd_lock.yaml
  - ./common_patches/f3_opamp2.yaml
  - ./common_patches/f3_comp246.yaml
  - ./common_patches/f3_comp246_inmsel3.yaml

--- a/devices/stm32f3x4.yaml
+++ b/devices/stm32f3x4.yaml
@@ -82,6 +82,7 @@ SYSCFG:
   CFGR1:
     _delete:
       - USB_IT_RMP
+      - ADC24_DMA_RMP
   CFGR3:
     _delete:
       - ADC2_DMA_RMP*

--- a/devices/stm32f3x4.yaml
+++ b/devices/stm32f3x4.yaml
@@ -230,6 +230,7 @@ _include:
  - ./common_patches/f3_syscfg_cfgr1_dac2_ch1_dma_rmp.yaml
  - ./common_patches/f3_syscfg_cfgr1_timx_dacx_chx_dma_rmp.yaml
  - ./common_patches/f3_syscfg_cfgr2.yaml
+ - ../peripherals/syscfg/syscfg_f3.yaml
  - ./common_patches/f3_opamp2.yaml
  - ./common_patches/f3_comp246.yaml
  - ./common_patches/f3_comp246_inmsel3.yaml

--- a/devices/stm32f3x4.yaml
+++ b/devices/stm32f3x4.yaml
@@ -228,6 +228,7 @@ _include:
  - ./common_patches/f3_rcc_delete_tim8.yaml
  - ./common_patches/f3_syscfg.yaml
  - ./common_patches/f3_syscfg_cfgr1_dac2_ch1_dma_rmp.yaml
+ - ./common_patches/f3_syscfg_cfgr1_timx_dacx_chx_dma_rmp.yaml
  - ./common_patches/f3_syscfg_cfgr2.yaml
  - ./common_patches/f3_opamp2.yaml
  - ./common_patches/f3_comp246.yaml

--- a/devices/stm32f3x4.yaml
+++ b/devices/stm32f3x4.yaml
@@ -232,6 +232,7 @@ _include:
  - ./common_patches/f3_syscfg_cfgr2.yaml
  - ../peripherals/syscfg/syscfg_f3.yaml
  - ../peripherals/syscfg/syscfg_f3_cfgr2_pvd_lock.yaml
+ - ../peripherals/syscfg/syscfg_f3x4.yaml
  - ./common_patches/f3_opamp2.yaml
  - ./common_patches/f3_comp246.yaml
  - ./common_patches/f3_comp246_inmsel3.yaml

--- a/devices/stm32f3x8.yaml
+++ b/devices/stm32f3x8.yaml
@@ -269,6 +269,7 @@ _include:
  - ./common_patches/f3_syscfg_rcr_page8-15.yaml
  - ./common_patches/f3_opamp1234.yaml
  - ./common_patches/f3_comp1234567.yaml
+ - ../peripherals/syscfg/syscfg_f3.yaml
  - common_patches/can/can.yaml
  - common_patches/can/can_filter_bank.yaml
  - ../peripherals/can/can.yaml

--- a/devices/stm32f3x8.yaml
+++ b/devices/stm32f3x8.yaml
@@ -270,6 +270,7 @@ _include:
  - ./common_patches/f3_opamp1234.yaml
  - ./common_patches/f3_comp1234567.yaml
  - ../peripherals/syscfg/syscfg_f3.yaml
+ - ../peripherals/syscfg/syscfg_f303_3x8.yaml
  - common_patches/can/can.yaml
  - common_patches/can/can_filter_bank.yaml
  - ../peripherals/can/can.yaml

--- a/devices/stm32f3x8.yaml
+++ b/devices/stm32f3x8.yaml
@@ -263,6 +263,7 @@ _include:
  - ./common_patches/f3_syscfg_cfgr1_mem_mode_3.yaml
  - ./common_patches/f3_syscfg_cfgr1_dac2_ch1_dma_rmp.yaml
  - ./common_patches/f3_syscfg_cfgr1_i2c3_fmp.yaml
+ - ./common_patches/f3_syscfg_cfgr1_timx_dacx_chx_dma_rmp.yaml
  - ./common_patches/f3_syscfg_cfgr2.yaml
  - ./common_patches/f3_syscfg_cfgr4.yaml
  - ./common_patches/f3_syscfg_rcr_page8-15.yaml

--- a/devices/stm32f3x8.yaml
+++ b/devices/stm32f3x8.yaml
@@ -270,6 +270,7 @@ _include:
  - ./common_patches/f3_opamp1234.yaml
  - ./common_patches/f3_comp1234567.yaml
  - ../peripherals/syscfg/syscfg_f3.yaml
+ - ../peripherals/syscfg/syscfg_f3_cfgr2_pvd_lock.yaml
  - ../peripherals/syscfg/syscfg_f303_3x8.yaml
  - common_patches/can/can.yaml
  - common_patches/can/can_filter_bank.yaml

--- a/devices/stm32f3x8.yaml
+++ b/devices/stm32f3x8.yaml
@@ -267,6 +267,7 @@ _include:
  - ./common_patches/f3_syscfg_cfgr2.yaml
  - ./common_patches/f3_syscfg_cfgr4.yaml
  - ./common_patches/f3_syscfg_rcr_page8-15.yaml
+ - ./common_patches/f3_syscfg_cfgr1_adc2_dac1_rmp.yaml
  - ./common_patches/f3_opamp1234.yaml
  - ./common_patches/f3_comp1234567.yaml
  - ../peripherals/syscfg/syscfg_f3.yaml

--- a/peripherals/syscfg/syscfg_f0.yaml
+++ b/peripherals/syscfg/syscfg_f0.yaml
@@ -55,8 +55,11 @@ SYSCFG:
       Disconnected: [0, "SRAM parity error disconnected from TIM1/15/16/17 Break input"]
       Connected: [1, "SRAM parity error connected to TIM1/15/16/17 Break input"]
     SRAM_PEF:
-      NoParityError: [0, "No SRAM parity error detected"]
-      ParityErrorDetected: [1, "SRAM parity error detected"]
+      _read:
+        NoParityError: [0, "No SRAM parity error detected"]
+        ParityErrorDetected: [1, "SRAM parity error detected"]
+      _write:
+        Clear: [1, "Clear SRAM parity error flag"]
   EXTICR1:
     EXTI0:
       PA0: [0, "Select PA0 as the source input for the EXTI0 external interrupt"]

--- a/peripherals/syscfg/syscfg_f3.yaml
+++ b/peripherals/syscfg/syscfg_f3.yaml
@@ -1,0 +1,44 @@
+SYSCFG:
+  CFGR1:
+    FPU_IE5:
+      Disabled: [0, "Inexact interrupt disable"]
+      Enabled: [1, "Inexact interrupt enable"]
+    FPU_IE4:
+      Disabled: [0, "Input denormal interrupt disable"]
+      Enabled: [1, "Input denormal interrupt enable"]
+    FPU_IE3:
+      Disabled: [0, "Overflow interrupt disable"]
+      Enabled: [1, "Overflow interrupt enable"]
+    FPU_IE2:
+      Disabled: [0, "Underflow interrupt disable"]
+      Enabled: [1, "Underflow interrupt enable"]
+    FPU_IE1:
+      Disabled: [0, "Devide-by-zero interrupt disable"]
+      Enabled: [1, "Devide-by-zero interrupt enable"]
+    FPU_IE0:
+      Disabled: [0, "Invalid operation interrupt disable"]
+      Enabled: [1, "Invalid operation interrupt enable"]
+    I2C2_FMP:
+      Standard: [0, "FM+ mode is controlled by I2C_Pxx_FMP bits only"]
+      FMP: [1, "FM+ mode is enabled on all I2C2 pins selected through selection through IOPORT control registers AF selection bits"]
+    I2C1_FMP:
+      Standard: [0, "FM+ mode is controlled by I2C_Pxx_FMP bits only"]
+      FMP: [1, "FM+ mode is enabled on all I2C1 pins selected through selection through IOPORT control registers AF selection bits"]
+    I2C_PB9_FMP:
+      Standard: [0, "PB9 pin operate in standard mode"]
+      FMP: [1, "I2C FM+ mode enabled on PB9 and the Speed control is bypassed"]
+    I2C_PB8_FMP:
+      Standard: [0, "PB8 pin operate in standard mode"]
+      FMP: [1, "I2C FM+ mode enabled on PB8 and the Speed control is bypassed"]
+    I2C_PB7_FMP:
+      Standard: [0, "PB7 pin operate in standard mode"]
+      FMP: [1, "I2C FM+ mode enabled on PB7 and the Speed control is bypassed"]
+    I2C_PB6_FMP:
+      Standard: [0, "PB6 pin operate in standard mode"]
+      FMP: [1, "I2C FM+ mode enabled on PB6 and the Speed control is bypassed"]
+    TIM17_DMA_RMP:
+      NotRemapped: [0, "TIM17_CH1 and TIM17_UP DMA requests mapped on DMA channel 1"]
+      Remapped: [1, "TIM17_CH1 and TIM17_UP DMA requests mapped on DMA channel 2"]
+    TIM16_DMA_RMP:
+      NotRemapped: [0, "TIM16_CH1 and TIM16_UP DMA requests mapped on DMA channel 3"]
+      Remapped: [1, "TIM16_CH1 and TIM16_UP DMA requests mapped on DMA channel 4"]

--- a/peripherals/syscfg/syscfg_f301.yaml
+++ b/peripherals/syscfg/syscfg_f301.yaml
@@ -1,0 +1,90 @@
+SYSCFG:
+  CFGR1:
+    I2C3_FMP:
+      Standard: [0, "FM+ mode is controlled by I2C_Pxx_FMP bits only"]
+      FMP: [1, "FM+ mode is enabled on all I2C3 pins selected through selection trhough IOPORT control registers AF selection bits"]
+    ENCODER_MODE:
+      NoRedirection: [0, "No redirection"]
+      MapTim2Tim15: [1, "TIM2 IC1 and TIM2 IC2 are connected to TIM15 IC1 and TIM15 IC2 respectively"]
+    TIM6_DAC1_DMA_RMP:
+      NotRemapped: [0, "TIM6_UP and DAC_CH1 DMA requests mapped on DMA2 channel 3"]
+      Remapped: [1, "TIM6_UP and DAC_CH1 DMA requests mapped on DMA1 channel 3"]
+    TIM1_ITR3_RMP:
+      NotRemapped: [0, "Not remapped"]
+      Remapped: [1, "TIM1_ITR3 = TIM17_OC"]
+    MEM_MODE:
+      MainFlash: [0, "Main Flash memory mapped at 0x0000_0000"]
+      SystemFlash: [1, "System Flash memory mapped at 0x0000_0000"]
+      MainFlash2: [2, "Main Flash memory mapped at 0x0000_0000"]
+      SRAM: [3, "Embedded SRAM mapped at 0x0000_0000"]
+  EXTICR1:
+    EXTI0:
+      PA0: [0, "Select PA0 as the source input for the EXTI0 external interrupt"]
+      PB0: [1, "Select PB0 as the source input for the EXTI0 external interrupt"]
+      PC0: [2, "Select PC0 as the source input for the EXTI0 external interrupt"]
+      PF0: [5, "Select PF0 as the source input for the EXTI0 external interrupt"]
+    EXTI1:
+      PA1: [0, "Select PA1 as the source input for the EXTI1 external interrupt"]
+      PB1: [1, "Select PB1 as the source input for the EXTI1 external interrupt"]
+      PC1: [2, "Select PC1 as the source input for the EXTI1 external interrupt"]
+      PF1: [5, "Select PF1 as the source input for the EXTI1 external interrupt"]
+    EXTI2:
+      PA2: [0, "Select PA2 as the source input for the EXTI2 external interrupt"]
+      PB2: [1, "Select PB2 as the source input for the EXTI2 external interrupt"]
+      PC2: [2, "Select PC2 as the source input for the EXTI2 external interrupt"]
+      PD2: [3, "Select PD2 as the source input for the EXTI2 external interrupt"]
+    EXTI3:
+      PA3: [0, "Select PA3 as the source input for the EXTI3 external interrupt"]
+      PB3: [1, "Select PB3 as the source input for the EXTI3 external interrupt"]
+      PC3: [2, "Select PC3 as the source input for the EXTI3 external interrupt"]
+  EXTICR2:
+    EXTI4:
+      PA4: [0, "Select PA4 as the source input for the EXTI4 external interrupt"]
+      PB4: [1, "Select PB4 as the source input for the EXTI4 external interrupt"]
+      PC4: [2, "Select PC4 as the source input for the EXTI4 external interrupt"]
+    EXTI5:
+      PA5: [0, "Select PA5 as the source input for the EXTI5 external interrupt"]
+      PB5: [1, "Select PB5 as the source input for the EXTI5 external interrupt"]
+      PC5: [2, "Select PC5 as the source input for the EXTI5 external interrupt"]
+    EXTI6:
+      PA6: [0, "Select PA6 as the source input for the EXTI6 external interrupt"]
+      PB6: [1, "Select PB6 as the source input for the EXTI6 external interrupt"]
+      PC6: [2, "Select PC6 as the source input for the EXTI6 external interrupt"]
+    EXTI7:
+      PA7: [0, "Select PA7 as the source input for the EXTI7 external interrupt"]
+      PB7: [1, "Select PB7 as the source input for the EXTI7 external interrupt"]
+      PC7: [2, "Select PC7 as the source input for the EXTI7 external interrupt"]
+  EXTICR3:
+    EXTI8:
+      PA8: [0, "Select PA8 as the source input for the EXTI8 external interrupt"]
+      PB8: [1, "Select PB8 as the source input for the EXTI8 external interrupt"]
+      PC8: [2, "Select PC8 as the source input for the EXTI8 external interrupt"]
+    EXTI9:
+      PA9: [0, "Select PA9 as the source input for the EXTI9 external interrupt"]
+      PB9: [1, "Select PB9 as the source input for the EXTI9 external interrupt"]
+      PC9: [2, "Select PC9 as the source input for the EXTI9 external interrupt"]
+    EXTI10:
+      PA10: [0, "Select PA10 as the source input for the EXTI10 external interrupt"]
+      PB10: [1, "Select PB10 as the source input for the EXTI10 external interrupt"]
+      PC10: [2, "Select PC10 as the source input for the EXTI10 external interrupt"]
+    EXTI11:
+      PA11: [0, "Select PA11 as the source input for the EXTI11 external interrupt"]
+      PB11: [1, "Select PB11 as the source input for the EXTI11 external interrupt"]
+      PC11: [2, "Select PC11 as the source input for the EXTI11 external interrupt"]
+  EXTICR4:
+    EXTI12:
+      PA12: [0, "Select PA12 as the source input for the EXTI12 external interrupt"]
+      PB12: [1, "Select PB12 as the source input for the EXTI12 external interrupt"]
+      PC12: [2, "Select PC12 as the source input for the EXTI12 external interrupt"]
+    EXTI13:
+      PA13: [0, "Select PA13 as the source input for the EXTI13 external interrupt"]
+      PB13: [1, "Select PB13 as the source input for the EXTI13 external interrupt"]
+      PC13: [2, "Select PC13 as the source input for the EXTI13 external interrupt"]
+    EXTI14:
+      PA14: [0, "Select PA14 as the source input for the EXTI14 external interrupt"]
+      PB14: [1, "Select PB14 as the source input for the EXTI14 external interrupt"]
+      PC14: [2, "Select PC14 as the source input for the EXTI14 external interrupt"]
+    EXTI15:
+      PA15: [0, "Select PA15 as the source input for the EXTI15 external interrupt"]
+      PB15: [1, "Select PB15 as the source input for the EXTI15 external interrupt"]
+      PC15: [2, "Select PC15 as the source input for the EXTI15 external interrupt"]

--- a/peripherals/syscfg/syscfg_f302.yaml
+++ b/peripherals/syscfg/syscfg_f302.yaml
@@ -11,10 +11,10 @@ SYSCFG:
     TIM6_DAC1_DMA_RMP:
       NotRemapped: [0, "TIM6_UP and DAC_CH1 DMA requests mapped on DMA2 channel 3"]
       Remapped: [1, "TIM6_UP and DAC_CH1 DMA requests mapped on DMA1 channel 3"]
-    ADC24_DMA_RMP:
+    ADC2_DMA_RMP:
       NotRemapped: [0, "ADC24 DMA requests mapped on DMA2 channels 1 and 2"]
       Remapped: [1, "ADC24 DMA requests mapped on DMA2 channels 3 and 4"]
-    DAC_TRIG_RMP:
+    DAC1_TRIG_RMP:
       NotRemapped: [0, "DAC trigger is TIM8_TRGO in STM32F303xB/C and STM32F358xC devices"]
       Remapped: [1, "DAC trigger is TIM3_TRGO"]
     TIM1_ITR3_RMP:

--- a/peripherals/syscfg/syscfg_f302.yaml
+++ b/peripherals/syscfg/syscfg_f302.yaml
@@ -1,0 +1,155 @@
+SYSCFG:
+  CFGR1:
+    I2C3_FMP:
+      Standard: [0, "FM+ mode is controlled by I2C_Pxx_FMP bits only"]
+      FMP: [1, "FM+ mode is enabled on all I2C3 pins selected through selection trhough IOPORT control registers AF selection bits"]
+    ENCODER_MODE:
+      NoRedirection: [0, "No redirection"]
+      MapTim2Tim15: [1, "TIM2 IC1 and TIM2 IC2 are connected to TIM15 IC1 and TIM15 IC2 respectively"]
+      MapTim3Tim15: [2, "TIM3 IC1 and TIM3 IC2 are connected to TIM15 IC1 and TIM15 IC2 respectively"]
+      MapTim4Tim15: [3, "TIM4 IC1 and TIM4 IC2 are connected to TIM15 IC1 and TIM15 IC2 respectively (STM32F302xB/C devices only)"]
+    TIM6_DAC1_DMA_RMP:
+      NotRemapped: [0, "TIM6_UP and DAC_CH1 DMA requests mapped on DMA2 channel 3"]
+      Remapped: [1, "TIM6_UP and DAC_CH1 DMA requests mapped on DMA1 channel 3"]
+    ADC24_DMA_RMP:
+      NotRemapped: [0, "ADC24 DMA requests mapped on DMA2 channels 1 and 2"]
+      Remapped: [1, "ADC24 DMA requests mapped on DMA2 channels 3 and 4"]
+    DAC_TRIG_RMP:
+      NotRemapped: [0, "DAC trigger is TIM8_TRGO in STM32F303xB/C and STM32F358xC devices"]
+      Remapped: [1, "DAC trigger is TIM3_TRGO"]
+    TIM1_ITR3_RMP:
+      NotRemapped: [0, "TIM1_ITR3 = TIM4_TRGO in STM32F303xB/C and STM32F358xC devices"]
+      Remapped: [1, "TIM1_ITR3 = TIM17_OC"]
+    # Is documented as reserverd but appears in register table (RM0365 p.172) and register map
+    USB_IT_RMP:
+      NotRemapped: [0, "USB_HP, USB_LP and USB_WAKEUP interrupts are mapped on interrupt lines 19, 20 and 42 respectively"]
+      Remapped: [1, "USB_HP, USB_LP and USB_WAKEUP interrupts are mapped on interrupt lines 74, 75 and 76 respectively"]
+    MEM_MODE:
+      MainFlash: [0, "Main Flash memory mapped at 0x0000_0000"]
+      SystemFlash: [1, "System Flash memory mapped at 0x0000_0000"]
+      SRAM: [3, "Embedded SRAM mapped at 0x0000_0000"]
+      FMC: [4, "FMC Bank (Only the first  two banks) (Available on STM32F302xD/E only)"]
+  EXTICR1:
+    EXTI0:
+      PA0: [0, "Select PA0 as the source input for the EXTI0 external interrupt"]
+      PB0: [1, "Select PB0 as the source input for the EXTI0 external interrupt"]
+      PC0: [2, "Select PC0 as the source input for the EXTI0 external interrupt"]
+      PD0: [3, "Select PD0 as the source input for the EXTI0 external interrupt"]
+      PE0: [4, "Select PE0 as the source input for the EXTI0 external interrupt"]
+      PF0: [5, "Select PF0 as the source input for the EXTI0 external interrupt"]
+    EXTI1:
+      PA1: [0, "Select PA1 as the source input for the EXTI1 external interrupt"]
+      PB1: [1, "Select PB1 as the source input for the EXTI1 external interrupt"]
+      PC1: [2, "Select PC1 as the source input for the EXTI1 external interrupt"]
+      PD1: [3, "Select PD1 as the source input for the EXTI1 external interrupt"]
+      PE1: [4, "Select PE1 as the source input for the EXTI1 external interrupt"]
+      PF1: [5, "Select PF1 as the source input for the EXTI1 external interrupt"]
+    EXTI2:
+      PA2: [0, "Select PA2 as the source input for the EXTI2 external interrupt"]
+      PB2: [1, "Select PB2 as the source input for the EXTI2 external interrupt"]
+      PC2: [2, "Select PC2 as the source input for the EXTI2 external interrupt"]
+      PD2: [3, "Select PD2 as the source input for the EXTI2 external interrupt"]
+      PE2: [4, "Select PE2 as the source input for the EXTI2 external interrupt"]
+      PF2: [5, "Select PF2 as the source input for the EXTI2 external interrupt"]
+    EXTI3:
+      PA3: [0, "Select PA3 as the source input for the EXTI3 external interrupt"]
+      PB3: [1, "Select PB3 as the source input for the EXTI3 external interrupt"]
+      PC3: [2, "Select PC3 as the source input for the EXTI3 external interrupt"]
+      PD3: [3, "Select PD3 as the source input for the EXTI3 external interrupt"]
+      PE3: [4, "Select PE3 as the source input for the EXTI3 external interrupt"]
+  EXTICR2:
+    EXTI4:
+      PA4: [0, "Select PA4 as the source input for the EXTI4 external interrupt"]
+      PB4: [1, "Select PB4 as the source input for the EXTI4 external interrupt"]
+      PC4: [2, "Select PC4 as the source input for the EXTI4 external interrupt"]
+      PD4: [3, "Select PD4 as the source input for the EXTI4 external interrupt"]
+      PE4: [4, "Select PE4 as the source input for the EXTI4 external interrupt"]
+      PF4: [5, "Select PF4 as the source input for the EXTI4 external interrupt"]
+    EXTI5:
+      PA5: [0, "Select PA5 as the source input for the EXTI5 external interrupt"]
+      PB5: [1, "Select PB5 as the source input for the EXTI5 external interrupt"]
+      PC5: [2, "Select PC5 as the source input for the EXTI5 external interrupt"]
+      PD5: [3, "Select PD5 as the source input for the EXTI5 external interrupt"]
+      PE5: [4, "Select PE5 as the source input for the EXTI5 external interrupt"]
+      PF5: [5, "Select PF5 as the source input for the EXTI5 external interrupt"]
+    EXTI6:
+      PA6: [0, "Select PA6 as the source input for the EXTI6 external interrupt"]
+      PB6: [1, "Select PB6 as the source input for the EXTI6 external interrupt"]
+      PC6: [2, "Select PC6 as the source input for the EXTI6 external interrupt"]
+      PD6: [3, "Select PD6 as the source input for the EXTI6 external interrupt"]
+      PE6: [4, "Select PE6 as the source input for the EXTI6 external interrupt"]
+      PF6: [5, "Select PF6 as the source input for the EXTI6 external interrupt"]
+    EXTI7:
+      PA7: [0, "Select PA7 as the source input for the EXTI7 external interrupt"]
+      PB7: [1, "Select PB7 as the source input for the EXTI7 external interrupt"]
+      PC7: [2, "Select PC7 as the source input for the EXTI7 external interrupt"]
+      PD7: [3, "Select PD7 as the source input for the EXTI7 external interrupt"]
+      PE7: [4, "Select PE7 as the source input for the EXTI7 external interrupt"]
+  EXTICR3:
+    EXTI8:
+      PA8: [0, "Select PA8 as the source input for the EXTI8 external interrupt"]
+      PB8: [1, "Select PB8 as the source input for the EXTI8 external interrupt"]
+      PC8: [2, "Select PC8 as the source input for the EXTI8 external interrupt"]
+      PD8: [3, "Select PD8 as the source input for the EXTI8 external interrupt"]
+      PE8: [4, "Select PE8 as the source input for the EXTI8 external interrupt"]
+    EXTI9:
+      PA9: [0, "Select PA9 as the source input for the EXTI9 external interrupt"]
+      PB9: [1, "Select PB9 as the source input for the EXTI9 external interrupt"]
+      PC9: [2, "Select PC9 as the source input for the EXTI9 external interrupt"]
+      PD9: [3, "Select PD9 as the source input for the EXTI9 external interrupt"]
+      PE9: [4, "Select PE9 as the source input for the EXTI9 external interrupt"]
+      PF9: [5, "Select PF9 as the source input for the EXTI9 external interrupt"]
+    EXTI10:
+      PA10: [0, "Select PA10 as the source input for the EXTI10 external interrupt"]
+      PB10: [1, "Select PB10 as the source input for the EXTI10 external interrupt"]
+      PC10: [2, "Select PC10 as the source input for the EXTI10 external interrupt"]
+      PD10: [3, "Select PD10 as the source input for the EXTI10 external interrupt"]
+      PE10: [4, "Select PE10 as the source input for the EXTI10 external interrupt"]
+      PF10: [5, "Select PF10 as the source input for the EXTI10 external interrupt"]
+    EXTI11:
+      PA11: [0, "Select PA11 as the source input for the EXTI11 external interrupt"]
+      PB11: [1, "Select PB11 as the source input for the EXTI11 external interrupt"]
+      PC11: [2, "Select PC11 as the source input for the EXTI11 external interrupt"]
+      PD11: [3, "Select PD11 as the source input for the EXTI11 external interrupt"]
+      PE11: [4, "Select PE11 as the source input for the EXTI11 external interrupt"]
+  EXTICR4:
+    EXTI12:
+      PA12: [0, "Select PA12 as the source input for the EXTI12 external interrupt"]
+      PB12: [1, "Select PB12 as the source input for the EXTI12 external interrupt"]
+      PC12: [2, "Select PC12 as the source input for the EXTI12 external interrupt"]
+      PD12: [3, "Select PD12 as the source input for the EXTI12 external interrupt"]
+      PE12: [4, "Select PE12 as the source input for the EXTI12 external interrupt"]
+    EXTI13:
+      PA13: [0, "Select PA13 as the source input for the EXTI13 external interrupt"]
+      PB13: [1, "Select PB13 as the source input for the EXTI13 external interrupt"]
+      PC13: [2, "Select PC13 as the source input for the EXTI13 external interrupt"]
+      PD13: [3, "Select PD13 as the source input for the EXTI13 external interrupt"]
+      PE13: [4, "Select PE13 as the source input for the EXTI13 external interrupt"]
+    EXTI14:
+      PA14: [0, "Select PA14 as the source input for the EXTI14 external interrupt"]
+      PB14: [1, "Select PB14 as the source input for the EXTI14 external interrupt"]
+      PC14: [2, "Select PC14 as the source input for the EXTI14 external interrupt"]
+      PD14: [3, "Select PD14 as the source input for the EXTI14 external interrupt"]
+      PE14: [4, "Select PE14 as the source input for the EXTI14 external interrupt"]
+    EXTI15:
+      PA15: [0, "Select PA15 as the source input for the EXTI15 external interrupt"]
+      PB15: [1, "Select PB15 as the source input for the EXTI15 external interrupt"]
+      PC15: [2, "Select PC15 as the source input for the EXTI15 external interrupt"]
+      PD15: [3, "Select PD15 as the source input for the EXTI15 external interrupt"]
+      PE15: [4, "Select PE15 as the source input for the EXTI15 external interrupt"]
+  CFGR2:
+    SRAM_PEF:
+      _read:
+        NoParityError: [0, "No SRAM parity error detected"]
+        ParityErrorDetected: [1, "SRAM parity error detected"]
+      _write:
+        Clear: [1, "Clear SRAM parity error flag"]
+    BYP_ADDR_PAR:
+      NoBypass: [0, "The ramload operation is performed taking into consideration bit 29 of the address when the parity is calculated"]
+      Bypass: [1, "The ramload operation is performed without taking into consideration bit 29 of the address when the parity is calculated"]
+    SRAM_PARITY_LOCK:
+      Disconnected: [0, "SRAM parity error disconnected from TIM1/15/16/17 Break input"]
+      Connected: [1, "SRAM parity error connected to TIM1/15/16/17 Break input"]
+    LOCKUP_LOCK:
+      Disconnected: [0, "Cortex-M4 LOCKUP output disconnected from TIM1/15/16/17 Break input"]
+      Connected: [1, "Cortex-M4 LOCKUP output connected to TIM1/15/16/17 Break input"]

--- a/peripherals/syscfg/syscfg_f303_3x8.yaml
+++ b/peripherals/syscfg/syscfg_f303_3x8.yaml
@@ -18,11 +18,11 @@ SYSCFG:
       NotRemapped: [0, "TIM6_UP and DAC_CH1 DMA requests mapped on DMA2 channel 3 in STM32F303xB/C and STM32F358xC"]
       Remapped: [1, "TIM6_UP and DAC_CH1 DMA requests mapped on DMA1 channel 3"]
     # TODO: Is named ADC2_... in register description (RM0316 p.247) but ADC24_... in register map (RM0316 p.261)
-    ADC24_DMA_RMP:
+    ADC2_DMA_RMP:
       NotRemapped: [0, "ADC24 DMA requests mapped on DMA2 channels 1 and 2"]
       Remapped: [1, "ADC24 DMA requests mapped on DMA2 channels 3 and 4"]
     # TODO: Is named DAC1_... in register description (RM0316 p.247) but DAC_... in register map (RM0316 p.261)
-    DAC_TRIG_RMP:
+    DAC1_TRIG_RMP:
       NotRemapped: [0, "DAC trigger is TIM8_TRGO in STM32F303xB/C and STM32F358xC devices"]
       Remapped: [1, "DAC trigger is TIM3_TRGO"]
     TIM1_ITR3_RMP:

--- a/peripherals/syscfg/syscfg_f303_3x8.yaml
+++ b/peripherals/syscfg/syscfg_f303_3x8.yaml
@@ -1,0 +1,257 @@
+SYSCFG:
+  CFGR1:
+    I2C3_FMP:
+      Standard: [0, "FM+ mode is controlled by I2C_Pxx_FMP bits only"]
+      FMP: [1, "FM+ mode is enabled on all I2C3 pins selected through selection through IOPORT control registers AF selection bits"]
+    ENCODER_MODE:
+      NoRedirection: [0, "No redirection"]
+      MapTim2Tim15: [1, "TIM2 IC1 and TIM2 IC2 are connected to TIM15 IC1 and TIM15 IC2 respectively"]
+      MapTim3Tim15: [2, "TIM3 IC1 and TIM3 IC2 are connected to TIM15 IC1 and TIM15 IC2 respectively"]
+      MapTim4Tim15: [3, "TIM4 IC1 and TIM4 IC2 are connected to TIM15 IC1 and TIM15 IC2 respectively (STM32F303xB/C and STM32F358xC devices only)"]
+    DAC2_CH1_DMA_RMP:
+      NotRemapped: [0, "Not remapped"]
+      Remapped: [1, "DAC2_CH1 DMA requests mapped on DMA1 channel 5"]
+    TIM7_DAC1_CH2_DMA_RMP:
+      NotRemapped: [0, "TIM7_UP and DAC_CH2 DMA requests mapped on DMA2 channel 4 in STM32F303xB/C and STM32F358xC devices"]
+      Remapped: [1, "TIM7_UP and DAC_CH2 DMA requests mapped on DMA1 channel 4"]
+    TIM6_DAC1_CH1_DMA_RMP:
+      NotRemapped: [0, "TIM6_UP and DAC_CH1 DMA requests mapped on DMA2 channel 3 in STM32F303xB/C and STM32F358xC"]
+      Remapped: [1, "TIM6_UP and DAC_CH1 DMA requests mapped on DMA1 channel 3"]
+    # TODO: Is named ADC2_... in register description (RM0316 p.247) but ADC24_... in register map (RM0316 p.261)
+    ADC24_DMA_RMP:
+      NotRemapped: [0, "ADC24 DMA requests mapped on DMA2 channels 1 and 2"]
+      Remapped: [1, "ADC24 DMA requests mapped on DMA2 channels 3 and 4"]
+    # TODO: Is named DAC1_... in register description (RM0316 p.247) but DAC_... in register map (RM0316 p.261)
+    DAC_TRIG_RMP:
+      NotRemapped: [0, "DAC trigger is TIM8_TRGO in STM32F303xB/C and STM32F358xC devices"]
+      Remapped: [1, "DAC trigger is TIM3_TRGO"]
+    TIM1_ITR3_RMP:
+      NotRemapped: [0, "TIM1_ITR3 = TIM4_TRGO in STM32F303xB/C and STM32F358xC devices"]
+      Remapped: [1, "TIM1_ITR3 = TIM17_OC"]
+    USB_IT_RMP:
+      NotRemapped: [0, "USB_HP, USB_LP and USB_WAKEUP interrupts are mapped on interrupt lines 19, 20 and 42 respectively"]
+      Remapped: [1, "USB_HP, USB_LP and USB_WAKEUP interrupts are mapped on interrupt lines 74, 75 and 76 respectively"]
+    MEM_MODE:
+      MainFlash: [0, "Main Flash memory mapped at 0x0000_0000"]
+      SystemFlash: [1, "System Flash memory mapped at 0x0000_0000"]
+      SRAM: [3, "Embedded SRAM mapped at 0x0000_0000"]
+      FMC: [4, "FMC Bank (Only the first  two banks) (Available on STM32F303xD/E only)"]
+  RCR:
+    PAGE*_WP:
+      Disabled: [0, "Write protection of pagex is disabled"]
+      Enabled: [1, "Write protection of pagex is enabled"]
+  EXTICR1:
+    EXTI0:
+      PA0: [0, "Select PA0 as the source input for the EXTI0 external interrupt"]
+      PB0: [1, "Select PB0 as the source input for the EXTI0 external interrupt"]
+      PC0: [2, "Select PC0 as the source input for the EXTI0 external interrupt"]
+      PD0: [3, "Select PD0 as the source input for the EXTI0 external interrupt"]
+      PE0: [4, "Select PE0 as the source input for the EXTI0 external interrupt"]
+      PF0: [5, "Select PF0 as the source input for the EXTI0 external interrupt"]
+      PG0: [6, "Select PG0 as the source input for the EXTI0 external interrupt"]
+      PH0: [7, "Select PH0 as the source input for the EXTI0 external interrupt"]
+    EXTI1:
+      PA1: [0, "Select PA1 as the source input for the EXTI1 external interrupt"]
+      PB1: [1, "Select PB1 as the source input for the EXTI1 external interrupt"]
+      PC1: [2, "Select PC1 as the source input for the EXTI1 external interrupt"]
+      PD1: [3, "Select PD1 as the source input for the EXTI1 external interrupt"]
+      PE1: [4, "Select PE1 as the source input for the EXTI1 external interrupt"]
+      PF1: [5, "Select PF1 as the source input for the EXTI1 external interrupt"]
+      PG1: [6, "Select PG1 as the source input for the EXTI1 external interrupt"]
+      PH1: [7, "Select PH1 as the source input for the EXTI1 external interrupt"]
+    EXTI2:
+      PA2: [0, "Select PA2 as the source input for the EXTI2 external interrupt"]
+      PB2: [1, "Select PB2 as the source input for the EXTI2 external interrupt"]
+      PC2: [2, "Select PC2 as the source input for the EXTI2 external interrupt"]
+      PD2: [3, "Select PD2 as the source input for the EXTI2 external interrupt"]
+      PE2: [4, "Select PE2 as the source input for the EXTI2 external interrupt"]
+      PF2: [5, "Select PF2 as the source input for the EXTI2 external interrupt"]
+      PG2: [6, "Select PG2 as the source input for the EXTI2 external interrupt"]
+      PH2: [7, "Select PH2 as the source input for the EXTI2 external interrupt"]
+    EXTI3:
+      PA3: [0, "Select PA3 as the source input for the EXTI3 external interrupt"]
+      PB3: [1, "Select PB3 as the source input for the EXTI3 external interrupt"]
+      PC3: [2, "Select PC3 as the source input for the EXTI3 external interrupt"]
+      PD3: [3, "Select PD3 as the source input for the EXTI3 external interrupt"]
+      PE3: [4, "Select PE3 as the source input for the EXTI3 external interrupt"]
+      PF3: [5, "Select PF3 as the source input for the EXTI3 external interrupt"]
+      PG3: [6, "Select PG3 as the source input for the EXTI3 external interrupt"]
+  EXTICR2:
+    EXTI4:
+      PA4: [0, "Select PA4 as the source input for the EXTI4 external interrupt"]
+      PB4: [1, "Select PB4 as the source input for the EXTI4 external interrupt"]
+      PC4: [2, "Select PC4 as the source input for the EXTI4 external interrupt"]
+      PD4: [3, "Select PD4 as the source input for the EXTI4 external interrupt"]
+      PE4: [4, "Select PE4 as the source input for the EXTI4 external interrupt"]
+      PF4: [5, "Select PF4 as the source input for the EXTI4 external interrupt"]
+      PG4: [6, "Select PG4 as the source input for the EXTI4 external interrupt"]
+    EXTI5:
+      PA5: [0, "Select PA5 as the source input for the EXTI5 external interrupt"]
+      PB5: [1, "Select PB5 as the source input for the EXTI5 external interrupt"]
+      PC5: [2, "Select PC5 as the source input for the EXTI5 external interrupt"]
+      PD5: [3, "Select PD5 as the source input for the EXTI5 external interrupt"]
+      PE5: [4, "Select PE5 as the source input for the EXTI5 external interrupt"]
+      PF5: [5, "Select PF5 as the source input for the EXTI5 external interrupt"]
+      PG5: [6, "Select PG5 as the source input for the EXTI5 external interrupt"]
+    EXTI6:
+      PA6: [0, "Select PA6 as the source input for the EXTI6 external interrupt"]
+      PB6: [1, "Select PB6 as the source input for the EXTI6 external interrupt"]
+      PC6: [2, "Select PC6 as the source input for the EXTI6 external interrupt"]
+      PD6: [3, "Select PD6 as the source input for the EXTI6 external interrupt"]
+      PE6: [4, "Select PE6 as the source input for the EXTI6 external interrupt"]
+      PF6: [5, "Select PF6 as the source input for the EXTI6 external interrupt"]
+      PG6: [6, "Select PG6 as the source input for the EXTI6 external interrupt"]
+    EXTI7:
+      PA7: [0, "Select PA7 as the source input for the EXTI7 external interrupt"]
+      PB7: [1, "Select PB7 as the source input for the EXTI7 external interrupt"]
+      PC7: [2, "Select PC7 as the source input for the EXTI7 external interrupt"]
+      PD7: [3, "Select PD7 as the source input for the EXTI7 external interrupt"]
+      PE7: [4, "Select PE7 as the source input for the EXTI7 external interrupt"]
+      PF7: [5, "Select PF7 as the source input for the EXTI7 external interrupt"]
+      PG7: [6, "Select PG7 as the source input for the EXTI7 external interrupt"]
+  EXTICR3:
+    EXTI8:
+      PA8: [0, "Select PA8 as the source input for the EXTI8 external interrupt"]
+      PB8: [1, "Select PB8 as the source input for the EXTI8 external interrupt"]
+      PC8: [2, "Select PC8 as the source input for the EXTI8 external interrupt"]
+      PD8: [3, "Select PD8 as the source input for the EXTI8 external interrupt"]
+      PE8: [4, "Select PE8 as the source input for the EXTI8 external interrupt"]
+      PF8: [5, "Select PF8 as the source input for the EXTI8 external interrupt"]
+      PG8: [6, "Select PG8 as the source input for the EXTI8 external interrupt"]
+    EXTI9:
+      PA9: [0, "Select PA9 as the source input for the EXTI9 external interrupt"]
+      PB9: [1, "Select PB9 as the source input for the EXTI9 external interrupt"]
+      PC9: [2, "Select PC9 as the source input for the EXTI9 external interrupt"]
+      PD9: [3, "Select PD9 as the source input for the EXTI9 external interrupt"]
+      PE9: [4, "Select PE9 as the source input for the EXTI9 external interrupt"]
+      PF9: [5, "Select PF9 as the source input for the EXTI9 external interrupt"]
+      PG9: [6, "Select PG9 as the source input for the EXTI9 external interrupt"]
+    EXTI10:
+      PA10: [0, "Select PA10 as the source input for the EXTI10 external interrupt"]
+      PB10: [1, "Select PB10 as the source input for the EXTI10 external interrupt"]
+      PC10: [2, "Select PC10 as the source input for the EXTI10 external interrupt"]
+      PD10: [3, "Select PD10 as the source input for the EXTI10 external interrupt"]
+      PE10: [4, "Select PE10 as the source input for the EXTI10 external interrupt"]
+      PF10: [5, "Select PF10 as the source input for the EXTI10 external interrupt"]
+      PG10: [6, "Select PG10 as the source input for the EXTI10 external interrupt"]
+    EXTI11:
+      PA11: [0, "Select PA11 as the source input for the EXTI11 external interrupt"]
+      PB11: [1, "Select PB11 as the source input for the EXTI11 external interrupt"]
+      PC11: [2, "Select PC11 as the source input for the EXTI11 external interrupt"]
+      PD11: [3, "Select PD11 as the source input for the EXTI11 external interrupt"]
+      PE11: [4, "Select PE11 as the source input for the EXTI11 external interrupt"]
+      PF11: [5, "Select PF11 as the source input for the EXTI11 external interrupt"]
+      PG11: [6, "Select PG11 as the source input for the EXTI11 external interrupt"]
+  EXTICR4:
+    EXTI12:
+      PA12: [0, "Select PA12 as the source input for the EXTI12 external interrupt"]
+      PB12: [1, "Select PB12 as the source input for the EXTI12 external interrupt"]
+      PC12: [2, "Select PC12 as the source input for the EXTI12 external interrupt"]
+      PD12: [3, "Select PD12 as the source input for the EXTI12 external interrupt"]
+      PE12: [4, "Select PE12 as the source input for the EXTI12 external interrupt"]
+      PF12: [5, "Select PF12 as the source input for the EXTI12 external interrupt"]
+      PG12: [6, "Select PG12 as the source input for the EXTI12 external interrupt"]
+    EXTI13:
+      PA13: [0, "Select PA13 as the source input for the EXTI13 external interrupt"]
+      PB13: [1, "Select PB13 as the source input for the EXTI13 external interrupt"]
+      PC13: [2, "Select PC13 as the source input for the EXTI13 external interrupt"]
+      PD13: [3, "Select PD13 as the source input for the EXTI13 external interrupt"]
+      PE13: [4, "Select PE13 as the source input for the EXTI13 external interrupt"]
+      PF13: [5, "Select PF13 as the source input for the EXTI13 external interrupt"]
+      PG13: [6, "Select PG13 as the source input for the EXTI13 external interrupt"]
+    EXTI14:
+      PA14: [0, "Select PA14 as the source input for the EXTI14 external interrupt"]
+      PB14: [1, "Select PB14 as the source input for the EXTI14 external interrupt"]
+      PC14: [2, "Select PC14 as the source input for the EXTI14 external interrupt"]
+      PD14: [3, "Select PD14 as the source input for the EXTI14 external interrupt"]
+      PE14: [4, "Select PE14 as the source input for the EXTI14 external interrupt"]
+      PF14: [5, "Select PF14 as the source input for the EXTI14 external interrupt"]
+      PG14: [6, "Select PG14 as the source input for the EXTI14 external interrupt"]
+    EXTI15:
+      PA15: [0, "Select PA15 as the source input for the EXTI15 external interrupt"]
+      PB15: [1, "Select PB15 as the source input for the EXTI15 external interrupt"]
+      PC15: [2, "Select PC15 as the source input for the EXTI15 external interrupt"]
+      PD15: [3, "Select PD15 as the source input for the EXTI15 external interrupt"]
+      PE15: [4, "Select PE15 as the source input for the EXTI15 external interrupt"]
+      PF15: [5, "Select PF15 as the source input for the EXTI15 external interrupt"]
+      PG15: [6, "Select PG15 as the source input for the EXTI15 external interrupt"]
+  CFGR2:
+    SRAM_PEF:
+      _read:
+        NoParityError: [0, "No SRAM parity error detected"]
+        ParityErrorDetected: [1, "SRAM parity error detected"]
+      _write:
+        Clear: [1, "Clear SRAM parity error flag"]
+    BYP_ADDR_PAR:
+      NoBypass: [0, "The ramload operation is performed taking into consideration bit 29 of the address when the parity is calculated"]
+      Bypass: [1, "The ramload operation is performed without taking into consideration bit 29 of the address when the parity is calculated"]
+    SRAM_PARITY_LOCK:
+      Disconnected: [0, "SRAM parity error disconnected from TIM1/15/16/17 Break input"]
+      Connected: [1, "SRAM parity error connected to TIM1/15/16/17 Break input"]
+    LOCKUP_LOCK:
+      Disconnected: [0, "Cortex-M4F LOCKUP output disconnected from TIM1/15/16/17 Break input"]
+      Connected: [1, "Cortex-M4F LOCKUP output connected to TIM1/15/16/17 Break input"]
+  CFGR3:
+    ADC2_DMA_RMP:
+      MapDma2: [0, "ADC2 mapped on DMA2"]
+      MapDma1Ch2: [3, "ADC2 mapped on DMA1 channel 2"]
+      MapDma1Ch4: [4, "DC2 mapped on DMA1 channel 4"]
+    I2C1_TX_DMA_RMP:
+      MapDma1Ch6: [0, "I2C1_TX mapped on DMA1 CH6"]
+      MapDma1Ch2: [1, "I2C1_TX mapped on DMA1 CH2"]
+      MapDma1Ch4: [2, "I2C1_TX mapped on DMA1 CH4"]
+    I2C1_RX_DMA_RMP:
+      MapDma1Ch7: [0, "I2C1_RX mapped on DMA1 CH7"]
+      MapDma1Ch3: [1, "I2C1_RX mapped on DMA1 CH3"]
+      MapDma1Ch5: [2, "I2C1_RX mapped on DMA1 CH5"]
+    SPI1_TX_DMA_RMP:
+      MapDma1Ch3: [0, "SPI1_TX mapped on DMA1 CH3"]
+      MapDma1Ch5: [1, "SPI1_TX mapped on DMA1 CH5"]
+      MapDma1Ch7: [2, "SPI1_TX mapped on DMA1 CH7"]
+    SPI1_RX_DMA_RMP:
+      MapDma1Ch3: [0, "SPI1_RX mapped on DMA1 CH2"]
+      MapDma1Ch5: [1, "SPI1_RX mapped on DMA1 CH4"]
+      MapDma1Ch7: [2, "SPI1_RX mapped on DMA1 CH6"]
+  CFGR4:
+    ADC34_JEXT14_RMP:
+      Tim7: [0, "Trigger source is TIM7_TRGO"]
+      Tim20: [1, "Trigger source is TIM20_CC2"]
+    ADC34_JEXT11_RMP:
+      Tim1: [0, "Trigger source is TIM1_CC3"]
+      Tim20: [1, "Trigger source is TIM20_TRGO2"]
+    ADC34_JEXT5_RMP:
+      Tim4: [0, "Trigger source is TIM4_CC3"]
+      Tim20: [1, "Trigger source is TIM20_TRGO"]
+    ADC34_EXT15_RMP:
+      Tim2: [0, "Trigger source is TIM2_CC1"]
+      Tim20: [1, "Trigger source is TIM20_CC1"]
+    ADC34_EXT6_RMP:
+      Tim4: [0, "Trigger source is TIM4_CC1"]
+      Tim20: [1, "Trigger source is TIM20_TRGO2"]
+    ADC34_EXT5_RMP:
+      Exti2: [0, "Trigger source is EXTI line 2 when reset at 0"]
+      Tim20: [1, "Trigger source is TIM20_TRGO"]
+    ADC12_JEXT13_RMP:
+      Tim3: [0, "Trigger source is TIM3_CC1"]
+      Tim20: [1, "Trigger source is TIM20_CC4"]
+    ADC12_JEXT6_RMP:
+      Exti15: [0, "Trigger source is EXTI line 15"]
+      Tim20: [1, "Trigger source is TIM20_TRGO2"]
+    ADC12_JEXT3_RMP:
+      Tim2: [0, "Trigger source is TIM2_CC1"]
+      Tim20: [1, "Trigger source is TIM20_TRGO"]
+    ADC12_EXT15_RMP:
+      Tim3: [0, "Trigger source is TIM3_CC4"]
+      Tim20: [1, "Trigger source is TIM20_CC3"]
+    ADC12_EXT13_RMP:
+      Tim6: [0, "Trigger source is TIM6_TRGO"]
+      Tim20: [1, "Trigger source is TIM20_CC2"]
+    ADC12_EXT5_RMP:
+      Tim4: [0, "Trigger source is TIM4_CC4"]
+      Tim20: [1, "Trigger source is TIM20_CC1"]
+    ADC12_EXT3_RMP:
+      Tim2: [0, "Trigger source is TIM2_CC2"]
+      Tim20: [1, "rigger source is TIM20_TRGO2"]
+    ADC12_EXT2_RMP:
+      Tim1: [0, "Trigger source is TIM3_CC3"]
+      Tim20: [1, "rigger source is TIM20_TRGO"]

--- a/peripherals/syscfg/syscfg_f37x.yaml
+++ b/peripherals/syscfg/syscfg_f37x.yaml
@@ -1,0 +1,137 @@
+SYSCFG:
+  CFGR1:
+    VBAT_MON:
+      Disable: [0, "Disable the power switch to not deliver VBAT voltage on ADC channel 18 input"]
+      Enable: [1, "Enable the power switch to deliver VBAT voltage on ADC channel 18 input"]
+    TIM18_DAC2_OUT1_DMA_RMP:
+      NotRemapped: [0, "TIM18 and DAC2_OUT1 DMA requests mapped on DMA2 channel 5"]
+      Remapped: [1, "TIM18 and DAC2_OUT1 DMA requests mapped on DMA1 channel 5"]
+    TIM7_DAC1_OUT2_DMA_RMP:
+      NotRemapped: [0, "TIM7 and DAC1_OUT2 DMA requests mapped on DMA2 channel 4"]
+      Remapped: [1, "TIM7 and DAC1_OUT2 DMA requests mapped on DMA1 channel 4"]
+    TIM6_DAC1_OUT1_DMA_RMP:
+      NotRemapped: [0, "TIM7 and DAC1_OUT1 DMA requests mapped on DMA2 channel 3"]
+      Remapped: [1, "TIM7 and DAC1_OUT1 DMA requests mapped on DMA1 channel 3"]
+    MEM_MODE:
+      MainFlash: [0, "Main Flash memory mapped at 0x0000_0000"]
+      SystemFlash: [1, "System Flash memory mapped at 0x0000_0000"]
+      MainFlash2: [2, "Main Flash memory mapped at 0x0000_0000"]
+      SRAM: [3, "Embedded SRAM mapped at 0x0000_0000"]
+  EXTICR1:
+    EXTI0:
+      PA0: [0, "Select PA0 as the source input for the EXTI0 external interrupt"]
+      PB0: [1, "Select PB0 as the source input for the EXTI0 external interrupt"]
+      PC0: [2, "Select PC0 as the source input for the EXTI0 external interrupt"]
+      PD0: [3, "Select PD0 as the source input for the EXTI0 external interrupt"]
+      PE0: [4, "Select PE0 as the source input for the EXTI0 external interrupt"]
+      PF0: [5, "Select PF0 as the source input for the EXTI0 external interrupt"]
+    EXTI1:
+      PA1: [0, "Select PA1 as the source input for the EXTI1 external interrupt"]
+      PB1: [1, "Select PB1 as the source input for the EXTI1 external interrupt"]
+      PC1: [2, "Select PC1 as the source input for the EXTI1 external interrupt"]
+      PD1: [3, "Select PD1 as the source input for the EXTI1 external interrupt"]
+      PE1: [4, "Select PE1 as the source input for the EXTI1 external interrupt"]
+      PF1: [5, "Select PF1 as the source input for the EXTI1 external interrupt"]
+    EXTI2:
+      PA2: [0, "Select PA2 as the source input for the EXTI2 external interrupt"]
+      PB2: [1, "Select PB2 as the source input for the EXTI2 external interrupt"]
+      PC2: [2, "Select PC2 as the source input for the EXTI2 external interrupt"]
+      PD2: [3, "Select PD2 as the source input for the EXTI2 external interrupt"]
+      PE2: [4, "Select PE2 as the source input for the EXTI2 external interrupt"]
+      PF2: [5, "Select PF2 as the source input for the EXTI2 external interrupt"]
+    EXTI3:
+      PA3: [0, "Select PA3 as the source input for the EXTI3 external interrupt"]
+      PB3: [1, "Select PB3 as the source input for the EXTI3 external interrupt"]
+      PC3: [2, "Select PC3 as the source input for the EXTI3 external interrupt"]
+      PD3: [3, "Select PD3 as the source input for the EXTI3 external interrupt"]
+      PE3: [4, "Select PE3 as the source input for the EXTI3 external interrupt"]
+  EXTICR2:
+    EXTI4:
+      PA4: [0, "Select PA4 as the source input for the EXTI4 external interrupt"]
+      PB4: [1, "Select PB4 as the source input for the EXTI4 external interrupt"]
+      PC4: [2, "Select PC4 as the source input for the EXTI4 external interrupt"]
+      PD4: [3, "Select PD4 as the source input for the EXTI4 external interrupt"]
+      PE4: [4, "Select PE4 as the source input for the EXTI4 external interrupt"]
+      PF4: [5, "Select PF4 as the source input for the EXTI4 external interrupt"]
+    EXTI5:
+      PA5: [0, "Select PA5 as the source input for the EXTI5 external interrupt"]
+      PB5: [1, "Select PB5 as the source input for the EXTI5 external interrupt"]
+      PC5: [2, "Select PC5 as the source input for the EXTI5 external interrupt"]
+      PD5: [3, "Select PD5 as the source input for the EXTI5 external interrupt"]
+      PE5: [4, "Select PE5 as the source input for the EXTI5 external interrupt"]
+    EXTI6:
+      PA6: [0, "Select PA6 as the source input for the EXTI6 external interrupt"]
+      PB6: [1, "Select PB6 as the source input for the EXTI6 external interrupt"]
+      PC6: [2, "Select PC6 as the source input for the EXTI6 external interrupt"]
+      PD6: [3, "Select PD6 as the source input for the EXTI6 external interrupt"]
+      PE6: [4, "Select PE6 as the source input for the EXTI6 external interrupt"]
+      PF6: [5, "Select PF6 as the source input for the EXTI6 external interrupt"]
+    EXTI7:
+      PA7: [0, "Select PA7 as the source input for the EXTI7 external interrupt"]
+      PB7: [1, "Select PB7 as the source input for the EXTI7 external interrupt"]
+      PC7: [2, "Select PC7 as the source input for the EXTI7 external interrupt"]
+      PD7: [3, "Select PD7 as the source input for the EXTI7 external interrupt"]
+      PE7: [4, "Select PE7 as the source input for the EXTI7 external interrupt"]
+      PF7: [5, "Select PF7 as the source input for the EXTI7 external interrupt"]
+  EXTICR3:
+    EXTI8:
+      PA8: [0, "Select PA8 as the source input for the EXTI8 external interrupt"]
+      PB8: [1, "Select PB8 as the source input for the EXTI8 external interrupt"]
+      PC8: [2, "Select PC8 as the source input for the EXTI8 external interrupt"]
+      PD8: [3, "Select PD8 as the source input for the EXTI8 external interrupt"]
+      PE8: [4, "Select PE8 as the source input for the EXTI8 external interrupt"]
+    EXTI9:
+      PA9: [0, "Select PA9 as the source input for the EXTI9 external interrupt"]
+      PB9: [1, "Select PB9 as the source input for the EXTI9 external interrupt"]
+      PC9: [2, "Select PC9 as the source input for the EXTI9 external interrupt"]
+      PD9: [3, "Select PD9 as the source input for the EXTI9 external interrupt"]
+      PE9: [4, "Select PE9 as the source input for the EXTI9 external interrupt"]
+      PF9: [5, "Select PF9 as the source input for the EXTI9 external interrupt"]
+    EXTI10:
+      PA10: [0, "Select PA10 as the source input for the EXTI10 external interrupt"]
+      PB10: [1, "Select PB10 as the source input for the EXTI10 external interrupt"]
+      PC10: [2, "Select PC10 as the source input for the EXTI10 external interrupt"]
+      PD10: [3, "Select PD10 as the source input for the EXTI10 external interrupt"]
+      PE10: [4, "Select PE10 as the source input for the EXTI10 external interrupt"]
+      PF10: [5, "Select PF10 as the source input for the EXTI10 external interrupt"]
+    EXTI11:
+      PA11: [0, "Select PA11 as the source input for the EXTI11 external interrupt"]
+      PC11: [2, "Select PC11 as the source input for the EXTI11 external interrupt"]
+      PD11: [3, "Select PD11 as the source input for the EXTI11 external interrupt"]
+      PE11: [4, "Select PE11 as the source input for the EXTI11 external interrupt"]
+  EXTICR4:
+    EXTI12:
+      PA12: [0, "Select PA12 as the source input for the EXTI12 external interrupt"]
+      PC12: [2, "Select PC12 as the source input for the EXTI12 external interrupt"]
+      PD12: [3, "Select PD12 as the source input for the EXTI12 external interrupt"]
+      PE12: [4, "Select PE12 as the source input for the EXTI12 external interrupt"]
+    EXTI13:
+      PA13: [0, "Select PA13 as the source input for the EXTI13 external interrupt"]
+      PC13: [2, "Select PC13 as the source input for the EXTI13 external interrupt"]
+      PD13: [3, "Select PD13 as the source input for the EXTI13 external interrupt"]
+      PE13: [4, "Select PE13 as the source input for the EXTI13 external interrupt"]
+    EXTI14:
+      PA14: [0, "Select PA14 as the source input for the EXTI14 external interrupt"]
+      PB14: [1, "Select PB14 as the source input for the EXTI14 external interrupt"]
+      PC14: [2, "Select PC14 as the source input for the EXTI14 external interrupt"]
+      PD14: [3, "Select PD14 as the source input for the EXTI14 external interrupt"]
+      PE14: [4, "Select PE14 as the source input for the EXTI14 external interrupt"]
+    EXTI15:
+      PA15: [0, "Select PA15 as the source input for the EXTI15 external interrupt"]
+      PB15: [1, "Select PB15 as the source input for the EXTI15 external interrupt"]
+      PC15: [2, "Select PC15 as the source input for the EXTI15 external interrupt"]
+      PD15: [3, "Select PD15 as the source input for the EXTI15 external interrupt"]
+      PE15: [4, "Select PE15 as the source input for the EXTI15 external interrupt"]
+  CFGR2:
+    SRAM_PEF:
+      _read:
+        NoParityError: [0, "No SRAM parity error detected"]
+        ParityErrorDetected: [1, "SRAM parity error detected"]
+      _write:
+        Clear: [1, "Clear SRAM parity error flag"]
+    SRAM_PARITY_LOCK:
+      Disconnected: [0, "SRAM parity error disconnected from TIM1/15/16/17 Break input"]
+      Connected: [1, "SRAM parity error connected to TIM1/15/16/17 Break input"]
+    LOCKUP_LOCK:
+      Disconnected: [0, "Cortex-M4F LOCKUP output disconnected from TIM1/15/16/17 Break input"]
+      Connected: [1, "Cortex-M4F LOCKUP output connected to TIM1/15/16/17 Break input"]

--- a/peripherals/syscfg/syscfg_f3_cfgr2_pvd_lock.yaml
+++ b/peripherals/syscfg/syscfg_f3_cfgr2_pvd_lock.yaml
@@ -1,0 +1,5 @@
+SYSCFG:
+  CFGR2:
+    PVD_LOCK:
+      Disconnected: [0, "PVD interrupt disconnected from TIM15/16/17 Break input"]
+      Connected: [1, "PVD interrupt connected to TIM15/16/17 Break input"]

--- a/peripherals/syscfg/syscfg_f3x4.yaml
+++ b/peripherals/syscfg/syscfg_f3x4.yaml
@@ -1,0 +1,181 @@
+SYSCFG:
+  CFGR1:
+    ENCODER_MODE:
+      NoRedirection: [0, "No redirection"]
+      MapTim2Tim15: [1, "TIM2 IC1 and TIM2 IC2 are connected to TIM15 IC1 and TIM15 IC2 respectively"]
+      MapTim3Tim15: [2, "TIM3 IC1 and TIM3 IC2 are connected to TIM15 IC1 and TIM15 IC2 respectively"]
+    DAC2_CH1_DMA_RMP:
+      NotRemapped: [0, "Not remapped"]
+      Remapped: [1, "DAC2_CH1 DMA requests mapped on DMA1 channel 5"]
+    TIM7_DAC1_CH2_DMA_RMP:
+      NotRemapped: [0, "Not remapped"]
+      Remapped: [1, "TIM7_UP and DAC_CH2 DMA requests mapped on DMA1 channel 4"]
+    TIM6_DAC1_CH1_DMA_RMP:
+      NotRemapped: [0, "TIM6_UP and DAC_CH1 DMA requests mapped on DMA2 channel 3"]
+      Remapped: [1, "TIM6_UP and DAC_CH1 DMA requests mapped on DMA1 channel 3"]
+    DAC_TRIG_RMP:
+      NotRemapped: [0, "Not remapped"]
+      Remapped: [1, "DAC trigger is TIM3_TRGO"]
+    TIM1_ITR3_RMP:
+      NotRemapped: [0, "Not remapped"]
+      Remapped: [1, "TIM1_ITR3 = TIM17_OC"]
+    MEM_MODE:
+      MainFlash: [0, "Main Flash memory mapped at 0x0000_0000"]
+      SystemFlash: [1, "System Flash memory mapped at 0x0000_0000"]
+      MainFlash2: [2, "Main Flash memory mapped at 0x0000_0000"]
+      SRAM: [3, "Embedded SRAM mapped at 0x0000_0000"]
+  RCR:
+    PAGE*_WP:
+      Disabled: [0, "Write protection of pagex is disabled"]
+      Enabled: [1, "Write protection of pagex is enabled"]
+  EXTICR1:
+    EXTI0:
+      PA0: [0, "Select PA0 as the source input for the EXTI0 external interrupt"]
+      PB0: [1, "Select PB0 as the source input for the EXTI0 external interrupt"]
+      PC0: [2, "Select PC0 as the source input for the EXTI0 external interrupt"]
+      PD0: [3, "Select PD0 as the source input for the EXTI0 external interrupt"]
+      PE0: [4, "Select PE0 as the source input for the EXTI0 external interrupt"]
+      PF0: [5, "Select PF0 as the source input for the EXTI0 external interrupt"]
+    EXTI1:
+      PA1: [0, "Select PA1 as the source input for the EXTI1 external interrupt"]
+      PB1: [1, "Select PB1 as the source input for the EXTI1 external interrupt"]
+      PC1: [2, "Select PC1 as the source input for the EXTI1 external interrupt"]
+      PD1: [3, "Select PD1 as the source input for the EXTI1 external interrupt"]
+      PE1: [4, "Select PE1 as the source input for the EXTI1 external interrupt"]
+      PF1: [5, "Select PF1 as the source input for the EXTI1 external interrupt"]
+    EXTI2:
+      PA2: [0, "Select PA2 as the source input for the EXTI2 external interrupt"]
+      PB2: [1, "Select PB2 as the source input for the EXTI2 external interrupt"]
+      PC2: [2, "Select PC2 as the source input for the EXTI2 external interrupt"]
+      PD2: [3, "Select PD2 as the source input for the EXTI2 external interrupt"]
+      PE2: [4, "Select PE2 as the source input for the EXTI2 external interrupt"]
+      PF2: [5, "Select PF2 as the source input for the EXTI2 external interrupt"]
+    EXTI3:
+      PA3: [0, "Select PA3 as the source input for the EXTI3 external interrupt"]
+      PB3: [1, "Select PB3 as the source input for the EXTI3 external interrupt"]
+      PC3: [2, "Select PC3 as the source input for the EXTI3 external interrupt"]
+      PD3: [3, "Select PD3 as the source input for the EXTI3 external interrupt"]
+      PE3: [4, "Select PE3 as the source input for the EXTI3 external interrupt"]
+  EXTICR2:
+    EXTI4:
+      PA4: [0, "Select PA4 as the source input for the EXTI4 external interrupt"]
+      PB4: [1, "Select PB4 as the source input for the EXTI4 external interrupt"]
+      PC4: [2, "Select PC4 as the source input for the EXTI4 external interrupt"]
+      PD4: [3, "Select PD4 as the source input for the EXTI4 external interrupt"]
+      PE4: [4, "Select PE4 as the source input for the EXTI4 external interrupt"]
+      PF4: [5, "Select PF4 as the source input for the EXTI4 external interrupt"]
+    EXTI5:
+      PA5: [0, "Select PA5 as the source input for the EXTI5 external interrupt"]
+      PB5: [1, "Select PB5 as the source input for the EXTI5 external interrupt"]
+      PC5: [2, "Select PC5 as the source input for the EXTI5 external interrupt"]
+      PD5: [3, "Select PD5 as the source input for the EXTI5 external interrupt"]
+      PE5: [4, "Select PE5 as the source input for the EXTI5 external interrupt"]
+      PF5: [5, "Select PF5 as the source input for the EXTI5 external interrupt"]
+    EXTI6:
+      PA6: [0, "Select PA6 as the source input for the EXTI6 external interrupt"]
+      PB6: [1, "Select PB6 as the source input for the EXTI6 external interrupt"]
+      PC6: [2, "Select PC6 as the source input for the EXTI6 external interrupt"]
+      PD6: [3, "Select PD6 as the source input for the EXTI6 external interrupt"]
+      PE6: [4, "Select PE6 as the source input for the EXTI6 external interrupt"]
+      PF6: [5, "Select PF6 as the source input for the EXTI6 external interrupt"]
+    EXTI7:
+      PA7: [0, "Select PA7 as the source input for the EXTI7 external interrupt"]
+      PB7: [1, "Select PB7 as the source input for the EXTI7 external interrupt"]
+      PC7: [2, "Select PC7 as the source input for the EXTI7 external interrupt"]
+      PD7: [3, "Select PD7 as the source input for the EXTI7 external interrupt"]
+      PE7: [4, "Select PE7 as the source input for the EXTI7 external interrupt"]
+  EXTICR3:
+    EXTI8:
+      PA8: [0, "Select PA8 as the source input for the EXTI8 external interrupt"]
+      PB8: [1, "Select PB8 as the source input for the EXTI8 external interrupt"]
+      PC8: [2, "Select PC8 as the source input for the EXTI8 external interrupt"]
+      PD8: [3, "Select PD8 as the source input for the EXTI8 external interrupt"]
+      PE8: [4, "Select PE8 as the source input for the EXTI8 external interrupt"]
+    EXTI9:
+      PA9: [0, "Select PA9 as the source input for the EXTI9 external interrupt"]
+      PB9: [1, "Select PB9 as the source input for the EXTI9 external interrupt"]
+      PC9: [2, "Select PC9 as the source input for the EXTI9 external interrupt"]
+      PD9: [3, "Select PD9 as the source input for the EXTI9 external interrupt"]
+      PE9: [4, "Select PE9 as the source input for the EXTI9 external interrupt"]
+      PF9: [5, "Select PF9 as the source input for the EXTI9 external interrupt"]
+    EXTI10:
+      PA10: [0, "Select PA10 as the source input for the EXTI10 external interrupt"]
+      PB10: [1, "Select PB10 as the source input for the EXTI10 external interrupt"]
+      PC10: [2, "Select PC10 as the source input for the EXTI10 external interrupt"]
+      PD10: [3, "Select PD10 as the source input for the EXTI10 external interrupt"]
+      PE10: [4, "Select PE10 as the source input for the EXTI10 external interrupt"]
+      PF10: [5, "Select PF10 as the source input for the EXTI10 external interrupt"]
+    EXTI11:
+      PA11: [0, "Select PA11 as the source input for the EXTI11 external interrupt"]
+      PB11: [1, "Select PB11 as the source input for the EXTI11 external interrupt"]
+      PC11: [2, "Select PC11 as the source input for the EXTI11 external interrupt"]
+      PD11: [3, "Select PD11 as the source input for the EXTI11 external interrupt"]
+      PE11: [4, "Select PE11 as the source input for the EXTI11 external interrupt"]
+  EXTICR4:
+    EXTI12:
+      PA12: [0, "Select PA12 as the source input for the EXTI12 external interrupt"]
+      PB12: [1, "Select PB12 as the source input for the EXTI12 external interrupt"]
+      PC12: [2, "Select PC12 as the source input for the EXTI12 external interrupt"]
+      PD12: [3, "Select PD12 as the source input for the EXTI12 external interrupt"]
+      PE12: [4, "Select PE12 as the source input for the EXTI12 external interrupt"]
+    EXTI13:
+      PA13: [0, "Select PA13 as the source input for the EXTI13 external interrupt"]
+      PB13: [1, "Select PB13 as the source input for the EXTI13 external interrupt"]
+      PC13: [2, "Select PC13 as the source input for the EXTI13 external interrupt"]
+      PD13: [3, "Select PD13 as the source input for the EXTI13 external interrupt"]
+      PE13: [4, "Select PE13 as the source input for the EXTI13 external interrupt"]
+    EXTI14:
+      PA14: [0, "Select PA14 as the source input for the EXTI14 external interrupt"]
+      PB14: [1, "Select PB14 as the source input for the EXTI14 external interrupt"]
+      PC14: [2, "Select PC14 as the source input for the EXTI14 external interrupt"]
+      PD14: [3, "Select PD14 as the source input for the EXTI14 external interrupt"]
+      PE14: [4, "Select PE14 as the source input for the EXTI14 external interrupt"]
+    EXTI15:
+      PA15: [0, "Select PA15 as the source input for the EXTI15 external interrupt"]
+      PB15: [1, "Select PB15 as the source input for the EXTI15 external interrupt"]
+      PC15: [2, "Select PC15 as the source input for the EXTI15 external interrupt"]
+      PD15: [3, "Select PD15 as the source input for the EXTI15 external interrupt"]
+      PE15: [4, "Select PE15 as the source input for the EXTI15 external interrupt"]
+  CFGR2:
+    SRAM_PEF:
+      _read:
+        NoParityError: [0, "No SRAM parity error detected"]
+        ParityErrorDetected: [1, "SRAM parity error detected"]
+      _write:
+        Clear: [1, "Clear SRAM parity error flag"]
+    BYP_ADDR_PAR:
+      NoBypass: [0, "The ramload operation is performed taking into consideration bit 29 of the address when the parity is calculated"]
+      Bypass: [1, "The ramload operation is performed without taking into consideration bit 29 of the address when the parity is calculated"]
+    SRAM_PARITY_LOCK:
+      Disconnected: [0, "SRAM parity error signal disconnected from TIM1/15/16/17 and HRTIM1 SYSFLT Break inputs"]
+      Connected: [1, "SRAM parity error signal connected to TIM1/15/16/17 and HRTIM1 SYSFLT Break inputs"]
+    LOCKUP_LOCK:
+      Disconnected: [0, "Cortex-M4 LOCKUP output disconnected from TIM1/15/16/17 Break inputs and HRTIM1 SYSFLT."]
+      Connected: [1, "Cortex-M4 LOCKUP output connected to TIM1/15/16/17 and HRTIM1 SYSFLT Break inputs"]
+  CFGR3:
+    DAC1_TRIG5_RMP:
+      NotRemapped: [0, "Not remapped"]
+      Remapped: [1, "DAC trigger is HRTIM1_DAC1_TRIG2"]
+    DAC1_TRIG3_RMP:
+      Tim15: [0, "DAC trigger is TIM15_TRGO"]
+      HrTim1: [1, "DAC trigger is HRTIM1_DAC1_TRIG1"]
+    ADC2_DMA_RMP:
+      MapDma2: [0, "ADC2 mapped on DMA2"]
+      MapDma1Ch2: [3, "ADC2 mapped on DMA1 channel 2"]
+      MapDma1Ch4: [4, "DC2 mapped on DMA1 channel 4"]
+    I2C1_TX_DMA_RMP:
+      MapDma1Ch6: [0, "I2C1_TX mapped on DMA1 CH6"]
+      MapDma1Ch2: [1, "I2C1_TX mapped on DMA1 CH2"]
+      MapDma1Ch4: [2, "I2C1_TX mapped on DMA1 CH4"]
+    I2C1_RX_DMA_RMP:
+      MapDma1Ch7: [0, "I2C1_RX mapped on DMA1 CH7"]
+      MapDma1Ch3: [1, "I2C1_RX mapped on DMA1 CH3"]
+      MapDma1Ch5: [2, "I2C1_RX mapped on DMA1 CH5"]
+    SPI1_TX_DMA_RMP:
+      MapDma1Ch3: [0, "SPI1_TX mapped on DMA1 CH3"]
+      MapDma1Ch5: [1, "SPI1_TX mapped on DMA1 CH5"]
+      MapDma1Ch7: [2, "SPI1_TX mapped on DMA1 CH7"]
+    SPI1_RX_DMA_RMP:
+      MapDma1Ch3: [0, "SPI1_RX mapped on DMA1 CH2"]
+      MapDma1Ch5: [1, "SPI1_RX mapped on DMA1 CH4"]
+      MapDma1Ch7: [2, "SPI1_RX mapped on DMA1 CH6"]


### PR DESCRIPTION
This should cover 100 % of the syscfg register from the stm32f3 devices. 

- I left quite a view TODOs regarding naming and doubled values, as I'm unsure how to go about this
- Some files could be split to smaller chunks, to reduce the duplication (however some devices slightly differ in their description strings and syscfg control register are sometimes quiet different between the devices)
- I split up the FPU_IE into it's five flags, as it seems, that they are independent of each other (correct me if I'm wrong about this)
- This PR is split into many small commits intentionally. This should make it easier to sqaush it into larger more reasonable commits after all review comments are addressed. 