### PR TITLE
[scripts/makecrates] Use space instead of comma, fixes `make crates`

### DIFF
--- a/scripts/makecrates.py
+++ b/scripts/makecrates.py
@@ -194,14 +194,13 @@ def make_device_clauses(devices):
 
 
 def main(devices_path, yes, families):
-    families = families.split(',') if len(families) > 0 else None
     devices = {}
 
     for path in glob.glob(os.path.join(devices_path, "*.yaml")):
         yamlfile = os.path.basename(path)
         family = yamlfile[:7]
         device = os.path.splitext(yamlfile)[0].lower()
-        if families is None or family in families:
+        if len(families) == 0 or family in families:
             if family not in devices:
                 devices[family] = []
             devices[family].append(device)
@@ -251,9 +250,11 @@ if __name__ == "__main__":
     parser.add_argument("devices",
                         help="Path to device YAML files")
     parser.add_argument('--families',
-                        help="Families of components to generate crates for, separated by commas",
+                        help="Families of components to generate crates for",
+                        nargs='+',
                         required=False,
-                        default='',
+                        metavar='FAMILY',
+                        default=[],
                         type=str)
     args = parser.parse_args()
     main(args.devices, args.y, args.families)


### PR DESCRIPTION
#424 is breaking the build system:

    usage: makecrates.py [-h] [-y] [--families FAMILIES] devices
    makecrates.py: error: unrecognized arguments: stm32f1 stm32f2 stm32f3 stm32f4 stm32f7 stm32h7 stm32l0 stm32l1 stm32l4 stm32l5 stm32g0 stm32g4

This fix uses space to separate arguments instead of comma.