### PR TITLE
Use wildcard in bors.toml instead of specifying each build

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -1,6 +1,5 @@
 required_approvals = 1
 block_labels = ["wip"]
 delete_merged_branches = true
-status = [
-    "Check (%)",
-]
+status = ["Check (%)"]
+status_wait_success = ["Check (%)"]

--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -2,17 +2,5 @@ required_approvals = 1
 block_labels = ["wip"]
 delete_merged_branches = true
 status = [
-    "Check (stm32f0)",
-    "Check (stm32f1)",
-    "Check (stm32f2)",
-    "Check (stm32f3)",
-    "Check (stm32f4)",
-    "Check (stm32f7)",
-    "Check (stm32h7)",
-    "Check (stm32l0)",
-    "Check (stm32l1)",
-    "Check (stm32l4)",
-    "Check (stm32l5)",
-    "Check (stm32g0)",
-    "Check (stm32g4)",
+    "Check (%)",
 ]


### PR DESCRIPTION
According to the bors documentation SQL-like wildcards are allowed