### PR TITLE
Do not add writeConstraints to DMA address registers

### DIFF
--- a/peripherals/dma/dma_v1.yaml
+++ b/peripherals/dma/dma_v1.yaml
@@ -64,7 +64,3 @@
       Enabled: [1, "Channel enabled"]
   "CNDTR*":
     NDT: [0, 65535]
-  "CPAR*":
-    PA: [0, 4294967295]
-  "CMAR*":
-    MA: [0, 4294967295]

--- a/peripherals/dma/dma_v3.yaml
+++ b/peripherals/dma/dma_v3.yaml
@@ -82,10 +82,6 @@
       Enabled: [1, "Stream enabled"]
   "S?NDTR":
     NDT: [0, 65535]
-  "S?PAR":
-    PA: [0, 4294967295]
-  "S?M?AR":
-    "M?A": [0, 4294967295]
   "S?FCR":
     FEIE:
       Disabled: [0, "FE interrupt disabled"]

--- a/peripherals/eth/eth_dma_common.yaml
+++ b/peripherals/eth/eth_dma_common.yaml
@@ -78,13 +78,11 @@
         description: Receive poll demand
 
   DMARDLAR:
-    SRL: [0, 0xFFFFFFFF]
     _modify:
       SRL:
         description: Start of receive list
 
   DMATDLAR:
-    STL: [0, 0xFFFFFFFF]
     _modify:
       STL:
         description: Start of transmit list


### PR DESCRIPTION
Currently we mark these fields with a writeConstraint of any 32-bit value, which means svd2rust generates a safe `bits()` method to write to them. In turn, this allows entirely safe code to use the DMA to read or write any address, which can cause memory unsafety.

Ideally perhaps svd2rust shouldn't act like this, but by removing these writeConstraints we make the relevant `bits()` methods unsafe, so unsafe code is required to use the DMA engine. A HAL with a DMA driver can implement a safe abstraction using the upcoming DMA traits to ensure the addresses being written do not lead to unsafety.

What do people think about this change? Especially it might impact @thalesfragoso's DMA and stm32-eth work.