### PR TITLE
Add virtual DR8 and DR16 registers to the advanced CRC peripheral

### DIFF
--- a/peripherals/crc/crc_advanced.yaml
+++ b/peripherals/crc/crc_advanced.yaml
@@ -12,6 +12,7 @@ CRC:
       size: 0x8
       access: read-write
       resetValue: 0xFF
+      alternateRegister: DR
       fields:
         DR8:
           description: Data register bits

--- a/peripherals/crc/crc_advanced.yaml
+++ b/peripherals/crc/crc_advanced.yaml
@@ -5,6 +5,34 @@ _include:
  - ./crc_basic.yaml
 
 CRC:
+  _add:
+    DR8:
+      description: Data register - byte sized
+      addressOffset: 0x0
+      size: 0x8
+      access: read-write
+      resetValue: 0xFF
+      fields:
+        DR8:
+          description: Data register bits
+          bitOffset: 0
+          bitWidth: 8
+    DR16:
+      description: Data register - half-word sized
+      addressOffset: 0x0
+      size: 0x10
+      access: read-write
+      resetValue: 0xFFFF
+      fields:
+        DR16:
+          description: Data register bits
+          bitOffset: 0
+          bitWidth: 16
+
+  DR8:
+    DR8: [0, 255]
+  DR16:
+    DR16: [0, 65535]
   CR:
     REV_IN:
       Normal: [0, "Bit order not affected"]

--- a/peripherals/crc/crc_advanced.yaml
+++ b/peripherals/crc/crc_advanced.yaml
@@ -24,6 +24,7 @@ CRC:
       size: 0x10
       access: read-write
       resetValue: 0xFFFF
+      alternateRegister: DR
       fields:
         DR16:
           description: Data register bits


### PR DESCRIPTION
The advanced CRC peripheral, present on e.g. the stm32f0 series, can process input data by byte, half-word or word. Currently, the CRC's DR register is only defined as a word-sized register, making it impossible to supply input data by half-word or byte.

This patch adds two "virtual" DR8 and DR16 registers to the advanced CRC peripheral. They are both mapped to the same base address as the DR register, but come with a width of 8 and 16 bits respectively. These virtual registers allow writing data per byte or half-word to the DR register.

From RM0091:
![Screenshot from 2020-08-07 21-21-05](https://user-images.githubusercontent.com/1167521/89681933-2c98fe80-d8f6-11ea-9f9c-3dc051d2cceb.png)
