### PR TITLE
stm32h7: add or fix interrupts for b3

### DIFF
--- a/devices/common_patches/h7_common_highmemory.yaml
+++ b/devices/common_patches/h7_common_highmemory.yaml
@@ -314,6 +314,8 @@ AXI:
 
 _delete:
   - DMA2
+  - USART9
+  - USART10
 
 _add:
   DMA2:
@@ -787,10 +789,6 @@ SPDIFRX:
       SPDIFRX:
         description: SPDIFRX global interrupt
         value: 97
-
-_delete:
-  - USART9
-  - USART10
 
 _add:
   UART9:

--- a/devices/common_patches/h7_common_highmemory.yaml
+++ b/devices/common_patches/h7_common_highmemory.yaml
@@ -346,6 +346,33 @@ _add:
       DMA2_STR7:
         value: 70
         description: DMA2 Stream7
+  UART9:
+    derivedFrom: USART1
+    baseAddress: 0x40018000
+    interrupts:
+      UART7:
+        description: UART7 global interrupt
+        value: 82
+      UART8:
+        description: UART8 global interrupt
+        value: 83
+      UART9:
+         description: UART9 global interrupt
+         value: 140
+  USART10:
+    derivedFrom: USART1
+    baseAddress: 0x4001C000
+    interrupts:
+      USART10:
+        description: USART10 global interrupt
+        value: 141
+  DAC2:
+    derivedFrom: DAC1
+    baseAddress: 0x58003400
+    interrupts:
+      DAC2:
+        description: DAC2 underrun interrupt
+        value: 127
 
 DMA1:
   _add:
@@ -684,15 +711,6 @@ DAC1:
   _strip:
     - DAC_
 
-_add:
-  DAC2:
-    derivedFrom: DAC1
-    baseAddress: 0x58003400
-    interrupts:
-      DAC2:
-        description: DAC2 underrun interrupt
-        value: 127
-
 DMA2D:
   _strip:
     - DMA2D_
@@ -789,28 +807,6 @@ SPDIFRX:
       SPDIFRX:
         description: SPDIFRX global interrupt
         value: 97
-
-_add:
-  UART9:
-    derivedFrom: USART1
-    baseAddress: 0x40018000
-    interrupts:
-      UART7:
-        description: UART7 global interrupt
-        value: 82
-      UART8:
-        description: UART8 global interrupt
-        value: 83
-      UART9:
-         description: UART9 global interrupt
-         value: 140
-  USART10:
-    derivedFrom: USART1
-    baseAddress: 0x4001C000
-    interrupts:
-      USART10:
-        description: USART10 global interrupt
-        value: 141
 
 VREFBUF:
   _strip:

--- a/devices/common_patches/h7_common_highmemory.yaml
+++ b/devices/common_patches/h7_common_highmemory.yaml
@@ -795,6 +795,12 @@ _add:
     derivedFrom: USART1
     baseAddress: 0x40018000
     interrupts:
+      UART7:
+        description: UART7 global interrupt
+        value: 82
+      UART8:
+        description: UART8 global interrupt
+        value: 83
       UART9:
          description: UART9 global interrupt
          value: 140

--- a/devices/common_patches/h7_common_highmemory.yaml
+++ b/devices/common_patches/h7_common_highmemory.yaml
@@ -10,6 +10,8 @@ _modify:
     name: FDCAN1
   FDCAN:
     name: FDCAN2
+  DAC:
+    name: DAC1
 
 # The SVD is just quite different to the RM for all these registers.
 # We'll go with the RM convention even though it is inconsistent too.
@@ -264,6 +266,13 @@ _modify:
     _modify:
       AWDCH1CH:
         name: AWD1CH
+
+# The ADC3 interrupt doesn't exist (no ADC3 peripheral), but the slot was
+# re-used for DAC2
+ADC1:
+  _delete:
+    _interrupts:
+      - ADC3
 
 AXI:
   _strip:
@@ -669,9 +678,18 @@ CRS:
   _strip:
     - CRS_
 
-DAC:
+DAC1:
   _strip:
     - DAC_
+
+_add:
+  DAC2:
+    derivedFrom: DAC1
+    baseAddress: 0x58003400
+    interrupts:
+      DAC2:
+        description: DAC2 underrun interrupt
+        value: 127
 
 DMA2D:
   _strip:
@@ -712,6 +730,8 @@ MDIOS:
 PWR:
   _strip:
     - PWR_
+  _delete:
+    _interrupts: WWDG1_RST      # Doesn't exist at all on these parts
   CR3:
     # Annoyingly RM0455 names these fields differently to RM0399 whilst
     # they have the same function
@@ -729,6 +749,13 @@ PWR:
         bitOffset: 3
         bitWidth: 1
 
+RAMECC:
+  _add:
+    _interrupts:
+      RAMECC:
+        description: ECC diagnostic global interrupt
+        value: 145
+
 RTC:
   _strip:
     - RTC_
@@ -744,10 +771,42 @@ I2C3:
 SAI1:
   _strip:
     - SAI_
+  _add:
+    _interrupts:
+      SAI1:
+        description: SAI1 global interrupt
+        value: 87
 
 SDMMC?:
   _strip:
     - SDMMC_
+
+SPDIFRX:
+  _add:
+    _interrupts:
+      SPDIFRX:
+        description: SPDIFRX global interrupt
+        value: 97
+
+_delete:
+  - USART9
+  - USART10
+
+_add:
+  UART9:
+    derivedFrom: USART1
+    baseAddress: 0x40018000
+    interrupts:
+      UART9:
+         description: UART9 global interrupt
+         value: 140
+  USART10:
+    derivedFrom: USART1
+    baseAddress: 0x4001C000
+    interrupts:
+      USART10:
+        description: USART10 global interrupt
+        value: 141
 
 VREFBUF:
   _strip:


### PR DESCRIPTION
Ended up changing some peripherals too:
* DAC -> DAC1
* Add DAC2
* USART9 -> UART9