### PR TITLE
stm32h7: rcc ccip patches and sdmmc prefix for b3

### DIFF
--- a/devices/common_patches/h7_common_highmemory.yaml
+++ b/devices/common_patches/h7_common_highmemory.yaml
@@ -368,6 +368,14 @@ RCC:
   _modify:
     CIFR:
       access: read-only
+    D1CCIPR:
+      name: CDCCIPR
+    D2CCIP1R:
+      name: CDCCIP1R
+    D2CCIP2R:
+      name: CDCCIP2R
+    D3CCIPR:
+      name: SRDCCIPR
     C1_APB1LENR:
       name: APB1LENR
     C1_APB1LLPENR:
@@ -419,6 +427,87 @@ RCC:
           description: WWDG1 reset scope control
           bitOffset: 0
           bitWidth: 1
+
+  CDCCIPR:
+    _delete:
+      - "QSPI*"
+    _add:
+      OCTOSPISEL:
+        description: "OCTOSPI kernel clock source selection"
+        bitOffset: 4
+        bitWidth: 2
+    _modify:
+      CKPERSRC:
+          name: CKPERSEL
+      SDMMCSRC:
+          name: SDMMCSEL
+      FMCSRC:
+          name: FMCSEL
+  CDCCIP1R:
+    _delete:
+      - "SAI23*"
+    _add:
+      SAI2ASEL:
+        description: "SAI2 kernel clock source A source selection"
+        bitOffset: 6
+        bitWidth: 3
+      SAI2BSEL:
+        description: "SAI2 kernel clock source B source selection"
+        bitOffset: 9
+        bitWidth: 3
+    _modify:
+      SWPSRC:
+          name: SWPSEL
+      FDCANSRC:
+          name: FDCANSEL
+      DFSDM1SRC:
+          name: DFSDM1SEL
+      SPDIFSRC:
+          name: SPDIFRXSEL
+      SPI45SRC:
+          name: SPI45SEL
+      SPI123SRC:
+          name: SPI123SEL
+      SAI1SRC:
+          name: SAI1SEL
+  CDCCIP2R:
+    _modify:
+      LPTIM1SRC:
+          name: LPTIM1SEL
+      CECSRC:
+          name: CECSEL
+      USBSRC:
+          name: USBSEL
+      I2C123SRC:
+          name: I2C123SEL
+      RNGSRC:
+          name: RNGSEL
+      USART16SRC:
+          name: USART16910SEL
+          description: "USART1, 6, 9 and 10 kernel clock source selection"
+      USART234578SRC:
+          name: USART234578SEL
+  SRDCCIPR:
+    _delete:
+      - "SAI4*"
+    _add:
+      DFSDM2SEL:
+        description: "DFSDM2 kernel clock source selection"
+        bitOffset: 27
+        bitWidth: 1
+    _modify:
+      SPI6SRC:
+          name: SPI6SEL
+      ADCSRC:
+          name: ADCSEL
+      LPTIM345SRC:
+          name: LPTIM3SEL       # LPTIM3 only
+      LPTIM2SRC:
+          name: LPTIM2SEL
+      I2C4SRC:
+          name: I2C4SEL
+      LPUART1SRC:
+          name: LPUART1SEL
 
   D3CFGR:
     _delete: "*"
@@ -655,6 +744,10 @@ I2C3:
 SAI1:
   _strip:
     - SAI_
+
+SDMMC?:
+  _strip:
+    - SDMMC_
 
 VREFBUF:
   _strip:

--- a/devices/common_patches/h7_rcc_src_sel.yaml
+++ b/devices/common_patches/h7_rcc_src_sel.yaml
@@ -1,5 +1,7 @@
 # Rename *SRC to *SEL in H7 domain kernel clock configuration registers (DxCCIPR)
 
+# Applies only to RM0433 and RM0399 parts
+
 RCC:
   D1CCIPR:
     _modify:

--- a/devices/stm32h7b3.yaml
+++ b/devices/stm32h7b3.yaml
@@ -19,7 +19,6 @@ _include:
  - common_patches/dma/bdma_v2.yaml
  - common_patches/dma/dma_v3.yaml
  - common_patches/fsmc/fsmc_sdram_cluster.yaml
- - common_patches/h7_rcc_src_sel.yaml
  - common_patches/h7_exti_singlecore.yaml
  - common_patches/h7_dbgmcu.yaml
  - common_patches/h7_dmamux.yaml

--- a/peripherals/rcc/rcc_v3_h7_ccip.yaml
+++ b/peripherals/rcc/rcc_v3_h7_ccip.yaml
@@ -22,7 +22,7 @@ RCC:
       Div4: [5, "rcc_hclk divided by 4"]
       Div8: [6, "rcc_hclk divided by 8"]
       Div16: [7, "rcc_hclk divided by 16"]
-  D1CCIPR:
+  D1CCIPR,CDCCIPR:
     CKPERSEL:
       HSI: [0, "HSI selected as peripheral clock"]
       CSI: [1, "CSI selected as peripheral clock"]
@@ -30,12 +30,12 @@ RCC:
     SDMMCSEL:
       PLL1_Q: [0, "pll1_q selected as peripheral clock"]
       PLL2_R: [1, "pll2_r selected as peripheral clock"]
-    QSPISEL,FMCSEL:
+    QSPISEL,FMCSEL,OCTOSPISEL:
       RCC_HCLK3: [0, "rcc_hclk3 selected as peripheral clock"]
       PLL1_Q: [1, "pll1_q selected as peripheral clock"]
       PLL2_R: [2, "pll2_r selected as peripheral clock"]
       PER: [3, "PER selected as peripheral clock"]
-  D2CCIP1R:
+  D2CCIP1R,CDCCIP1R:
     SWPSEL:
       PCLK: [0, "pclk selected as peripheral clock"]
       HSI_KER: [1, "hsi_ker selected as peripheral clock"]
@@ -46,7 +46,7 @@ RCC:
     DFSDM1SEL:
       RCC_PCLK2: [0, "rcc_pclk2 selected as peripheral clock"]
       SYS: [1, "System clock selected as peripheral clock"]
-    SPDIFSEL:
+    SPDIFSEL,SPDIFRXSEL:
       PLL1_Q: [0, "pll1_q selected as peripheral clock"]
       PLL2_R: [1, "pll2_r selected as peripheral clock"]
       PLL3_R: [2, "pll3_r selected as peripheral clock"]
@@ -64,7 +64,7 @@ RCC:
       PLL3_P: [2, "pll3_p selected as peripheral clock"]
       I2S_CKIN: [3, "I2S_CKIN selected as peripheral clock"]
       PER: [4, "PER selected as peripheral clock"]
-  D2CCIP2R:
+  D2CCIP2R,CDCCIP2R:
     LPTIM1SEL:
       RCC_PCLK1: [0, "rcc_pclk1 selected as peripheral clock"]
       PLL2_P: [1, "pll2_p selected as peripheral clock"]
@@ -91,7 +91,7 @@ RCC:
       PLL1_Q: [1, "pll1_q selected as peripheral clock"]
       LSE: [2, "LSE selected as peripheral clock"]
       LSI: [3, "LSI selected as peripheral clock"]
-    USART16SEL:
+    USART16SEL,USART16910SEL:
       RCC_PCLK2: [0, "rcc_pclk2 selected as peripheral clock"]
       PLL2_Q: [1, "pll2_q selected as peripheral clock"]
       PLL3_Q: [2, "pll3_q selected as peripheral clock"]
@@ -105,7 +105,9 @@ RCC:
       HSI_KER: [3, "hsi_ker selected as peripheral clock"]
       CSI_KER: [4, "csi_ker selected as peripheral clock"]
       LSE: [5, "LSE selected as peripheral clock"]
-  D3CCIPR:
+
+  # D3 / SRD
+  D3CCIPR,SRDCCIPR:
     SPI6SEL:
       RCC_PCLK4: [0, "rcc_pclk4 selected as peripheral clock"]
       PLL2_Q: [1, "pll2_q selected as peripheral clock"]
@@ -113,18 +115,6 @@ RCC:
       HSI_KER: [3, "hsi_ker selected as peripheral clock"]
       CSI_KER: [4, "csi_ker selected as peripheral clock"]
       HSE: [5, "HSE selected as peripheral clock"]
-    SAI4BSEL:
-      PLL1_Q: [0, "pll1_q selected as peripheral clock"]
-      PLL2_P: [1, "pll2_p selected as peripheral clock"]
-      PLL3_P: [2, "pll3_p selected as peripheral clock"]
-      I2S_CKIN: [3, "i2s_ckin selected as peripheral clock"]
-      PER: [4, "PER selected as peripheral clock"]
-    SAI4ASEL:
-      PLL1_Q: [0, "pll1_q selected as peripheral clock"]
-      PLL2_P: [1, "pll2_p selected as peripheral clock"]
-      PLL3_P: [2, "pll3_p selected as peripheral clock"]
-      I2S_CKIN: [3, "i2s_ckin selected as peripheral clock"]
-      PER: [4, "PER selected as peripheral clock"]
     ADCSEL:
       PLL2_P: [0, "pll2_p selected as peripheral clock"]
       PLL3_R: [1, "pll3_r selected as peripheral clock"]
@@ -148,3 +138,12 @@ RCC:
       HSI_KER: [3, "hsi_ker selected as peripheral clock"]
       CSI_KER: [4, "csi_ker selected as peripheral clock"]
       LSE: [5, "LSE selected as peripheral clock"]
+
+  # Applies to SAI2 or SAI4 when split
+  D3CCIPR,CDCCIP1R:
+    SAI*[AB]SEL:
+      PLL1_Q: [0, "pll1_q selected as peripheral clock"]
+      PLL2_P: [1, "pll2_p selected as peripheral clock"]
+      PLL3_P: [2, "pll3_p selected as peripheral clock"]
+      I2S_CKIN: [3, "i2s_ckin selected as peripheral clock"]
+      PER: [4, "PER selected as peripheral clock"]


### PR DESCRIPTION
Quick coverage of two points from https://github.com/stm32-rs/stm32h7xx-hal/pull/122

* Rename d3ccip -> srdccip (ref https://github.com/stm32-rs/stm32h7xx-hal/issues/95 ), fix field naming in that register
* Strip `SDMMC_` prefix from sdmmc registers