### PR TITLE
Correct IWDG and WWDG peripherals for the g4 family

### DIFF
--- a/devices/common_patches/g4_swap_IWDG_WWDG.yaml
+++ b/devices/common_patches/g4_swap_IWDG_WWDG.yaml
@@ -8,7 +8,7 @@ _add:
     baseAddress: 0x40002C00
     addressBlock:
       offset: 0x0
-      size: 0x4
+      size: 0x400
       usage: registers
     registers:
       CR:

--- a/devices/common_patches/g4_swap_IWDG_WWDG.yaml
+++ b/devices/common_patches/g4_swap_IWDG_WWDG.yaml
@@ -56,8 +56,6 @@ _add:
             description: Early wakeup interrupt
             bitOffset: 0
             bitWidth: 1
-
-_add:
   IWDG:
     description: WinWATCHDOG
     baseAddress: 0x40002C00

--- a/devices/common_patches/g4_swap_IWDG_WWDG.yaml
+++ b/devices/common_patches/g4_swap_IWDG_WWDG.yaml
@@ -1,0 +1,131 @@
+_delete:
+  - WWDG
+  - IWDG
+
+_add:
+  WWDG:
+    description: System window watchdog
+    baseAddress: 0x40003000
+    addressBlock:
+      offset: 0x0
+      size: 0x4
+      usage: registers
+    registers:
+      CR:
+        description: Control register
+        addressOffset: 0x000
+        size: 0x20
+        access: read-write
+        resetValue: 0x0000007F
+        fields:
+          WDGA:
+            description: Activation bit
+            bitOffset: 7
+            bitWidth: 1
+          T:
+            description: 7-bit counter (MSB to LSB)
+            bitOffset: 0
+            bitWidth: 7
+      CFR:
+        description: Configuration register
+        addressOffset: 0x4
+        size: 0x20
+        access: read-write
+        resetValue: 0x0000007F
+        fields:
+          WDGTB:
+            description: Timer base
+            bitOffset: 11
+            bitWidth: 3
+          EWI:
+            description: Early wakeup interrupt
+            bitOffset: 9
+            bitWidth: 1
+          W:
+            description: 7-bit window value
+            bitOffset: 0
+            bitWidth: 7
+      SR:
+        description: Status register
+        addressOffset: 0x8
+        size: 0x20
+        access: read-write
+        resetValue: 0x00000000
+        fields:
+          EWIF:
+            description: Early wakeup interrupt
+            bitOffset: 0
+            bitWidth: 1
+
+_add:
+  IWDG:
+    description: WinWATCHDOG
+    baseAddress: 0x40002C00
+    addressBlock:
+      offset: 0x0
+      size: 0x400
+      usage: registers
+    registers:
+      KR:
+        description: Key register
+        addressOffset: 0x0
+        size: 0x20
+        access: write-only
+        resetValue: 0x00000000
+        fields:
+          KEY:
+            description: Key value (write only, read 0x0000)
+            bitOffset: 0
+            bitWidth: 16
+      PR:
+        description: Prescaler register
+        addressOffset: 0x4
+        size: 0x20
+        access: read-write
+        resetValue: 0x00000000
+        fields:
+          PR:
+            description: Prescaler divider
+            bitOffset: 0
+            bitWidth: 3
+      RLR:
+        description: Reload register
+        addressOffset: 0x8
+        size: 0x20
+        access: read-write
+        resetValue: 0x00000FFF
+        fields:
+          RL:
+            description: Watchdog counter reload value
+            bitOffset: 0
+            bitWidth: 12
+      SR:
+        description: Status register
+        addressOffset: 0xC
+        size: 0x20
+        access: read-only
+        resetValue: 0x00000000
+        fields:
+          WVU:
+            description: Watchdog counter window update
+            bitOffset: 2
+            bitWidth: 1
+          RVU:
+            description: Watchdog counter reload update
+            bitOffset: 1
+            bitWidth: 1
+          PVU:
+            description: Watchdog prescaler value update
+            bitOffset: 0
+            bitWidth: 1
+      WINR:
+        description: Window register
+        addressOffset: 0x10
+        size: 0x20
+        access: read-write
+        resetValue: 0x00000FFF
+        fields:
+          WIN:
+            description: Watchdog counter window value
+            bitOffset: 0
+            bitWidth: 12

--- a/devices/common_patches/g4_swap_IWDG_WWDG.yaml
+++ b/devices/common_patches/g4_swap_IWDG_WWDG.yaml
@@ -5,7 +5,7 @@ _delete:
 _add:
   WWDG:
     description: System window watchdog
-    baseAddress: 0x40003000
+    baseAddress: 0x40002C00
     addressBlock:
       offset: 0x0
       size: 0x4
@@ -58,7 +58,7 @@ _add:
             bitWidth: 1
   IWDG:
     description: WinWATCHDOG
-    baseAddress: 0x40002C00
+    baseAddress: 0x40003000
     addressBlock:
       offset: 0x0
       size: 0x400

--- a/devices/stm32g431.yaml
+++ b/devices/stm32g431.yaml
@@ -9,3 +9,4 @@ _include:
  - ../peripherals/adc/adc_v3_common_g4.yaml
  - ./common_patches/g4_comp.yaml
  - ./common_patches/g4_adc.yaml
+ - ./common_patches/g4_swap_IWDG_WWDG.yaml

--- a/devices/stm32g431.yaml
+++ b/devices/stm32g431.yaml
@@ -11,3 +11,4 @@ _include:
  - ./common_patches/g4_adc.yaml
  - ./common_patches/g4_swap_IWDG_WWDG.yaml
  - ../peripherals/iwdg/iwdg_with_WINR.yaml
+ - ../peripherals/wwdg/g4_wwdg.yaml

--- a/devices/stm32g431.yaml
+++ b/devices/stm32g431.yaml
@@ -10,3 +10,4 @@ _include:
  - ./common_patches/g4_comp.yaml
  - ./common_patches/g4_adc.yaml
  - ./common_patches/g4_swap_IWDG_WWDG.yaml
+ - ../peripherals/iwdg/iwdg_with_WINR.yaml

--- a/devices/stm32g441.yaml
+++ b/devices/stm32g441.yaml
@@ -9,4 +9,6 @@ _include:
  - ../peripherals/adc/adc_v3_common_g4.yaml
  - ./common_patches/g4_comp.yaml
  - ./common_patches/g4_adc.yaml
-  - ./common_patches/g4_swap_IWDG_WWDG.yaml
+ - ./common_patches/g4_swap_IWDG_WWDG.yaml
+ - ../peripherals/iwdg/iwdg_with_WINR.yaml
+ 

--- a/devices/stm32g441.yaml
+++ b/devices/stm32g441.yaml
@@ -9,4 +9,4 @@ _include:
  - ../peripherals/adc/adc_v3_common_g4.yaml
  - ./common_patches/g4_comp.yaml
  - ./common_patches/g4_adc.yaml
- 
+  - ./common_patches/g4_swap_IWDG_WWDG.yaml

--- a/devices/stm32g441.yaml
+++ b/devices/stm32g441.yaml
@@ -11,4 +11,5 @@ _include:
  - ./common_patches/g4_adc.yaml
  - ./common_patches/g4_swap_IWDG_WWDG.yaml
  - ../peripherals/iwdg/iwdg_with_WINR.yaml
+ - ../peripherals/wwdg/g4_wwdg.yaml
  

--- a/devices/stm32g471.yaml
+++ b/devices/stm32g471.yaml
@@ -9,4 +9,6 @@ _include:
  - ../peripherals/adc/adc_v3_common_g4.yaml
  - ./common_patches/g4_comp.yaml
  - ./common_patches/g4_adc.yaml
-  - ./common_patches/g4_swap_IWDG_WWDG.yaml
+ - ./common_patches/g4_swap_IWDG_WWDG.yaml
+ - ../peripherals/iwdg/iwdg_with_WINR.yaml
+ 

--- a/devices/stm32g471.yaml
+++ b/devices/stm32g471.yaml
@@ -9,4 +9,4 @@ _include:
  - ../peripherals/adc/adc_v3_common_g4.yaml
  - ./common_patches/g4_comp.yaml
  - ./common_patches/g4_adc.yaml
- 
+  - ./common_patches/g4_swap_IWDG_WWDG.yaml

--- a/devices/stm32g471.yaml
+++ b/devices/stm32g471.yaml
@@ -11,4 +11,5 @@ _include:
  - ./common_patches/g4_adc.yaml
  - ./common_patches/g4_swap_IWDG_WWDG.yaml
  - ../peripherals/iwdg/iwdg_with_WINR.yaml
+ - ../peripherals/wwdg/g4_wwdg.yaml
  

--- a/devices/stm32g473.yaml
+++ b/devices/stm32g473.yaml
@@ -9,4 +9,6 @@ _include:
  - ../peripherals/adc/adc_v3_common_g4.yaml
  - ./common_patches/g4_comp.yaml
  - ./common_patches/g4_adc.yaml
+ - ./common_patches/g4_swap_IWDG_WWDG.yaml
+ - ../peripherals/iwdg/iwdg_with_WINR.yaml
  

--- a/devices/stm32g473.yaml
+++ b/devices/stm32g473.yaml
@@ -11,4 +11,5 @@ _include:
  - ./common_patches/g4_adc.yaml
  - ./common_patches/g4_swap_IWDG_WWDG.yaml
  - ../peripherals/iwdg/iwdg_with_WINR.yaml
+ - ../peripherals/wwdg/g4_wwdg.yaml
  

--- a/devices/stm32g474.yaml
+++ b/devices/stm32g474.yaml
@@ -9,4 +9,6 @@ _include:
  - ../peripherals/adc/adc_v3_common_g4.yaml
  - ./common_patches/g4_comp.yaml
  - ./common_patches/g4_adc.yaml
-  - ./common_patches/g4_swap_IWDG_WWDG.yaml
+ - ./common_patches/g4_swap_IWDG_WWDG.yaml
+ - ../peripherals/iwdg/iwdg_with_WINR.yaml
+ 

--- a/devices/stm32g474.yaml
+++ b/devices/stm32g474.yaml
@@ -9,4 +9,4 @@ _include:
  - ../peripherals/adc/adc_v3_common_g4.yaml
  - ./common_patches/g4_comp.yaml
  - ./common_patches/g4_adc.yaml
- 
+  - ./common_patches/g4_swap_IWDG_WWDG.yaml

--- a/devices/stm32g474.yaml
+++ b/devices/stm32g474.yaml
@@ -11,4 +11,5 @@ _include:
  - ./common_patches/g4_adc.yaml
  - ./common_patches/g4_swap_IWDG_WWDG.yaml
  - ../peripherals/iwdg/iwdg_with_WINR.yaml
+ - ../peripherals/wwdg/g4_wwdg.yaml
  

--- a/devices/stm32g483.yaml
+++ b/devices/stm32g483.yaml
@@ -9,4 +9,6 @@ _include:
  - ../peripherals/adc/adc_v3_common_g4.yaml
  - ./common_patches/g4_comp.yaml
  - ./common_patches/g4_adc.yaml
-  - ./common_patches/g4_swap_IWDG_WWDG.yaml
+ - ./common_patches/g4_swap_IWDG_WWDG.yaml
+ - ../peripherals/iwdg/iwdg_with_WINR.yaml
+ 

--- a/devices/stm32g483.yaml
+++ b/devices/stm32g483.yaml
@@ -9,4 +9,4 @@ _include:
  - ../peripherals/adc/adc_v3_common_g4.yaml
  - ./common_patches/g4_comp.yaml
  - ./common_patches/g4_adc.yaml
- 
+  - ./common_patches/g4_swap_IWDG_WWDG.yaml

--- a/devices/stm32g483.yaml
+++ b/devices/stm32g483.yaml
@@ -11,4 +11,5 @@ _include:
  - ./common_patches/g4_adc.yaml
  - ./common_patches/g4_swap_IWDG_WWDG.yaml
  - ../peripherals/iwdg/iwdg_with_WINR.yaml
+ - ../peripherals/wwdg/g4_wwdg.yaml
  

--- a/devices/stm32g484.yaml
+++ b/devices/stm32g484.yaml
@@ -9,4 +9,6 @@ _include:
  - ../peripherals/adc/adc_v3_common_g4.yaml
  - ./common_patches/g4_comp.yaml
  - ./common_patches/g4_adc.yaml
-  - ./common_patches/g4_swap_IWDG_WWDG.yaml
+ - ./common_patches/g4_swap_IWDG_WWDG.yaml
+ - ../peripherals/iwdg/iwdg_with_WINR.yaml
+ 

--- a/devices/stm32g484.yaml
+++ b/devices/stm32g484.yaml
@@ -9,4 +9,4 @@ _include:
  - ../peripherals/adc/adc_v3_common_g4.yaml
  - ./common_patches/g4_comp.yaml
  - ./common_patches/g4_adc.yaml
- 
+  - ./common_patches/g4_swap_IWDG_WWDG.yaml

--- a/devices/stm32g484.yaml
+++ b/devices/stm32g484.yaml
@@ -11,4 +11,5 @@ _include:
  - ./common_patches/g4_adc.yaml
  - ./common_patches/g4_swap_IWDG_WWDG.yaml
  - ../peripherals/iwdg/iwdg_with_WINR.yaml
+ - ../peripherals/wwdg/g4_wwdg.yaml
  

--- a/peripherals/wwdg/g4_wwdg.yaml
+++ b/peripherals/wwdg/g4_wwdg.yaml
@@ -1,0 +1,13 @@
+# WWDG peripheral for the g4 family.
+# Extend `wwdg.yaml`.
+
+_include:
+  - ./wwdg.yaml
+
+"WWDG,WWDG?":
+  CFR:
+    WDGTB:
+        Div16: [4, "Counter clock (PCLK1 div 4096) div 16"]
+        Div32: [5, "Counter clock (PCLK1 div 4096) div 32"]
+        Div64: [6, "Counter clock (PCLK1 div 4096) div 64"]
+        Div128: [7, "Counter clock (PCLK1 div 4096) div 128"]


### PR DESCRIPTION
Closes #474.

Adds a patch, `devices/common_patches/g4_swap_IWDG_WWDG.yaml`, that restores the correct values for the IWDG and WWDG peripherals for the g4 family of devices.

Adds this newly added patch to the whole g4 family configuration files.

Further adds the IWDG peripheral configuration file to the whole g4 family.