### PR TITLE
h7: Rename USBxOTGHSEN -> USBxOTGEN, USBxOTGULPIHSEN -> USBxULPIEN

### DIFF
--- a/devices/common_patches/h7_common_dualcore.yaml
+++ b/devices/common_patches/h7_common_dualcore.yaml
@@ -558,15 +558,6 @@ RCC:
         description: ART Clock Enable
         bitOffset: 14
         bitWidth: 1
-    _modify:
-      USB1OTGEN:
-        name: USB1OTGHSEN
-      USB2OTGEN:
-        name: USB2OTGHSEN
-      USB1ULPIEN:
-        name: USB1OTGHSULPIEN
-    _delete:
-      - USB2ULPIEN
   AHB2ENR,C1_AHB2ENR:
     _modify:
       CAMITFEN:
@@ -584,15 +575,6 @@ RCC:
         description: ART Clock Enable During CSleep Mode
         bitOffset: 14
         bitWidth: 1
-    _modify:
-      USB1OTGLPEN:
-        name: USB1OTGHSLPEN
-      USB2OTGLPEN:
-        name: USB2OTGHSLPEN
-      USB1ULPILPEN:
-        name: USB1OTGHSULPILPEN
-      USB2ULPILPEN:
-        name: USB2OTGHSULPILPEN
   AHB2LPENR,C1_AHB2LPENR:
     _modify:
       CAMITFLPEN:

--- a/devices/common_patches/h7_common_highmemory.yaml
+++ b/devices/common_patches/h7_common_highmemory.yaml
@@ -503,14 +503,8 @@ RCC:
       HDMICECLPEN:
         name: CECLPEN
   AHB1ENR:
-    _modify:
-      USB1OTGEN:
-        name: USB1OTGHSEN
-      USB2OTGEN:
-        name: USB2OTGHSEN
-      USB1ULPIEN:
-        name: USB1OTGHSULPIEN
-    _delete:
+    _delete:                    # highmemory only has one USB HS
+      - USB2OTGEN
       - USB2ULPIEN
   AHB2ENR:
     _modify:
@@ -518,15 +512,9 @@ RCC:
         name: DCMIEN
         description: "DCMI peripheral clock"
   AHB1LPENR:
-    _modify:
-      USB1OTGLPEN:
-        name: USB1OTGHSLPEN
-      USB2OTGLPEN:
-        name: USB2OTGHSLPEN
-      USB1ULPILPEN:
-        name: USB1OTGHSULPILPEN
-      USB2ULPILPEN:
-        name: USB2OTGHSULPILPEN
+    _delete:                    # highmemory only has one USB HS
+      - USB2OTGLPEN
+      - USB2ULPILPEN
   AHB2LPENR:
     _modify:
       CAMITFLPEN:

--- a/devices/common_patches/h7_common_singlecore.yaml
+++ b/devices/common_patches/h7_common_singlecore.yaml
@@ -447,14 +447,14 @@ RCC:
         name: CECEN
   AHB1ENR,C1_AHB1ENR:
     _modify:
-      USB1OTGEN:
-        name: USB1OTGHSEN
-      USB2OTGEN:
-        name: USB2OTGHSEN
-      USB1ULPIEN:
-        name: USB1OTGHSULPIEN
-    _delete:
-      - USB2ULPIEN
+      USB1OTGHSEN:
+        name: USB1OTGEN
+      USB2OTGHSEN:
+        name: USB2OTGEN
+      USB1ULPIHSEN:
+        name: USB1ULPIEN
+      USB2ULPIHSEN:
+        name: USB2ULPIEN
   AHB2ENR,C1_AHB2ENR:
     _modify:
       CAMITFEN:
@@ -464,16 +464,16 @@ RCC:
     _modify:
       HDMICECLPEN:
         name: CECLPEN
-  C1_AHB1LPENR:
+  AHB1LPENR,C1_AHB1LPENR:
     _modify:
-      USB1OTGLPEN:
-        name: USB1OTGHSLPEN
-      USB2OTGLPEN:
-        name: USB2OTGHSLPEN
-      USB1ULPILPEN:
-        name: USB1OTGHSULPILPEN
-      USB2ULPILPEN:
-        name: USB2OTGHSULPILPEN
+      USB1OTGHSLPEN:
+        name: USB1OTGLPEN
+      USB2OTGHSLPEN:
+        name: USB2OTGLPEN
+      USB1ULPIHSLPEN:
+        name: USB1ULPILPEN
+      USB2ULPIHSLPEN:
+        name: USB2ULPILPEN
   AHB2LPENR,C1_AHB2LPENR:
     _modify:
       CAMITFLPEN:


### PR DESCRIPTION
The effect of this PR is different between the H7 groupings:

**highmemory (RM0455):** This change brings us in line with the RM, fixing a mistake on our part

**singlecore/dualcore (RM0433/RM0399):** Breaks with the RM, instead preferring a more consistent scheme that matches RM0455. All other peripherals enable/resets are in the form name{en,rst} , so having the inconsistent name{hsen,rst} is a pain.

I'm not sure the existance of USB2ULPIEN makes any sense (the USB2 peripheral has no ULPI), but it is RM0433/RM0399.