### PR TITLE
Add Basic DMA

### DIFF
--- a/devices/common_patches/dma/bdma.yaml
+++ b/devices/common_patches/dma/bdma.yaml
@@ -1,0 +1,170 @@
+"BDMA*":
+  _add:
+    CM1AR0:
+      description: Channel x memory 1 address register
+      addressOffset: 0x18
+      access: read-write
+      resetValue: 0x00000000
+      fields:
+        MA:
+          description: Memory address
+          bitOffset: 0
+          bitWidth: 32
+    CM1AR1:
+      description: Channel x memory 1 address register
+      addressOffset: 0x2C
+      access: read-write
+      resetValue: 0x00000000
+      fields:
+        MA:
+          description: Memory address
+          bitOffset: 0
+          bitWidth: 32
+    CM1AR2:
+      description: Channel x memory 1 address register
+      addressOffset: 0x40
+      access: read-write
+      resetValue: 0x00000000
+      fields:
+        MA:
+          description: Memory address
+          bitOffset: 0
+          bitWidth: 32
+    CM1AR3:
+      description: Channel x memory 1 address register
+      addressOffset: 0x54
+      access: read-write
+      resetValue: 0x00000000
+      fields:
+        MA:
+          description: Memory address
+          bitOffset: 0
+          bitWidth: 32
+    CM1AR4:
+      description: Channel x memory 1 address register
+      addressOffset: 0x68
+      access: read-write
+      resetValue: 0x00000000
+      fields:
+        MA:
+          description: Memory address
+          bitOffset: 0
+          bitWidth: 32
+    CM1AR5:
+      description: Channel x memory 1 address register
+      addressOffset: 0x7C
+      access: read-write
+      resetValue: 0x00000000
+      fields:
+        MA:
+          description: Memory address
+          bitOffset: 0
+          bitWidth: 32
+    CM1AR6:
+      description: Channel x memory 1 address register
+      addressOffset: 0x90
+      access: read-write
+      resetValue: 0x00000000
+      fields:
+        MA:
+          description: Memory address
+          bitOffset: 0
+          bitWidth: 32
+    CM1AR7:
+      description: Channel x memory 1 address register
+      addressOffset: 0xA4
+      access: read-write
+      resetValue: 0x00000000
+      fields:
+        MA:
+          description: Memory address
+          bitOffset: 0
+          bitWidth: 32
+  _modify:
+    CMAR1:
+      name: CM0AR0
+    CMAR2:
+      name: CM0AR1
+    CMAR3:
+      name: CM0AR2
+    CMAR4:
+      name: CM0AR3
+    CMAR5:
+      name: CM0AR4
+    CMAR6:
+      name: CM0AR5
+    CMAR7:
+      name: CM0AR6
+    CMAR8:
+      name: CM0AR7
+    CCR1:
+      name: CCR0
+    CCR2:
+      name: CCR1
+    CCR3:
+      name: CCR2
+    CCR4:
+      name: CCR3
+    CCR5:
+      name: CCR4
+    CCR6:
+      name: CCR5
+    CCR7:
+      name: CCR6
+    CCR8:
+      name: CCR7
+    CNDTR1:
+      name: CNDTR0
+    CNDTR2:
+      name: CNDTR1
+    CNDTR3:
+      name: CNDTR2
+    CNDTR4:
+      name: CNDTR3
+    CNDTR5:
+      name: CNDTR4
+    CNDTR6:
+      name: CNDTR5
+    CNDTR7:
+      name: CNDTR6
+    CNDTR8:
+      name: CNDTR7
+    CPAR1:
+      name: CPAR0
+    CPAR2:
+      name: CPAR1
+    CPAR3:
+      name: CPAR2
+    CPAR4:
+      name: CPAR3
+    CPAR5:
+      name: CPAR4
+    CPAR6:
+      name: CPAR5
+    CPAR7:
+      name: CPAR6
+    CPAR8:
+      name: CPAR7
+  "CCR?":
+    _add:
+      CT:
+        description: Current target memory in double-buffer mode
+        bitOffset: 16
+        bitWidth: 1
+      DBM:
+        description: Double-buffer mode
+        bitOffset: 15
+        bitWidth: 1
+  _cluster:
+    "CH%s":
+      description: "Channel cluster: CCR?, CNDTR?, CPAR?, CM0AR? and CM1AR? registers"
+      "CCR?":
+        name: CR
+      "CNDTR?":
+        name: NDTR
+      "CPAR?":
+        name: PAR
+      "CM0AR?":
+        name: M0AR
+      "CM1AR?":
+        name: M1AR

--- a/devices/common_patches/dma/bdma_v2.yaml
+++ b/devices/common_patches/dma/bdma_v2.yaml
@@ -1,0 +1,30 @@
+"BDMA*":
+  "CCR?":
+    _add:
+      CT:
+        description: Current target memory in double-buffer mode
+        bitOffset: 16
+        bitWidth: 1
+      DBM:
+        description: Double-buffer mode
+        bitOffset: 15
+        bitWidth: 1
+  "CM1AR?":
+    _add:
+      MA:
+        description: Memory address
+        bitOffset: 0
+        bitWidth: 32
+  _cluster:
+    "CH%s":
+      description: "Channel cluster: CCR?, CNDTR?, CPAR?, CM0AR? and CM1AR registers?"
+      "CCR?":
+        name: CR
+      "CNDTR?":
+        name: NDTR
+      "CPAR?":
+        name: PAR
+      "CM0AR?":
+        name: M0AR
+      "CM1AR?":
+        name: M1AR

--- a/devices/common_patches/h7_common_highmemory.yaml
+++ b/devices/common_patches/h7_common_highmemory.yaml
@@ -568,6 +568,10 @@ HRTIM_Common:
           bitOffset: 0
           bitWidth: 32
 
+BDMA?:
+  _strip:
+    - BDMA_
+
 CEC:
   _strip:
     - CEC_

--- a/devices/stm32h743.yaml
+++ b/devices/stm32h743.yaml
@@ -3,6 +3,7 @@ _svd: ../svd/stm32h743.svd
 _include:
  - common_patches/h7_common_singlecore.yaml
  - common_patches/dma_fcr_wo.yaml
+ - common_patches/dma/bdma.yaml
  - common_patches/dma/dma_v3.yaml
  - common_patches/fsmc/fsmc_sdram_cluster.yaml
  - common_patches/h7_rcc_src_sel.yaml
@@ -33,6 +34,7 @@ _include:
  - ../peripherals/crc/crc_advanced.yaml
  - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/crc/crc_pol.yaml
+ - ../peripherals/dma/bdma.yaml
  - ../peripherals/dma/dma_v3.yaml
  - ../peripherals/dma/dmamux_v1.yaml
  - ../peripherals/dma/dma2d_v2.yaml

--- a/devices/stm32h743v.yaml
+++ b/devices/stm32h743v.yaml
@@ -3,6 +3,7 @@ _svd: ../svd/stm32h743v.svd
 _include:
  - common_patches/h7_common_singlecore.yaml
  - common_patches/dma_fcr_wo.yaml
+ - common_patches/dma/bdma.yaml
  - common_patches/dma/dma_v3.yaml
  - common_patches/fsmc/fsmc_sdram_cluster.yaml
  - common_patches/h7_rcc_src_sel.yaml
@@ -35,6 +36,7 @@ _include:
  - ../peripherals/crc/crc_advanced.yaml
  - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/crc/crc_pol.yaml
+ - ../peripherals/dma/bdma.yaml
  - ../peripherals/dma/dma_v3.yaml
  - ../peripherals/dma/dmamux_v1.yaml
  - ../peripherals/dma/dma2d_v2.yaml

--- a/devices/stm32h747cm4.yaml
+++ b/devices/stm32h747cm4.yaml
@@ -17,6 +17,7 @@ _include:
  - common_patches/h7_common_dualcore.yaml
  - common_patches/4_nvic_prio_bits.yaml
  - common_patches/dma_fcr_wo.yaml
+ - common_patches/dma/bdma.yaml
  - common_patches/dma/dma_v3.yaml
  - common_patches/fsmc/fsmc_sdram_cluster.yaml
  - common_patches/h7_rcc_src_sel.yaml

--- a/devices/stm32h747cm4.yaml
+++ b/devices/stm32h747cm4.yaml
@@ -15,7 +15,7 @@ CRYP:
 
 _include:
  - common_patches/h7_common_dualcore.yaml
- - common_patches/4_nvic_prio_bits.yaml
+ - common_patches/4_nvic_prio_bits.yaml  # Specifically for CM4 core
  - common_patches/dma_fcr_wo.yaml
  - common_patches/dma/bdma.yaml
  - common_patches/dma/dma_v3.yaml
@@ -52,6 +52,8 @@ _include:
  - ../peripherals/crc/crc_advanced.yaml
  - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/crc/crc_pol.yaml
+ - ../peripherals/dma/bdma.yaml
+ - ../peripherals/dma/dma_v3.yaml
  - ../peripherals/dma/dmamux_v1.yaml
  - ../peripherals/dma/dma2d_v2.yaml
  - ../peripherals/gpio/gpio_v2.yaml
@@ -72,6 +74,7 @@ _include:
  - common_patches/tim/tim_h7.yaml
  - ../peripherals/tim/tim_h7.yaml
  - ../peripherals/iwdg/iwdg_with_WINR.yaml
+ - ../peripherals/exti/exti_h7.yaml
  - ../peripherals/i2c/i2c_v2.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/usart/usart_v2B1.yaml

--- a/devices/stm32h747cm7.yaml
+++ b/devices/stm32h747cm7.yaml
@@ -16,6 +16,7 @@ CRYP:
 _include:
  - common_patches/h7_common_dualcore.yaml
  - common_patches/dma_fcr_wo.yaml
+ - common_patches/dma/bdma.yaml
  - common_patches/dma/dma_v3.yaml
  - common_patches/fsmc/fsmc_sdram_cluster.yaml
  - common_patches/h7_rcc_src_sel.yaml
@@ -51,6 +52,7 @@ _include:
  - ../peripherals/crc/crc_advanced.yaml
  - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/crc/crc_pol.yaml
+ - ../peripherals/dma/bdma.yaml
  - ../peripherals/dma/dma_v3.yaml
  - ../peripherals/dma/dmamux_v1.yaml
  - ../peripherals/dma/dma2d_v2.yaml

--- a/devices/stm32h753.yaml
+++ b/devices/stm32h753.yaml
@@ -13,6 +13,7 @@ CRYP:
 _include:
  - common_patches/h7_common_singlecore.yaml
  - common_patches/dma_fcr_wo.yaml
+ - common_patches/dma/bdma.yaml
  - common_patches/dma/dma_v3.yaml
  - common_patches/fsmc/fsmc_sdram_cluster.yaml
  - common_patches/h7_rcc_src_sel.yaml
@@ -43,6 +44,7 @@ _include:
  - ../peripherals/crc/crc_advanced.yaml
  - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/crc/crc_pol.yaml
+ - ../peripherals/dma/bdma.yaml
  - ../peripherals/dma/dma_v3.yaml
  - ../peripherals/dma/dmamux_v1.yaml
  - ../peripherals/dma/dma2d_v2.yaml

--- a/devices/stm32h753v.yaml
+++ b/devices/stm32h753v.yaml
@@ -13,6 +13,7 @@ CRYP:
 _include:
  - common_patches/h7_common_singlecore.yaml
  - common_patches/dma_fcr_wo.yaml
+ - common_patches/dma/bdma.yaml
  - common_patches/dma/dma_v3.yaml
  - common_patches/fsmc/fsmc_sdram_cluster.yaml
  - common_patches/h7_rcc_src_sel.yaml
@@ -45,6 +46,7 @@ _include:
  - ../peripherals/crc/crc_advanced.yaml
  - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/crc/crc_pol.yaml
+ - ../peripherals/dma/bdma.yaml
  - ../peripherals/dma/dma_v3.yaml
  - ../peripherals/dma/dmamux_v1.yaml
  - ../peripherals/dma/dma2d_v2.yaml

--- a/devices/stm32h7b3.yaml
+++ b/devices/stm32h7b3.yaml
@@ -16,6 +16,7 @@ CRYP:
 _include:
  - common_patches/h7_common_highmemory.yaml
  - common_patches/dma_fcr_wo.yaml
+ - common_patches/dma/bdma_v2.yaml
  - common_patches/dma/dma_v3.yaml
  - common_patches/fsmc/fsmc_sdram_cluster.yaml
  - common_patches/h7_rcc_src_sel.yaml
@@ -47,6 +48,7 @@ _include:
  - ../peripherals/crc/crc_advanced.yaml
  - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/crc/crc_pol.yaml
+ - ../peripherals/dma/bdma.yaml
  - ../peripherals/dma/dma_v3.yaml
  #- ../peripherals/dma/dmamux_v1.yaml
  - ../peripherals/dma/dma2d_v2.yaml

--- a/peripherals/dma/bdma.yaml
+++ b/peripherals/dma/bdma.yaml
@@ -1,0 +1,67 @@
+# Basic DMA as found on H7, ..
+
+"BDMA*":
+  "ISR":
+    "TCIF?":
+      NotComplete: [0, "No transfer complete event on channel x"]
+      Complete: [1, "A transfer complete event occurred on channel x"]
+    "HTIF?":
+      NotHalf: [0, "No half transfer event on channel x"]
+      Half: [1, "A half transfer event occurred on channel x"]
+    "TEIF?":
+      NoError: [0, "No transfer error on channel x"]
+      Error: [1, "A transfer error occurred on channel x"]
+    "GIF?":
+      NoEvent: [0, "No TE, HT or TC event on channel x"]
+      Event: [1, "A TE, HT or TC event occurred on channel x"]
+  "IFCR":
+    "CTCIF?":
+      Clear: [1, "Clear the corresponding TCIFx flag"]
+    "CHTIF?":
+      Clear: [1, "Clear the corresponding HTIFx flag"]
+    "CTEIF?":
+      Clear: [1, "Clear the corresponding TEIFx flag"]
+    "CGIF?":
+      Clear: [1, "Clear the corresponding CGIFx flag"]
+  "CCR?":
+    CT:
+      Memory0: [0, "The current target memory is Memory 0"]
+      Memory1: [1, "The current target memory is Memory 1"]
+    DBM:
+      Disabled: [0, "No buffer switching at the end of transfer"]
+      Enabled: [1, "Memory target switched at the end of the DMA transfer"]
+    MEM2MEM:
+      Disabled: [0, "Memory-to-memory mode disabled"]
+      Enabled: [1, "Memory-to-memory mode enabled"]
+    PL:
+      Low: [0, "Low"]
+      Medium: [1, "Medium"]
+      High: [2, "High"]
+      VeryHigh: [3, "Very high"]
+    "[MP]SIZE":
+      Bits8: [0, "Byte (8-bit)"]
+      Bits16: [1, "Half-word (16-bit)"]
+      Bits32: [2, "Word (32-bit)"]
+    "[MP]INC":
+      Fixed: [0, "Address pointer is fixed"]
+      Incremented: [1, "Address pointer is incremented after each data transfer"]
+    CIRC:
+      Disabled: [0, "Circular mode disabled"]
+      Enabled: [1, "Circular mode enabled"]
+    DIR:
+      PeripheralToMemory: [0, "Peripheral-to-memory"]
+      MemoryToPeripheral: [1, "Memory-to-peripheral"]
+    TCIE:
+      Disabled: [0, "TC interrupt disabled"]
+      Enabled: [1, "TC interrupt enabled"]
+    HTIE:
+      Disabled: [0, "HT interrupt disabled"]
+      Enabled: [1, "HT interrupt enabled"]
+    TEIE:
+      Disabled: [0, "TE interrupt disabled"]
+      Enabled: [1, "TE interrupt enabled"]
+    EN:
+      Disabled: [0, "Channel disabled"]
+      Enabled: [1, "Channel enabled"]
+  "CNDTR?":
+    NDT: [0, 65535]


### PR DESCRIPTION
Currently only found on the H7 I think. Applies to:

* RM0433 / RM0399: BDMA
* RM0455: BDMA1, BDMA2

Quite some bashing was required on the older SVDs to get them to match the newer RM0455. With this they do all generate the same register definitions, including an array of channels like `pub ch: [CH; 8]`

Additionally add this, dma_v3 and exti to the H747 CM4 core (not sure why they were missing?)