### PR TITLE
Add optional `families` parameter to makecrates.py

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ svd/%.svd.formatted: svd/%.svd.patched
 
 # Generates the common crate files: Cargo.toml, build.rs, src/lib.rs, README.md
 crates:
-	python3 scripts/makecrates.py devices/ -y
+	python3 scripts/makecrates.py devices/ -y --families $(CRATES)
 
 define crate_template
 $(1)/src/%/mod.rs: svd/%.svd.patched $(1)/Cargo.toml

--- a/scripts/makecrates.py
+++ b/scripts/makecrates.py
@@ -193,16 +193,18 @@ def make_device_clauses(devices):
             " else { panic!(\"No device features selected\"); }"
 
 
-def main(devices_path, yes):
+def main(devices_path, yes, families):
+    families = families.split(',') if len(families) > 0 else None
     devices = {}
 
     for path in glob.glob(os.path.join(devices_path, "*.yaml")):
         yamlfile = os.path.basename(path)
         family = yamlfile[:7]
         device = os.path.splitext(yamlfile)[0].lower()
-        if family not in devices:
-            devices[family] = []
-        devices[family].append(device)
+        if families is None or family in families:
+            if family not in devices:
+                devices[family] = []
+            devices[family].append(device)
 
     table = read_device_table()
 
@@ -243,8 +245,15 @@ def main(devices_path, yes):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("-y", help="Assume 'yes' to prompt",
+    parser.add_argument("-y",
+                        help="Assume 'yes' to prompt",
                         action="store_true")
-    parser.add_argument("devices", help="Path to device YAML files")
+    parser.add_argument("devices",
+                        help="Path to device YAML files")
+    parser.add_argument('--families',
+                        help="Families of components to generate crates for, separated by commas",
+                        required=False,
+                        default='',
+                        type=str)
     args = parser.parse_args()
-    main(args.devices, args.y)
+    main(args.devices, args.y, args.families)


### PR DESCRIPTION
When running `make`, the `makecrates.py` scripts will retrieve every yaml files and run on every single one of them.
When making changes on a single family (or not all of them at least), one can edit the `CRATES` variable in `MakeFile` to specify the families that needs to be generated.
When running the script manually without specifying this new parameter, the behaviour will stay the same.