### PR TITLE
h7: Change DBGSTBY_D3 and DBGSTOP_D3 to reserved in DBGMCU CR

### DIFF
--- a/devices/common_patches/h7_dbgmcu.yaml
+++ b/devices/common_patches/h7_dbgmcu.yaml
@@ -1,4 +1,4 @@
-# Add H7 DBGMCU peripheral. From RM0433 rev 6
+# Add H7 DBGMCU peripheral. From RM0433 rev 7
 
 _add:
   DBGMCU:
@@ -45,14 +45,6 @@ _add:
           TRACECLKEN:
             description: Trace clock enable enable
             bitOffset: 20
-            bitWidth: 1
-          DBGSTBY_D3:
-            description: Allow debug in D3 Standby mode
-            bitOffset: 8
-            bitWidth: 1
-          DBGSTOP_D3:
-            description: Allow debug in D3 Stop mode
-            bitOffset: 7
             bitWidth: 1
           DBGSTBY_D1:
             description: Allow debug in D1 Standby mode


### PR DESCRIPTION
Update to match latest version of RM0433 and RM0399. Based on discussion with @diondokter [here](https://github.com/stm32-rs/stm32h7xx-hal/issues/7) setting these bits causes some undocumented clock gating or logic problem in the DBGMCU. ST have likely removed these bits to 'solve' this problem.