### PR TITLE
Define CRC IDR as 8-bit or 32-bit as appropriate

### DIFF
--- a/devices/common_patches/crc/crc_32bit_idr.yaml
+++ b/devices/common_patches/crc/crc_32bit_idr.yaml
@@ -1,8 +1,0 @@
-# Some CRC peripherals allow all 32-bits of their independent data register to be used.
-# Whether it's safe to use all 32-bits appears independent of other CRC features.
-
-CRC:
-  IDR:
-    _modify:
-      IDR:
-        _write_constraint: [0, 0xFFFFFFFF]

--- a/devices/common_patches/crc/crc_32bit_idr.yaml
+++ b/devices/common_patches/crc/crc_32bit_idr.yaml
@@ -5,4 +5,4 @@ CRC:
   IDR:
     _modify:
       IDR:
-        _write_constraint: [0, 4294967295]
+        _write_constraint: [0, 0xFFFFFFFF]

--- a/devices/common_patches/crc/crc_32bit_idr.yaml
+++ b/devices/common_patches/crc/crc_32bit_idr.yaml
@@ -1,0 +1,8 @@
+# Some CRC peripherals allow all 32-bits of their independent data register to be used.
+# Whether it's safe to use all 32-bits appears independent of other CRC features.
+
+CRC:
+  IDR:
+    _modify:
+      IDR:
+        _write_constraint: [0, 4294967295]

--- a/devices/stm32f0x0.yaml
+++ b/devices/stm32f0x0.yaml
@@ -56,6 +56,7 @@ _include:
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/gpio/gpio_with_brr.yaml
  - ../peripherals/crc/crc_advanced.yaml
+ - ../peripherals/crc/crc_idr_8bit.yaml
  - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml

--- a/devices/stm32f0x1.yaml
+++ b/devices/stm32f0x1.yaml
@@ -42,6 +42,7 @@ _include:
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/gpio/gpio_with_brr.yaml
  - ../peripherals/crc/crc_advanced.yaml
+ - ../peripherals/crc/crc_idr_8bit.yaml
  - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml

--- a/devices/stm32f0x2.yaml
+++ b/devices/stm32f0x2.yaml
@@ -59,6 +59,7 @@ _include:
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/gpio/gpio_with_brr.yaml
  - ../peripherals/crc/crc_advanced.yaml
+ - ../peripherals/crc/crc_idr_8bit.yaml
  - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml

--- a/devices/stm32f0x8.yaml
+++ b/devices/stm32f0x8.yaml
@@ -35,6 +35,7 @@ _include:
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/gpio/gpio_with_brr.yaml
  - ../peripherals/crc/crc_advanced.yaml
+ - ../peripherals/crc/crc_idr_8bit.yaml
  - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml

--- a/devices/stm32f100.yaml
+++ b/devices/stm32f100.yaml
@@ -22,6 +22,7 @@ _include:
  - ../peripherals/dac/dac_common_2ch.yaml
  - ../peripherals/dac/dac_dmaudr.yaml
  - ../peripherals/crc/crc_basic.yaml
+ - ../peripherals/crc/crc_idr_8bit.yaml
  - ../peripherals/i2c/i2c_v1.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml

--- a/devices/stm32f101.yaml
+++ b/devices/stm32f101.yaml
@@ -54,6 +54,7 @@ _include:
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml
  - ../peripherals/crc/crc_basic.yaml
+ - ../peripherals/crc/crc_idr_8bit.yaml
  - ../peripherals/i2c/i2c_v1.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml

--- a/devices/stm32f102.yaml
+++ b/devices/stm32f102.yaml
@@ -95,6 +95,7 @@ _include:
  - ../peripherals/dac/dac_common_2ch.yaml
  - ../peripherals/dac/dac_dmaudr.yaml
  - ../peripherals/crc/crc_basic.yaml
+ - ../peripherals/crc/crc_idr_8bit.yaml
  - ../peripherals/i2c/i2c_v1.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml

--- a/devices/stm32f103.yaml
+++ b/devices/stm32f103.yaml
@@ -59,6 +59,7 @@ _include:
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml
  - ../peripherals/crc/crc_basic.yaml
+ - ../peripherals/crc/crc_idr_8bit.yaml
  - common_patches/dma/dma_v1.yaml
  - ../peripherals/dma/dma_v1.yaml
  - ../peripherals/i2c/i2c_v1.yaml

--- a/devices/stm32f107.yaml
+++ b/devices/stm32f107.yaml
@@ -48,6 +48,7 @@ _include:
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml
  - ../peripherals/crc/crc_basic.yaml
+ - ../peripherals/crc/crc_idr_8bit.yaml
  - ../peripherals/i2c/i2c_v1.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml

--- a/devices/stm32f215.yaml
+++ b/devices/stm32f215.yaml
@@ -61,6 +61,7 @@ _include:
  - ../peripherals/rcc/rcc_merge_rtcsel.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/crc/crc_basic.yaml
+ - ../peripherals/crc/crc_idr_8bit.yaml
  - ../peripherals/adc/adc_v2_multi.yaml
  - common_patches/dma/dma_v2.yaml
  - ../peripherals/dma/dma_v2.yaml

--- a/devices/stm32f217.yaml
+++ b/devices/stm32f217.yaml
@@ -60,6 +60,7 @@ _include:
  - ../peripherals/rcc/rcc_merge_rtcsel.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/crc/crc_basic.yaml
+ - ../peripherals/crc/crc_idr_8bit.yaml
  - ../peripherals/adc/adc_v2_multi.yaml
  - common_patches/dma/dma_v2.yaml
  - ../peripherals/dma/dma_v2.yaml

--- a/devices/stm32f301.yaml
+++ b/devices/stm32f301.yaml
@@ -112,6 +112,7 @@ _include:
  - ./common_patches/unprefix_USB_registers.yaml
  - common_patches/tim/tim_o24ce.yaml
  - ../peripherals/crc/crc_advanced.yaml
+ - ../peripherals/crc/crc_idr_8bit.yaml
  - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/crc/crc_pol.yaml
  - ../peripherals/spi/spi_v2.yaml

--- a/devices/stm32f302.yaml
+++ b/devices/stm32f302.yaml
@@ -127,6 +127,7 @@ _include:
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/gpio/gpio_with_brr.yaml
  - ../peripherals/crc/crc_advanced.yaml
+ - ../peripherals/crc/crc_idr_8bit.yaml
  - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/crc/crc_pol.yaml
  - ../peripherals/spi/spi_v2.yaml

--- a/devices/stm32f303.yaml
+++ b/devices/stm32f303.yaml
@@ -111,6 +111,7 @@ _include:
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/gpio/gpio_with_brr.yaml
  - ../peripherals/crc/crc_advanced.yaml
+ - ../peripherals/crc/crc_idr_8bit.yaml
  - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/crc/crc_pol.yaml
  - ../peripherals/spi/spi_v2.yaml

--- a/devices/stm32f373.yaml
+++ b/devices/stm32f373.yaml
@@ -149,6 +149,7 @@ _include:
  - ./common_patches/unprefix_USB_registers.yaml
  - common_patches/tim/tim_o24ce.yaml
  - ../peripherals/crc/crc_advanced.yaml
+ - ../peripherals/crc/crc_idr_8bit.yaml
  - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/crc/crc_pol.yaml
  - ../peripherals/spi/spi_v2.yaml

--- a/devices/stm32f3x4.yaml
+++ b/devices/stm32f3x4.yaml
@@ -244,6 +244,7 @@ _include:
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/gpio/gpio_with_brr.yaml
  - ../peripherals/crc/crc_advanced.yaml
+ - ../peripherals/crc/crc_idr_32bit.yaml
  - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/crc/crc_pol.yaml
  - ../peripherals/spi/spi_v2.yaml

--- a/devices/stm32f3x8.yaml
+++ b/devices/stm32f3x8.yaml
@@ -219,6 +219,7 @@ _include:
  - ./common_patches/unprefix_USB_registers.yaml
  - common_patches/tim/tim_o24ce.yaml
  - ../peripherals/crc/crc_advanced.yaml
+ - ../peripherals/crc/crc_idr_8bit.yaml
  - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/crc/crc_pol.yaml
  - ../peripherals/spi/spi_v2.yaml

--- a/devices/stm32f401.yaml
+++ b/devices/stm32f401.yaml
@@ -115,6 +115,7 @@ _include:
  - ../peripherals/rcc/rcc_merge_rtcsel.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/crc/crc_basic.yaml
+ - ../peripherals/crc/crc_idr_8bit.yaml
  - ../peripherals/adc/adc_v2.yaml
  - ../peripherals/adc/adc_v2_smpr.yaml
  - common_patches/dma/dma_v2.yaml

--- a/devices/stm32f405.yaml
+++ b/devices/stm32f405.yaml
@@ -84,6 +84,7 @@ _include:
  - ../peripherals/rcc/rcc_merge_rtcsel.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/crc/crc_basic.yaml
+ - ../peripherals/crc/crc_idr_8bit.yaml
  - ../peripherals/adc/adc_v2_smpr.yaml
  - ../peripherals/adc/adc_v2_multi.yaml
  - common_patches/dma/dma_v2.yaml

--- a/devices/stm32f407.yaml
+++ b/devices/stm32f407.yaml
@@ -86,6 +86,7 @@ _include:
  - ../peripherals/rcc/rcc_merge_rtcsel.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/crc/crc_basic.yaml
+ - ../peripherals/crc/crc_idr_8bit.yaml
  - ../peripherals/adc/adc_v2_smpr.yaml
  - ../peripherals/adc/adc_v2_multi.yaml
  - common_patches/dma/dma_v2.yaml

--- a/devices/stm32f410.yaml
+++ b/devices/stm32f410.yaml
@@ -168,6 +168,7 @@ _include:
  - ../peripherals/rcc/rcc_merge_rtcsel.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/crc/crc_basic.yaml
+ - ../peripherals/crc/crc_idr_8bit.yaml
  - ../peripherals/adc/adc_v2_smpr.yaml
  - ../peripherals/adc/adc_v2_single.yaml
  - common_patches/dma/dma_v2.yaml

--- a/devices/stm32f411.yaml
+++ b/devices/stm32f411.yaml
@@ -139,6 +139,7 @@ _include:
  - ../peripherals/rcc/rcc_merge_rtcsel.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/crc/crc_basic.yaml
+ - ../peripherals/crc/crc_idr_8bit.yaml
  - ../peripherals/adc/adc_v2.yaml
  - ../peripherals/adc/adc_v2_smpr.yaml
  - common_patches/dma/dma_v2.yaml

--- a/devices/stm32f412.yaml
+++ b/devices/stm32f412.yaml
@@ -409,6 +409,7 @@ _include:
  - ../peripherals/rcc/rcc_merge_rtcsel.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/crc/crc_basic.yaml
+ - ../peripherals/crc/crc_idr_8bit.yaml
  - ../peripherals/adc/adc_v2_smpr.yaml
  - ../peripherals/adc/adc_v2_single.yaml
  - common_patches/dma/dma_v2.yaml

--- a/devices/stm32f413.yaml
+++ b/devices/stm32f413.yaml
@@ -168,6 +168,7 @@ _include:
  - ../peripherals/rcc/rcc_merge_rtcsel.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/crc/crc_basic.yaml
+ - ../peripherals/crc/crc_idr_8bit.yaml
  - ../peripherals/adc/adc_v2_smpr.yaml
  - ../peripherals/adc/adc_v2_single.yaml
  - common_patches/dma/dma_v21.yaml

--- a/devices/stm32f427.yaml
+++ b/devices/stm32f427.yaml
@@ -194,6 +194,7 @@ _include:
  - ../peripherals/rcc/rcc_merge_rtcsel.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/crc/crc_basic.yaml
+ - ../peripherals/crc/crc_idr_8bit.yaml
  - ../peripherals/adc/adc_v2_smpr.yaml
  - ../peripherals/adc/adc_v2_multi.yaml
  - common_patches/dma/dma_v2.yaml

--- a/devices/stm32f429.yaml
+++ b/devices/stm32f429.yaml
@@ -147,6 +147,7 @@ _include:
  - ../peripherals/rcc/rcc_merge_rtcsel.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/crc/crc_basic.yaml
+ - ../peripherals/crc/crc_idr_8bit.yaml
  - ../peripherals/adc/adc_v2_smpr.yaml
  - ../peripherals/adc/adc_v2_multi.yaml
  - common_patches/dma/dma_v2.yaml

--- a/devices/stm32f446.yaml
+++ b/devices/stm32f446.yaml
@@ -529,6 +529,7 @@ _include:
  - ../peripherals/rcc/rcc_v2_dckcfgr2_spdifrxsel.yaml
  - ../peripherals/rcc/rcc_v2_ckgatenr.yaml
  - ../peripherals/crc/crc_basic.yaml
+ - ../peripherals/crc/crc_idr_8bit.yaml
  - ../peripherals/adc/adc_v2_smpr.yaml
  - ../peripherals/adc/adc_v2_multi.yaml
  - common_patches/dma/dma_v2.yaml

--- a/devices/stm32f469.yaml
+++ b/devices/stm32f469.yaml
@@ -104,6 +104,7 @@ _include:
  - ../peripherals/rcc/rcc_merge_rtcsel.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/crc/crc_basic.yaml
+ - ../peripherals/crc/crc_idr_8bit.yaml
  - ../peripherals/adc/adc_v2_smpr.yaml
  - ../peripherals/adc/adc_v2_multi.yaml
  - common_patches/dma/dma_v2.yaml

--- a/devices/stm32f730.yaml
+++ b/devices/stm32f730.yaml
@@ -36,6 +36,7 @@ _include:
  - ../peripherals/gpio/gpio_v2.yaml
  - common_patches/crc/crc_rename_init.yaml
  - ../peripherals/crc/crc_advanced.yaml
+ - ../peripherals/crc/crc_idr_8bit.yaml
  - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/crc/crc_pol.yaml
  - ../peripherals/spi/spi_v2.yaml

--- a/devices/stm32f745.yaml
+++ b/devices/stm32f745.yaml
@@ -129,6 +129,7 @@ _include:
  - common_patches/crc/crc_rename_init.yaml
  - common_patches/crc/f7_polysize_rev_in_rev_out.yaml
  - ../peripherals/crc/crc_advanced.yaml
+ - ../peripherals/crc/crc_idr_8bit.yaml
  - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/crc/crc_pol.yaml
  - ../peripherals/adc/adc_v2_multi.yaml

--- a/devices/stm32f765.yaml
+++ b/devices/stm32f765.yaml
@@ -139,6 +139,7 @@ _include:
  - common_patches/crc/crc_rename_init.yaml
  - common_patches/crc/f7_polysize_rev_in_rev_out.yaml
  - ../peripherals/crc/crc_advanced.yaml
+ - ../peripherals/crc/crc_idr_8bit.yaml
  - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/crc/crc_pol.yaml
  - ../peripherals/adc/adc_v2_multi.yaml

--- a/devices/stm32f7x2.yaml
+++ b/devices/stm32f7x2.yaml
@@ -37,6 +37,7 @@ _include:
  - ../peripherals/gpio/gpio_v2.yaml
  - common_patches/crc/crc_rename_init.yaml
  - ../peripherals/crc/crc_advanced.yaml
+ - ../peripherals/crc/crc_idr_8bit.yaml
  - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/crc/crc_pol.yaml
  - ../peripherals/spi/spi_v2.yaml

--- a/devices/stm32f7x3.yaml
+++ b/devices/stm32f7x3.yaml
@@ -47,6 +47,7 @@ _include:
  - ../peripherals/gpio/gpio_v2.yaml
  - common_patches/crc/crc_rename_init.yaml
  - ../peripherals/crc/crc_advanced.yaml
+ - ../peripherals/crc/crc_idr_8bit.yaml
  - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/crc/crc_pol.yaml
  - ../peripherals/spi/spi_v2.yaml

--- a/devices/stm32f7x6.yaml
+++ b/devices/stm32f7x6.yaml
@@ -117,6 +117,7 @@ _include:
  - common_patches/crc/crc_rename_init.yaml
  - common_patches/crc/f7_polysize_rev_in_rev_out.yaml
  - ../peripherals/crc/crc_advanced.yaml
+ - ../peripherals/crc/crc_idr_8bit.yaml
  - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/crc/crc_pol.yaml
  - ../peripherals/spi/spi_v2.yaml

--- a/devices/stm32f7x7.yaml
+++ b/devices/stm32f7x7.yaml
@@ -285,6 +285,7 @@ _include:
  - common_patches/crc/crc_rename_init.yaml
  - common_patches/crc/f7_polysize_rev_in_rev_out.yaml
  - ../peripherals/crc/crc_advanced.yaml
+ - ../peripherals/crc/crc_idr_8bit.yaml
  - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/crc/crc_pol.yaml
  - ../peripherals/spi/spi_v2.yaml

--- a/devices/stm32f7x9.yaml
+++ b/devices/stm32f7x9.yaml
@@ -281,6 +281,7 @@ _include:
  - common_patches/crc/crc_rename_init.yaml
  - common_patches/crc/f7_polysize_rev_in_rev_out.yaml
  - ../peripherals/crc/crc_advanced.yaml
+ - ../peripherals/crc/crc_idr_8bit.yaml
  - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/crc/crc_pol.yaml
  - ../peripherals/spi/spi_v2.yaml

--- a/devices/stm32h743.yaml
+++ b/devices/stm32h743.yaml
@@ -72,3 +72,4 @@ _include:
  - ../peripherals/rtc/rtc_common.yaml
  - ../peripherals/rtc/rtc_h7.yaml
  - common_patches/h7_crc_addr_fix.yaml
+ - common_patches/crc/crc_32bit_idr.yaml

--- a/devices/stm32h743.yaml
+++ b/devices/stm32h743.yaml
@@ -36,6 +36,7 @@ _include:
  - ../peripherals/axi/axi_v1.yaml
  - common_patches/crc/crc_rename_init.yaml
  - ../peripherals/crc/crc_advanced.yaml
+ - ../peripherals/crc/crc_idr_32bit.yaml
  - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/crc/crc_pol.yaml
  - ../peripherals/dma/bdma.yaml
@@ -72,4 +73,3 @@ _include:
  - ../peripherals/rtc/rtc_common.yaml
  - ../peripherals/rtc/rtc_h7.yaml
  - common_patches/h7_crc_addr_fix.yaml
- - common_patches/crc/crc_32bit_idr.yaml

--- a/devices/stm32h743v.yaml
+++ b/devices/stm32h743v.yaml
@@ -74,3 +74,4 @@ _include:
  - ../peripherals/rtc/rtc_common.yaml
  - ../peripherals/rtc/rtc_h7.yaml
  - common_patches/h7_crc_addr_fix.yaml
+ - common_patches/crc/crc_32bit_idr.yaml

--- a/devices/stm32h743v.yaml
+++ b/devices/stm32h743v.yaml
@@ -38,6 +38,7 @@ _include:
  - ../peripherals/axi/axi_v1.yaml
  - common_patches/crc/crc_rename_init.yaml
  - ../peripherals/crc/crc_advanced.yaml
+ - ../peripherals/crc/crc_idr_32bit.yaml
  - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/crc/crc_pol.yaml
  - ../peripherals/dma/bdma.yaml
@@ -74,4 +75,3 @@ _include:
  - ../peripherals/rtc/rtc_common.yaml
  - ../peripherals/rtc/rtc_h7.yaml
  - common_patches/h7_crc_addr_fix.yaml
- - common_patches/crc/crc_32bit_idr.yaml

--- a/devices/stm32h747cm4.yaml
+++ b/devices/stm32h747cm4.yaml
@@ -53,6 +53,7 @@ _include:
  - ../peripherals/adc/adc_h7_revision_v.yaml
  - common_patches/crc/crc_rename_init.yaml
  - ../peripherals/crc/crc_advanced.yaml
+ - ../peripherals/crc/crc_idr_32bit.yaml
  - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/crc/crc_pol.yaml
  - ../peripherals/dma/bdma.yaml
@@ -86,4 +87,3 @@ _include:
  - ../peripherals/tim/tim1234_1567_ccm_v2.yaml
  - ../peripherals/sai/sai.yaml
  - common_patches/h7_crc_addr_fix.yaml
- - common_patches/crc/crc_32bit_idr.yaml

--- a/devices/stm32h747cm4.yaml
+++ b/devices/stm32h747cm4.yaml
@@ -86,3 +86,4 @@ _include:
  - ../peripherals/tim/tim1234_1567_ccm_v2.yaml
  - ../peripherals/sai/sai.yaml
  - common_patches/h7_crc_addr_fix.yaml
+ - common_patches/crc/crc_32bit_idr.yaml

--- a/devices/stm32h747cm7.yaml
+++ b/devices/stm32h747cm7.yaml
@@ -54,6 +54,7 @@ _include:
  - ../peripherals/axi/axi_v1.yaml
  - common_patches/crc/crc_rename_init.yaml
  - ../peripherals/crc/crc_advanced.yaml
+ - ../peripherals/crc/crc_idr_32bit.yaml
  - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/crc/crc_pol.yaml
  - ../peripherals/dma/bdma.yaml
@@ -91,4 +92,3 @@ _include:
  - ../peripherals/rtc/rtc_common.yaml
  - ../peripherals/rtc/rtc_h7.yaml
  - common_patches/h7_crc_addr_fix.yaml
- - common_patches/crc/crc_32bit_idr.yaml

--- a/devices/stm32h747cm7.yaml
+++ b/devices/stm32h747cm7.yaml
@@ -91,3 +91,4 @@ _include:
  - ../peripherals/rtc/rtc_common.yaml
  - ../peripherals/rtc/rtc_h7.yaml
  - common_patches/h7_crc_addr_fix.yaml
+ - common_patches/crc/crc_32bit_idr.yaml

--- a/devices/stm32h753.yaml
+++ b/devices/stm32h753.yaml
@@ -81,3 +81,4 @@ _include:
  - ../peripherals/rtc/rtc_common.yaml
  - ../peripherals/rtc/rtc_h7.yaml
  - common_patches/h7_crc_addr_fix.yaml
+ - common_patches/crc/crc_32bit_idr.yaml

--- a/devices/stm32h753.yaml
+++ b/devices/stm32h753.yaml
@@ -46,6 +46,7 @@ _include:
  - ../peripherals/axi/axi_v1.yaml
  - common_patches/crc/crc_rename_init.yaml
  - ../peripherals/crc/crc_advanced.yaml
+ - ../peripherals/crc/crc_idr_32bit.yaml
  - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/crc/crc_pol.yaml
  - ../peripherals/dma/bdma.yaml
@@ -81,4 +82,3 @@ _include:
  - ../peripherals/rtc/rtc_common.yaml
  - ../peripherals/rtc/rtc_h7.yaml
  - common_patches/h7_crc_addr_fix.yaml
- - common_patches/crc/crc_32bit_idr.yaml

--- a/devices/stm32h753v.yaml
+++ b/devices/stm32h753v.yaml
@@ -84,3 +84,4 @@ _include:
  - ../peripherals/rtc/rtc_common.yaml
  - ../peripherals/rtc/rtc_h7.yaml
  - common_patches/h7_crc_addr_fix.yaml
+ - common_patches/crc/crc_32bit_idr.yaml

--- a/devices/stm32h753v.yaml
+++ b/devices/stm32h753v.yaml
@@ -48,6 +48,7 @@ _include:
  - ../peripherals/axi/axi_v1.yaml
  - common_patches/crc/crc_rename_init.yaml
  - ../peripherals/crc/crc_advanced.yaml
+ - ../peripherals/crc/crc_idr_32bit.yaml
  - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/crc/crc_pol.yaml
  - ../peripherals/dma/bdma.yaml
@@ -84,4 +85,3 @@ _include:
  - ../peripherals/rtc/rtc_common.yaml
  - ../peripherals/rtc/rtc_h7.yaml
  - common_patches/h7_crc_addr_fix.yaml
- - common_patches/crc/crc_32bit_idr.yaml

--- a/devices/stm32h7b3.yaml
+++ b/devices/stm32h7b3.yaml
@@ -90,3 +90,4 @@ _include:
  - ../peripherals/rtc/rtc_common.yaml
  - ../peripherals/rtc/rtc_h7.yaml
  - common_patches/h7_crc_addr_fix.yaml
+ - common_patches/crc/crc_32bit_idr.yaml

--- a/devices/stm32h7b3.yaml
+++ b/devices/stm32h7b3.yaml
@@ -54,6 +54,7 @@ _include:
  - ../peripherals/axi/axi_v1.yaml
  - common_patches/crc/crc_rename_init.yaml
  - ../peripherals/crc/crc_advanced.yaml
+ - ../peripherals/crc/crc_idr_32bit.yaml
  - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/crc/crc_pol.yaml
  - ../peripherals/dma/bdma.yaml
@@ -90,4 +91,3 @@ _include:
  - ../peripherals/rtc/rtc_common.yaml
  - ../peripherals/rtc/rtc_h7.yaml
  - common_patches/h7_crc_addr_fix.yaml
- - common_patches/crc/crc_32bit_idr.yaml

--- a/devices/stm32l0x1.yaml
+++ b/devices/stm32l0x1.yaml
@@ -132,6 +132,7 @@ _include:
  - ../peripherals/aes/aes_l0.yaml
  - common_patches/crc/crc_rename_init.yaml
  - ../peripherals/crc/crc_advanced.yaml
+ - ../peripherals/crc/crc_idr_8bit.yaml
  - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/crc/crc_pol.yaml
  - ../peripherals/dbg/dbg_l0.yaml

--- a/devices/stm32l0x2.yaml
+++ b/devices/stm32l0x2.yaml
@@ -121,6 +121,7 @@ _include:
  - ../peripherals/aes/aes_l0.yaml
  - common_patches/crc/crc_rename_init.yaml
  - ../peripherals/crc/crc_advanced.yaml
+ - ../peripherals/crc/crc_idr_8bit.yaml
  - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/crc/crc_pol.yaml
  - ../peripherals/dbg/dbg_l0.yaml

--- a/devices/stm32l0x3.yaml
+++ b/devices/stm32l0x3.yaml
@@ -132,6 +132,7 @@ _include:
  - ../peripherals/aes/aes_l0.yaml
  - common_patches/crc/crc_rename_init.yaml
  - ../peripherals/crc/crc_advanced.yaml
+ - ../peripherals/crc/crc_idr_8bit.yaml
  - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/crc/crc_pol.yaml
  - ../peripherals/dbg/dbg_l0.yaml

--- a/devices/stm32l100.yaml
+++ b/devices/stm32l100.yaml
@@ -72,6 +72,7 @@ _include:
  - ../peripherals/dac/dac_common_2ch.yaml
  - ../peripherals/dac/dac_dmaudr.yaml
  - ../peripherals/crc/crc_basic.yaml
+ - ../peripherals/crc/crc_idr_8bit.yaml
  - ../peripherals/spi/spi_v1.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml

--- a/devices/stm32l151.yaml
+++ b/devices/stm32l151.yaml
@@ -24,6 +24,7 @@ _include:
  - ../peripherals/dac/dac_common_2ch.yaml
  - ../peripherals/dac/dac_dmaudr.yaml
  - ../peripherals/crc/crc_basic.yaml
+ - ../peripherals/crc/crc_idr_8bit.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml
  - ../devices/common_patches/gpio_with_OSPEEDER.yaml

--- a/devices/stm32l162.yaml
+++ b/devices/stm32l162.yaml
@@ -24,6 +24,7 @@ _include:
  - ../peripherals/dac/dac_common_2ch.yaml
  - ../peripherals/dac/dac_dmaudr.yaml
  - ../peripherals/crc/crc_basic.yaml
+ - ../peripherals/crc/crc_idr_8bit.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml
  - ../devices/common_patches/gpio_with_OSPEEDER.yaml

--- a/devices/stm32l4x1.yaml
+++ b/devices/stm32l4x1.yaml
@@ -55,6 +55,7 @@ _include:
  - ../peripherals/gpio/gpio_v2.yaml
  - common_patches/crc/crc_rename_init.yaml
  - ../peripherals/crc/crc_advanced.yaml
+ - ../peripherals/crc/crc_idr_8bit.yaml
  - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/rcc/rcc_l4.yaml

--- a/devices/stm32l4x2.yaml
+++ b/devices/stm32l4x2.yaml
@@ -87,6 +87,7 @@ _include:
  - ../peripherals/gpio/gpio_v2.yaml
  - common_patches/crc/crc_rename_init.yaml
  - ../peripherals/crc/crc_advanced.yaml
+ - ../peripherals/crc/crc_idr_8bit.yaml
  - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/rcc/rcc_l4.yaml

--- a/devices/stm32l4x3.yaml
+++ b/devices/stm32l4x3.yaml
@@ -44,6 +44,7 @@ _include:
  - ../peripherals/gpio/gpio_v2.yaml
  - common_patches/crc/crc_rename_init.yaml
  - ../peripherals/crc/crc_advanced.yaml
+ - ../peripherals/crc/crc_idr_8bit.yaml
  - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/rcc/rcc_l4.yaml

--- a/devices/stm32l4x5.yaml
+++ b/devices/stm32l4x5.yaml
@@ -117,6 +117,7 @@ _include:
  - ../peripherals/gpio/gpio_v2.yaml
  - common_patches/crc/crc_rename_init.yaml
  - ../peripherals/crc/crc_advanced.yaml
+ - ../peripherals/crc/crc_idr_8bit.yaml
  - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/rcc/rcc_l4.yaml

--- a/devices/stm32l4x6.yaml
+++ b/devices/stm32l4x6.yaml
@@ -48,6 +48,7 @@ _include:
  - ../peripherals/gpio/gpio_with_brr.yaml
  - common_patches/crc/crc_rename_init.yaml
  - ../peripherals/crc/crc_advanced.yaml
+ - ../peripherals/crc/crc_idr_8bit.yaml
  - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/rcc/rcc_l4.yaml

--- a/peripherals/crc/crc_advanced.yaml
+++ b/peripherals/crc/crc_advanced.yaml
@@ -1,5 +1,6 @@
 # CRC peripheral with reversal features.
 # Documented from STM32F0xx reference manual.
+# Additionally use crc_idr_8bit.yaml or crc_idr_32bit.yaml as appropriate.
 
 _include:
  - ./crc_basic.yaml

--- a/peripherals/crc/crc_basic.yaml
+++ b/peripherals/crc/crc_basic.yaml
@@ -1,12 +1,11 @@
 # CRC peripheral. Details specifically from RM0090 but widely applicable.
-# This covers the basic features - DR, IDR, and CR. For the more sophisticated
+# This covers the basic features - DR and CR. For the more sophisticated
 # CRC available on some STM32s, use crc_advanced.yaml.
+# Additionally use crc_idr_8bit.yaml or crc_idr_32bit.yaml as appropriate.
 
 CRC:
   DR:
     DR: [0, 4294967295]
-  IDR:
-    IDR: [0, 255]
   CR:
     RESET:
       _write:

--- a/peripherals/crc/crc_idr_32bit.yaml
+++ b/peripherals/crc/crc_idr_32bit.yaml
@@ -1,0 +1,9 @@
+# Independent data register allowing 32-bit usage.
+# Some STM32 CRC units have this.
+
+CRC:
+  IDR:
+    IDR: [0, 0xFFFFFFFF]
+    _modify:
+      IDR:
+        bitWidth: 32

--- a/peripherals/crc/crc_idr_8bit.yaml
+++ b/peripherals/crc/crc_idr_8bit.yaml
@@ -1,0 +1,9 @@
+# Independent data register allowing 8-bit usage only.
+# Most STM32 CRC units have this.
+
+CRC:
+  IDR:
+    IDR: [0, 0xFF]
+    _modify:
+      IDR:
+        bitWidth: 8


### PR DESCRIPTION
The CRC peripheral's independent data register only allows 8 bits to be used on most chips. On all H7 chips (RM0399, RM0433, RM0455, RM0468) it allows all 32 bits to be used. [As an example, RM0433 page 797](https://www.st.com/resource/en/reference_manual/dm00314099-stm32h742-stm32h743753-and-stm32h750-value-line-advanced-armbased-32bit-mcus-stmicroelectronics.pdf#page=797).

H7 chips are not the only chips that have a 32-bit IDR, but I don't have any of the others: the G4 series, G0 series, L5 series, and the STM32F334. Probably others, I didn't check every reference manual. Since I can't test them at all I haven't included them here, but I'll add this patch to the G0/G4 chips if desired.

I can't determine any pattern for which chips support it, as chips with the advanced peripheral + configurable polynomials do not necessarily have a 32-bit IDR (eg F373).

Tested on an STM32H743VIT6.