### PR TITLE
Add support for family with more than one letter

### DIFF
--- a/scripts/makecrates.py
+++ b/scripts/makecrates.py
@@ -13,6 +13,7 @@ import os
 import glob
 import os.path
 import argparse
+import re
 import yaml
 
 VERSION = "0.11.0"
@@ -198,7 +199,7 @@ def main(devices_path, yes):
 
     for path in glob.glob(os.path.join(devices_path, "*.yaml")):
         yamlfile = os.path.basename(path)
-        family = yamlfile[:7]
+        family = re.match(r'stm32[a-z]+[0-9]', yamlfile)[0]
         device = os.path.splitext(yamlfile)[0].lower()
         if family not in devices:
             devices[family] = []


### PR DESCRIPTION
We are trying to implement the support for the STM32MP1 family.
The `makecrates.py` script is currently retrieving the chip name by slicing the 7 first chars from the full chip name.
This pull request propose to match the chip name with a regex instead.