### PR TITLE
Rename DMA interrupts for STM32L4x3, L4x5, L552, L562. Closes #430.

### DIFF
--- a/devices/common_patches/dma_interrupt_names.yaml
+++ b/devices/common_patches/dma_interrupt_names.yaml
@@ -1,0 +1,35 @@
+DMA1:
+  _modify:
+    _interrupts:
+      DMA1_Channel1:
+        name: DMA1_CH1
+      DMA1_Channel2:
+        name: DMA1_CH2
+      DMA1_Channel3:
+        name: DMA1_CH3
+      DMA1_Channel4:
+        name: DMA1_CH4
+      DMA1_Channel5:
+        name: DMA1_CH5
+      DMA1_Channel6:
+        name: DMA1_CH6
+      DMA1_Channel7:
+        name: DMA1_CH7
+
+DMA2:
+  _modify:
+    _interrupts:
+      DMA2_Channel1:
+        name: DMA2_CH1
+      DMA2_Channel2:
+        name: DMA2_CH2
+      DMA2_Channel3:
+        name: DMA2_CH3
+      DMA2_Channel4:
+        name: DMA2_CH4
+      DMA2_Channel5:
+        name: DMA2_CH5
+      DMA2_Channel6:
+        name: DMA2_CH6
+      DMA2_Channel7:
+        name: DMA2_CH7

--- a/devices/stm32l4x3.yaml
+++ b/devices/stm32l4x3.yaml
@@ -65,4 +65,4 @@ _include:
  - ./common_patches/flash/flash_boot0s.yaml
  - ../peripherals/tim/tim_ccm_v2.yaml
  - ../peripherals/sai/sai.yaml
-
+ - common_patches/dma_interrupt_names.yaml

--- a/devices/stm32l4x5.yaml
+++ b/devices/stm32l4x5.yaml
@@ -138,4 +138,5 @@ _include:
  - ./common_patches/flash/flash_boot0s.yaml
  - ../peripherals/tim/tim_ccm_v2.yaml
  - ../peripherals/sai/sai.yaml
+ - common_patches/dma_interrupt_names.yaml
 

--- a/devices/stm32l552.yaml
+++ b/devices/stm32l552.yaml
@@ -1,1 +1,4 @@
 _svd: ../svd/stm32l552.svd
+
+_include:
+ - common_patches/dma_interrupt_names.yaml

--- a/devices/stm32l562.yaml
+++ b/devices/stm32l562.yaml
@@ -1,1 +1,4 @@
 _svd: ../svd/stm32l562.svd
+
+_include:
+ - common_patches/dma_interrupt_names.yaml


### PR DESCRIPTION
This PR requires https://github.com/stm32-rs/svdtools/pull/34 be released before it can be merged.