### PR TITLE
h7: Add TIM3/4/12/13/14 interrupts not preserved through _copy

### DIFF
--- a/devices/common_patches/h7_common_dualcore.yaml
+++ b/devices/common_patches/h7_common_dualcore.yaml
@@ -749,6 +749,20 @@ _copy:
   TIM14:
     from: TIM2
 
+# Add interrupts for TIM3 / TIM4
+TIM3:
+  _add:
+    _interrupts:
+      TIM3:
+        description: TIM3 global interrupt
+        value: 29
+TIM4:
+  _add:
+    _interrupts:
+      TIM4:
+        description: TIM4 global interrupt
+        value: 30
+
 SYSCFG:
   _add:
     PWRCR:

--- a/devices/common_patches/h7_common_singlecore.yaml
+++ b/devices/common_patches/h7_common_singlecore.yaml
@@ -539,3 +539,32 @@ _copy:
     from: TIM2
   TIM14:
     from: TIM2
+
+# Add interrupt for TIM3
+TIM3:
+  _add:
+    _interrupts:
+      TIM3:
+        description: TIM3 global interrupt
+        value: 29
+
+# Add interrupts for TIM12/TIM13/TIM14. For other SVDs these may be in TIM8, but
+# here they are in TIM12/TIM13/TIM14 and thus need to be added again
+TIM12:
+  _add:
+    _interrupts:
+      TIM8_BRK_TIM12:
+        description: TIM8 and 12 break global
+        value: 43
+TIM13:
+  _add:
+    _interrupts:
+      TIM8_UP_TIM13:
+        description: TIM8 and 13 update global
+        value: 44
+TIM14:
+  _add:
+    _interrupts:
+      TIM8_TRG_COM_TIM14:
+        description: TIM8 and 14 trigger/commutation and global
+        value: 45


### PR DESCRIPTION
This PR fixes a regression caused by the changes to `copy_peripheral` in https://github.com/stm32-rs/svdtools/pull/35. 

Previously interrupts from both the template peripheral and the target were generated in the patched SVD, resulting in two `<interrupt></interrupt>` blocks. Now only the interrupts from the template peripheral are preserved, so those from the target are lost. 

Confirmed that this is the only breakage for the h7 family by comparing mmaps for SVDs patched with svdtools 0.1.7 vs 0.1.8.

BTW - Thanks for all your hard work with the latest release  🎉 
Ref https://github.com/stm32-rs/stm32h7xx-hal/pull/134