### PR TITLE
Fix the address of the CRC INIT register for stm32f0xx devices

### DIFF
--- a/devices/common_patches/f0_crc_init_addr_fix.yaml
+++ b/devices/common_patches/f0_crc_init_addr_fix.yaml
@@ -1,0 +1,6 @@
+# Corrects the address of the INIT register of the CRC peripheral
+
+CRC:
+  _modify:
+    INIT:
+      addressOffset: "0x10"

--- a/devices/stm32f0x0.yaml
+++ b/devices/stm32f0x0.yaml
@@ -78,3 +78,4 @@ _include:
  - ../peripherals/flash/flash_f0.yaml
  - ../peripherals/tim/tim_ccm_v1.yaml
  - ./common_patches/2_nvic_prio_bits.yaml
+ - ./common_patches/f0_crc_init_addr_fix.yaml

--- a/devices/stm32f0x1.yaml
+++ b/devices/stm32f0x1.yaml
@@ -69,3 +69,4 @@ _include:
  - ../peripherals/flash/flash_f04x_f09x.yaml
  - ../peripherals/tim/tim_ccm_v1.yaml
  - ./common_patches/2_nvic_prio_bits.yaml
+ - ./common_patches/f0_crc_init_addr_fix.yaml

--- a/devices/stm32f0x2.yaml
+++ b/devices/stm32f0x2.yaml
@@ -87,3 +87,4 @@ _include:
  - ../peripherals/flash/flash_f04x_f09x.yaml
  - ../peripherals/tim/tim_ccm_v1.yaml
  - ./common_patches/2_nvic_prio_bits.yaml
+ - ./common_patches/f0_crc_init_addr_fix.yaml

--- a/devices/stm32f0x8.yaml
+++ b/devices/stm32f0x8.yaml
@@ -62,3 +62,4 @@ _include:
  - ../peripherals/flash/flash_f04x_f09x.yaml
  - ../peripherals/tim/tim_ccm_v1.yaml
  - ./common_patches/2_nvic_prio_bits.yaml
+ - ./common_patches/f0_crc_init_addr_fix.yaml


### PR DESCRIPTION
The SVD files for the stm32f0xx devices contain the wrong address offset for the INIT register of the CRC peripheral. The SVD files specify an address offset of 0xC, while the reference manual specifies an address offset of 0x10. I verified that the correct offset is indeed 0x10, on an stm32f042.

![CRC_INIT](https://user-images.githubusercontent.com/1167521/89351687-cff9d180-d6b2-11ea-8bce-b8fda318628c.png)
