### PR TITLE
Fix STM32L552 TIMx interrupts

### DIFF
--- a/devices/stm32l552.yaml
+++ b/devices/stm32l552.yaml
@@ -2,3 +2,51 @@ _svd: ../svd/stm32l552.svd
 
 _include:
  - common_patches/dma_interrupt_names.yaml
+
+# SVD has TIM3,TIM4,TIM5 interrupts under TIM2 as
+# TIM2_3, TIM2_4, TIM2_5.  This somewhat matches
+# documentation RM0438 vector table, but is non-
+# intuitive and appears a documentation error also.
+#
+# Remove from TIM2 and add to TIM3/4/5, add to
+# respective timers.
+TIM2:
+  _delete:
+    _interrupts:
+      - TIM2_*
+
+TIM3:
+  _add:
+    _interrupts:
+      TIM3:
+        description: TIM3 global interrupt
+        value: 46
+
+TIM4:
+  _add:
+    _interrupts:
+      TIM4:
+        description: TIM4 global interrupt
+        value: 47
+
+TIM5:
+  _add:
+    _interrupts:
+      TIM5:
+        description: TIM5 global interrupt
+        value: 48
+
+# TIM6 and TIM7 interrupts are missing from SVD
+TIM6:
+  _add:
+    _interrupts:
+      TIM6:
+        description: TIM6 global interrupt
+        value: 49
+
+TIM7:
+  _add:
+    _interrupts:
+      TIM7:
+        description: TIM7 global interrupt
+        value: 50


### PR DESCRIPTION
The timer documentation also seems 'broken'.  Table from RM0438 below.  I'm assuming acronym column is incorrect in the doc, so fixing that as well as adding missing interrupts from TIM6 & TIM7.
![image](https://user-images.githubusercontent.com/509378/103331208-a5216880-4a19-11eb-97a3-d394ffd795c7.png)
