### PR TITLE
Group DMA registers on STM32G0 series

### DIFF
--- a/devices/common_patches/g0_dma_5ch.yaml
+++ b/devices/common_patches/g0_dma_5ch.yaml
@@ -1,6 +1,17 @@
 # Fixes for STM32G0 devices with 5 DMA channels
 # This patch removes register fields for channels 6 and 7
 DMA:
+  _cluster:
+    "CH%s":
+      description: "Channel cluster: CCR?, CNDTR?, CPAR?, and CMAR? registers"
+      "CCR?":
+        name: CR
+      "CNDTR?":
+        name: NDTR
+      "CPAR?":
+        name: PAR
+      "CMAR?":
+        name: MAR
   _modify:
     IFCR:
       access: write-only

--- a/devices/common_patches/g0_dma_7ch.yaml
+++ b/devices/common_patches/g0_dma_7ch.yaml
@@ -1,5 +1,17 @@
+
 # Fixes for STM32G0 devices with 7 DMA channels
 DMA:
+  _cluster:
+    "CH%s":
+      description: "Channel cluster: CCR?, CNDTR?, CPAR?, and CMAR? registers"
+      "CCR?":
+        name: CR
+      "CNDTR?":
+        name: NDTR
+      "CPAR?":
+        name: PAR
+      "CMAR?":
+        name: MAR
   _modify:
     IFCR:
       access: write-only


### PR DESCRIPTION
This makes it more convenient to split up the HAL DMA driver in separate channels.
Inspired by stm32f3.