### PR TITLE
Fix H7 CRC INIT and POL register addresses

### DIFF
--- a/devices/common_patches/h7_crc_addr_fix.yaml
+++ b/devices/common_patches/h7_crc_addr_fix.yaml
@@ -1,0 +1,8 @@
+# Corrects the addresses of the INIT and POL registers of the CRC peripheral
+
+CRC:
+  _modify:
+    INIT:
+      addressOffset: "0x10"
+    POL:
+      addressOffset: "0x14"

--- a/devices/stm32h743.yaml
+++ b/devices/stm32h743.yaml
@@ -71,3 +71,4 @@ _include:
  - common_patches/rtc/rtc_cr.yaml
  - ../peripherals/rtc/rtc_common.yaml
  - ../peripherals/rtc/rtc_h7.yaml
+ - common_patches/h7_crc_addr_fix.yaml

--- a/devices/stm32h743v.yaml
+++ b/devices/stm32h743v.yaml
@@ -73,3 +73,4 @@ _include:
  - common_patches/rtc/rtc_cr.yaml
  - ../peripherals/rtc/rtc_common.yaml
  - ../peripherals/rtc/rtc_h7.yaml
+ - common_patches/h7_crc_addr_fix.yaml

--- a/devices/stm32h747cm4.yaml
+++ b/devices/stm32h747cm4.yaml
@@ -85,3 +85,4 @@ _include:
  - ../peripherals/tim/tim_ccm_v2.yaml
  - ../peripherals/tim/tim1234_1567_ccm_v2.yaml
  - ../peripherals/sai/sai.yaml
+ - common_patches/h7_crc_addr_fix.yaml

--- a/devices/stm32h747cm7.yaml
+++ b/devices/stm32h747cm7.yaml
@@ -90,3 +90,4 @@ _include:
  - common_patches/rtc/rtc_cr.yaml
  - ../peripherals/rtc/rtc_common.yaml
  - ../peripherals/rtc/rtc_h7.yaml
+ - common_patches/h7_crc_addr_fix.yaml

--- a/devices/stm32h753.yaml
+++ b/devices/stm32h753.yaml
@@ -80,3 +80,4 @@ _include:
  - common_patches/rtc/rtc_cr.yaml
  - ../peripherals/rtc/rtc_common.yaml
  - ../peripherals/rtc/rtc_h7.yaml
+ - common_patches/h7_crc_addr_fix.yaml

--- a/devices/stm32h753v.yaml
+++ b/devices/stm32h753v.yaml
@@ -83,3 +83,4 @@ _include:
  - common_patches/rtc/rtc_cr.yaml
  - ../peripherals/rtc/rtc_common.yaml
  - ../peripherals/rtc/rtc_h7.yaml
+ - common_patches/h7_crc_addr_fix.yaml

--- a/devices/stm32h7b3.yaml
+++ b/devices/stm32h7b3.yaml
@@ -89,3 +89,4 @@ _include:
  - common_patches/rtc/rtc_cr.yaml
  - ../peripherals/rtc/rtc_common.yaml
  - ../peripherals/rtc/rtc_h7.yaml
+ - common_patches/h7_crc_addr_fix.yaml


### PR DESCRIPTION
According to RM0433, RM0399, and RM0455 `INIT` is at 0x10 and `POL` is at 0x14. (See for example [page 798/section 21.4.4 of RM0433](https://www.st.com/resource/en/reference_manual/dm00314099-stm32h742-stm32h743-753-and-stm32h750-value-line-advanced-arm-based-32-bit-mcus-stmicroelectronics.pdf#page=798).) SVDs have them both four bytes earlier.

Tested on an STM32H750VBT6.