### PR TITLE
ADC -> ADC1 fix for STM32L4xx series

### DIFF
--- a/devices/stm32l4x1.yaml
+++ b/devices/stm32l4x1.yaml
@@ -18,6 +18,11 @@ RCC:
         name: USART3RST
         description: USART3 reset
 
+_modify:
+  # The SVD calls ADC1 ADC.
+  ADC:
+    name: ADC1
+
 # Merge the thousands of individal bit fields into a single field for each
 # CAN filter register. This is not only much easier to use but also saves
 # a huge amount of filespace and compilation time etc -- as much as 30% of all

--- a/devices/stm32l4x1.yaml
+++ b/devices/stm32l4x1.yaml
@@ -23,6 +23,12 @@ _modify:
   ADC:
     name: ADC1
 
+ADC1:
+  _modify:
+    _interrupts:
+      ADC1:
+        name: ADC1_2
+
 _add:
   ADC2:
     derivedFrom: ADC1

--- a/devices/stm32l4x1.yaml
+++ b/devices/stm32l4x1.yaml
@@ -23,6 +23,11 @@ _modify:
   ADC:
     name: ADC1
 
+_add:
+  ADC2:
+    derivedFrom: ADC1
+    baseAddress: "0x50040100"
+
 # Merge the thousands of individal bit fields into a single field for each
 # CAN filter register. This is not only much easier to use but also saves
 # a huge amount of filespace and compilation time etc -- as much as 30% of all

--- a/devices/stm32l4x2.yaml
+++ b/devices/stm32l4x2.yaml
@@ -29,6 +29,11 @@ RCC:
         bitWidth: 1
         access: read-write
 
+_modify:
+  # The SVD calls ADC1 ADC.
+  ADC:
+    name: ADC1
+
 # cf. <https://github.com/adamgreig/stm32-rs/issues/37>
 # we call the resulting peripheral `USB` instead of `USB-FS`
 # to be aligned with `mvirkkunen/stm32f103-usb`

--- a/devices/stm32l4x2.yaml
+++ b/devices/stm32l4x2.yaml
@@ -29,11 +29,6 @@ RCC:
         bitWidth: 1
         access: read-write
 
-_modify:
-  # The SVD calls ADC1 ADC.
-  ADC:
-    name: ADC1
-
 # cf. <https://github.com/adamgreig/stm32-rs/issues/37>
 # we call the resulting peripheral `USB` instead of `USB-FS`
 # to be aligned with `mvirkkunen/stm32f103-usb`
@@ -43,6 +38,9 @@ _modify:
      name: USB
      # without quotes, get less readable value 1073768448
      baseAddress: "0x40006800"
+  # The SVD calls ADC1 ADC.
+  ADC:
+    name: ADC1
 
 USB:
   _add:

--- a/devices/stm32l4x2.yaml
+++ b/devices/stm32l4x2.yaml
@@ -42,6 +42,11 @@ _modify:
   ADC:
     name: ADC1
 
+_add:
+  ADC2:
+    derivedFrom: ADC1
+    baseAddress: "0x50040100"
+
 USB:
   _add:
     _interrupts:

--- a/devices/stm32l4x2.yaml
+++ b/devices/stm32l4x2.yaml
@@ -42,6 +42,12 @@ _modify:
   ADC:
     name: ADC1
 
+ADC1:
+  _modify:
+    _interrupts:
+      ADC1:
+        name: ADC1_2
+
 _add:
   ADC2:
     derivedFrom: ADC1

--- a/devices/stm32l4x3.yaml
+++ b/devices/stm32l4x3.yaml
@@ -12,6 +12,11 @@ RCC:
         name: USBFSEN
         description: USB FS clock enable
 
+_modify:
+  # The SVD calls ADC1 ADC.
+  ADC:
+    name: ADC1
+
 # Merge the thousands of individal bit fields into a single field for each
 # CAN filter register. This is not only much easier to use but also saves
 # a huge amount of filespace and compilation time etc -- as much as 30% of all


### PR DESCRIPTION
Hi, I renamed the ADC to ADC1 to follow the datasheet.
It was not needed for the rest of the series, they had the correct name.

One question, ADC2 is missing and it shouly be on L412 and L422, but the feature flags do not have this granularity.
How should I add this?

Table for overview:

![image](https://user-images.githubusercontent.com/913109/102476879-ebf78180-405b-11eb-923c-a6cb97319057.png)
![image](https://user-images.githubusercontent.com/913109/102476906-f74aad00-405b-11eb-9002-f534cdb29821.png)

