### PR TITLE
Fix GPIO OSPEEDR variant on f3

### DIFF
--- a/devices/common_patches/f3_gpio_ospeedr.yaml
+++ b/devices/common_patches/f3_gpio_ospeedr.yaml
@@ -1,0 +1,16 @@
+# F3 mcus does not support very high speed mode.
+#
+# | value | F3     | others    |
+# |-------|--------|-----------|
+# | 0b00  | Low    | Low       |
+# | 0b01  | Medium | Medium    |
+# | 0b10  | Low    | High      |
+# | 0b11  | High   | Very high |
+
+"GPIO*":
+  OSPEEDR:
+    "OSPEEDR*":
+      _replace_enum:
+        LowSpeed: [0, "Low speed"]
+        MediumSpeed: [1, "Medium speed"]
+        HighSpeed: [3, "High speed"]

--- a/devices/stm32f301.yaml
+++ b/devices/stm32f301.yaml
@@ -119,6 +119,7 @@ _include:
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/gpio/gpio_with_brr.yaml
  - ../peripherals/gpio/gpio_v2.yaml
+ - common_patches/f3_gpio_ospeedr.yaml
  - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/tim/tim16.yaml
  - ../peripherals/tim/tim6.yaml

--- a/devices/stm32f302.yaml
+++ b/devices/stm32f302.yaml
@@ -126,6 +126,7 @@ _include:
  - ../peripherals/dac/dac_dmaudr.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/gpio/gpio_with_brr.yaml
+ - common_patches/f3_gpio_ospeedr.yaml
  - ../peripherals/crc/crc_advanced.yaml
  - ../peripherals/crc/crc_idr_8bit.yaml
  - ../peripherals/crc/crc_with_polysize.yaml

--- a/devices/stm32f303.yaml
+++ b/devices/stm32f303.yaml
@@ -110,6 +110,7 @@ _include:
  - ../peripherals/dac/dac_dmaudr.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/gpio/gpio_with_brr.yaml
+ - common_patches/f3_gpio_ospeedr.yaml
  - ../peripherals/crc/crc_advanced.yaml
  - ../peripherals/crc/crc_idr_8bit.yaml
  - ../peripherals/crc/crc_with_polysize.yaml

--- a/devices/stm32f373.yaml
+++ b/devices/stm32f373.yaml
@@ -156,6 +156,7 @@ _include:
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/gpio/gpio_v2_f373.yaml
  - ../peripherals/gpio/gpio_with_brr.yaml
+ - common_patches/f3_gpio_ospeedr.yaml
  - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/tim/tim16.yaml
  - ../peripherals/tim/tim6.yaml

--- a/devices/stm32f3x4.yaml
+++ b/devices/stm32f3x4.yaml
@@ -243,6 +243,7 @@ _include:
  - common_patches/tim/tim_o24ce.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/gpio/gpio_with_brr.yaml
+ - common_patches/f3_gpio_ospeedr.yaml
  - ../peripherals/crc/crc_advanced.yaml
  - ../peripherals/crc/crc_idr_32bit.yaml
  - ../peripherals/crc/crc_with_polysize.yaml

--- a/devices/stm32f3x8.yaml
+++ b/devices/stm32f3x8.yaml
@@ -227,6 +227,7 @@ _include:
  - ../peripherals/pwr/pwr_v1.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/gpio/gpio_with_brr.yaml
+ - common_patches/f3_gpio_ospeedr.yaml
  - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/tim/tim16.yaml
  - ../peripherals/tim/tim6.yaml


### PR DESCRIPTION
F3 mcus does not support very high speed mode in OSPEEDR register.

![image](https://user-images.githubusercontent.com/22536104/103092054-62d2e280-4639-11eb-99c4-bcdfc15647e0.png)

This patch ignores the `0b10`.