### PR TITLE
wb55: fix SYSCFG base address (and Makefile)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ SHELL := /usr/bin/env bash
 
 CRATES ?= stm32f0 stm32f1 stm32f2 stm32f3 stm32f4 stm32f7 stm32h7 \
           stm32l0 stm32l1 stm32l4 stm32l5 stm32g0 stm32g4 stm32mp1 \
-          stm32wl stm32wb55
+          stm32wl stm32wb
 
 # All yaml files in devices/ will be used to patch an SVD
 YAMLS := $(foreach crate, $(CRATES), \

--- a/devices/stm32wb55.yaml
+++ b/devices/stm32wb55.yaml
@@ -14,3 +14,9 @@ PWR:
     _modify:
       802EWKUP:
         name: _802EWKUP
+
+# Fix incorrect SYSCFG base address
+_modify:
+  SYSCFG:
+    baseAddress: "0x40010000"
+


### PR DESCRIPTION
This is a batch of two fixes:

- Uses the correct base address from the RM for `SYSCFG`. This fix was checked to work in the hardware
- Fixes `Makefile` to produce correct directory