### PR TITLE
Fix duplicate enums

### DIFF
--- a/peripherals/adc/adc_v3_g4.yaml
+++ b/peripherals/adc/adc_v3_g4.yaml
@@ -86,7 +86,7 @@ _include:
       Normal: [0, "2.5 in SMPR remains 2.5 cycles"]
       Plus1: [1, "2.5 in SMPR becomes 3.5 cycles"]
   "SMPR?":
-    "SMP*":
+    "SMP?,SMP??":
       Cycles2_5: [0, "2.5 ADC clock cycles"]
       Cycles6_5: [1, "6.5 ADC clock cycles"]
       Cycles12_5: [2, "12.5 ADC clock cycles"]

--- a/peripherals/rcc/rcc_common.yaml
+++ b/peripherals/rcc/rcc_common.yaml
@@ -14,7 +14,7 @@ RCC:
       _read:
         NotReady: [0, "Clock not ready"]
         Ready: [1, "Clock ready"]
-    "*ON":
+    HSION,HSEON,PLLON,PLLI2SON,PLLSAION:
       "Off": [0, "Clock Off"]
       "On": [1, "Clock On"]
   CFGR:


### PR DESCRIPTION
As reported in https://github.com/stm32-rs/svdtools/pull/31, some patches here produce multiple overlapping `<enumeratedValues>` tags in the patched SVD file.  This can be fixed by ensuring the two patch statements in question don't overlap.

I'll leave this PR a draft until all discussions in the above mentioned PR to `svdtools` are resolved, in case anything else comes up.