### PR TITLE
Add basic patches for FDCAN

### DIFF
--- a/devices/common_patches/fdcan/fdcan_common.yaml
+++ b/devices/common_patches/fdcan/fdcan_common.yaml
@@ -1,0 +1,24 @@
+# Patches for the Flexible Data Rate CAN (FDCAN) on at least H7, G4
+
+"FDCAN,FDCAN?":
+  _modify:
+    "DBTP,TDCR,TSCV,TOCV,IR,IE,ILS,NDAT1,NDAT2":
+      access: read-write
+    CAN_TTGTP:
+      name: TTGTP
+  TEST:
+    _modify:
+      "TX,LBCK":
+        access: read-write
+  RWD:
+    _modify:
+      "WDC":
+        access: read-write
+  NBTP:
+    _modify:
+      TSEG2:
+        name: NTSEG2
+  ECR:
+    _modify:
+      TREC:
+        name: REC

--- a/devices/common_patches/fdcan/fdcan_g4.yaml
+++ b/devices/common_patches/fdcan/fdcan_g4.yaml
@@ -1,0 +1,303 @@
+# Patches for the Flexible Data Rate CAN (FDCAN) on G4
+
+_include:
+  - ./fdcan_common.yaml
+
+"FDCAN,FDCAN?":
+  RXGFC:
+    _add:
+      LSE:
+        description: List size extended
+        bitOffset: 24
+        bitWidth: 4
+      LSS:
+        description: List size standard
+        bitOffset: 16
+        bitWidth: 5
+      F0OM:
+        description: FIFO 0 operation mode
+        bitOffset: 9
+        bitWidth: 1
+      F1OM:
+        description: FIFO 1 operation mode
+        bitOffset: 8
+        bitWidth: 1
+
+  # Interrupt registers are a disaster, start over
+  IR:
+    _delete:
+      - ?*
+    _add:
+      RF0N:
+        description: Rx FIFO 0 new message
+        bitOffset: 0
+        bitWidth: 1
+      RF0F:
+        description: Rx FIFO 0 full
+        bitOffset: 1
+        bitWidth: 1
+      RF0L:
+        description: Rx FIFO 0 message lost
+        bitOffset: 2
+        bitWidth: 1
+      RF1N:
+        description: Rx FIFO 1 new message
+        bitOffset: 3
+        bitWidth: 1
+      RF1F:
+        description: Rx FIFO 1 full
+        bitOffset: 4
+        bitWidth: 1
+      RF1L:
+        description: Rx FIFO 1 message lost
+        bitOffset: 5
+        bitWidth: 1
+      HPM:
+        description: High-priority message
+        bitOffset: 6
+        bitWidth: 1
+      TC:
+        description: Transmission completed
+        bitOffset: 7
+        bitWidth: 1
+      TCF:
+        description: Transmission cancellation finished
+        bitOffset: 8
+        bitWidth: 1
+      TFE:
+        description: Tx FIFO empty
+        bitOffset: 9
+        bitWidth: 1
+      TEFN:
+        description: Tx even FIFO new entry
+        bitOffset: 10
+        bitWidth: 1
+      TEFF:
+        description: Tx event FIFO full
+        bitOffset: 11
+        bitWidth: 1
+      TEFL:
+        description: Tx event FIFO element lost
+        bitOffset: 12
+        bitWidth: 1
+      TSW:
+        description: Timestamp wraparound
+        bitOffset: 13
+        bitWidth: 1
+      MRAF:
+        description: Message RAM access failure
+        bitOffset: 14
+        bitWidth: 1
+      TOO:
+        description: Timeout occurred
+        bitOffset: 15
+        bitWidth: 1
+      ELO:
+        description: Error logging overflow
+        bitOffset: 16
+        bitWidth: 1
+      EP:
+        description: Error passive
+        bitOffset: 17
+        bitWidth: 1
+      EW:
+        description: Warning status
+        bitOffset: 18
+        bitWidth: 1
+      BO:
+        description: Bus_off status
+        bitOffset: 19
+        bitWidth: 1
+      WDI:
+        description: Watchdog interrupt
+        bitOffset: 20
+        bitWidth: 1
+      PEA:
+        description: Protocol error in arbitration phase
+        bitOffset: 21
+        bitWidth: 1
+      PED:
+        description: Protocol error in data phase
+        bitOffset: 22
+        bitWidth: 1
+      ARA:
+        description: Access to reserved address
+        bitOffset: 23
+        bitWidth: 1
+  IE:
+    _delete:
+      - ?*
+    _add:
+      RF0NE:
+        description: Rx FIFO 0 new message enable
+        bitOffset: 0
+        bitWidth: 1
+      RF0FE:
+        description: Rx FIFO 0 full enable
+        bitOffset: 1
+        bitWidth: 1
+      RF0LE:
+        description: Rx FIFO 0 message lost enable
+        bitOffset: 2
+        bitWidth: 1
+      RF1NE:
+        description: Rx FIFO 1 new message enable
+        bitOffset: 3
+        bitWidth: 1
+      RF1FE:
+        description: Rx FIFO 1 full enable
+        bitOffset: 4
+        bitWidth: 1
+      RF1LE:
+        description: Rx FIFO 1 message lost enable
+        bitOffset: 5
+        bitWidth: 1
+      HPME:
+        description: High-priority message enable
+        bitOffset: 6
+        bitWidth: 1
+      TCE:
+        description: Transmission completed enable
+        bitOffset: 7
+        bitWidth: 1
+      TCFE:
+        description: Transmission cancellation finished enable
+        bitOffset: 8
+        bitWidth: 1
+      TFEE:
+        description: Tx FIFO empty enable
+        bitOffset: 9
+        bitWidth: 1
+      TEFNE:
+        description: Tx even FIFO new entry enable
+        bitOffset: 10
+        bitWidth: 1
+      TEFFE:
+        description: Tx event FIFO full enable
+        bitOffset: 11
+        bitWidth: 1
+      TEFLE:
+        description: Tx event FIFO element lost enable
+        bitOffset: 12
+        bitWidth: 1
+      TSWE:
+        description: Timestamp wraparound enable
+        bitOffset: 13
+        bitWidth: 1
+      MRAFE:
+        description: Message RAM access failure enable
+        bitOffset: 14
+        bitWidth: 1
+      TOOE:
+        description: Timeout occurred enable
+        bitOffset: 15
+        bitWidth: 1
+      ELOE:
+        description: Error logging overflow enable
+        bitOffset: 16
+        bitWidth: 1
+      EPE:
+        description: Error passive enable
+        bitOffset: 17
+        bitWidth: 1
+      EWE:
+        description: Warning status enable
+        bitOffset: 18
+        bitWidth: 1
+      BOE:
+        description: Bus_off status enable
+        bitOffset: 19
+        bitWidth: 1
+      WDIE:
+        description: Watchdog interrupt enable
+        bitOffset: 20
+        bitWidth: 1
+      PEAE:
+        description: Protocol error in arbitration phase enable
+        bitOffset: 21
+        bitWidth: 1
+      PEDE:
+        description: Protocol error in data phase enable
+        bitOffset: 22
+        bitWidth: 1
+      ARAE:
+        description: Access to reserved address enable
+        bitOffset: 23
+        bitWidth: 1
+  ILS:
+    _delete:
+      - ?*
+    _add:
+      RXFIFO0:
+        description: RX FIFO bit grouping the following interruption
+        bitOffset: 0
+        bitWidth: 1
+      RXFIFO1:
+        description: RX FIFO bit grouping the following interruption
+        bitOffset: 1
+        bitWidth: 1
+      SMSG:
+        description: Status message bit grouping the following interruption
+        bitOffset: 2
+        bitWidth: 1
+      TFERR:
+        description: TX FIFO error grouping the following interruption
+        bitOffset: 3
+        bitWidth: 1
+      MISC:
+        description: Interrupt regrouping the following interruption
+        bitOffset: 4
+        bitWidth: 1
+      BERR:
+        description: Bit and line error grouping the following interruption
+        bitOffset: 5
+        bitWidth: 1
+      PERR:
+        description: Protocol error grouping the following interruption
+        bitOffset: 6
+        bitWidth: 1
+
+  TXFQS:
+    _modify:
+      TFQPI:
+        bitWidth: 2
+      TFGI:
+        bitWidth: 2
+      TFFL:
+        bitWidth: 3
+  TXEFS:
+    _modify:
+      EFPI:
+        bitWidth: 2
+      EFGI:
+        bitWidth: 2
+      EFFL:
+        bitWidth: 3
+  TXBRP:
+    _modify:
+      TRP:
+        bitWidth: 3
+  TXBAR:
+    _modify:
+      AR:
+        bitWidth: 3
+  TXBCR:
+    _modify:
+      CR:
+        bitWidth: 3
+  TXBTO:
+    _modify:
+      TO:
+        bitWidth: 3
+  TXBCF:
+    _modify:
+      CF:
+        bitWidth: 3
+  TXBTIE:
+    _modify:
+      TIE:
+        bitWidth: 3
+  TXBCIE:
+    _modify:
+      CFIE:
+        bitWidth: 3

--- a/devices/common_patches/fdcan/fdcan_h7.yaml
+++ b/devices/common_patches/fdcan/fdcan_h7.yaml
@@ -1,0 +1,45 @@
+# Patches for the Flexible Data Rate CAN (FDCAN) on H7
+
+_include:
+  - ./fdcan_common.yaml
+
+"FDCAN,FDCAN?":
+  RXF0C:
+    _modify:
+      "F0S,F0WM":
+        bitWidth: 7
+    _add:
+      F0OM:
+        description: FIFO 0 operation mode
+        bitOffset: 31
+        bitWidth: 1
+  RXF0S:
+    _modify:
+      F0G:
+        name: F0GI
+      F0P:
+        name: F0PI
+  RXF0A:
+    _modify:
+      FA01:
+        name: F0AI
+  RXF1C:
+    _add:
+      F1OM:
+        description: FIFO 1 operation mode
+        bitOffset: 31
+        bitWidth: 1
+  TXEFS:
+    _add:
+      EFPI:
+        description: Event FIFO put index
+        bitOffset: 16
+        bitWidth: 5
+  TTOST:
+    _modify:
+      GTP:
+        name: QGTP
+  TTCPT:
+    _modify:
+      CT:
+        name: CCV

--- a/devices/common_patches/h7_common_dualcore.yaml
+++ b/devices/common_patches/h7_common_dualcore.yaml
@@ -716,7 +716,7 @@ SAI4:
   _strip:
     - OTG_HS_
 
-FDCAN1:
+"FDCAN?":
   _strip:
     - FDCAN_
 

--- a/devices/common_patches/h7_common_highmemory.yaml
+++ b/devices/common_patches/h7_common_highmemory.yaml
@@ -816,6 +816,10 @@ VREFBUF:
   _strip:
     - OTG_HS_
 
+"FDCAN?":
+  _strip:
+    - FDCAN_
+
 WWDG:
   _strip:
     - WWDG_

--- a/devices/common_patches/h7_common_singlecore.yaml
+++ b/devices/common_patches/h7_common_singlecore.yaml
@@ -523,7 +523,7 @@ AXI:
   _strip:
     - OTG_HS_
 
-FDCAN1:
+"FDCAN?":
   _strip:
     - FDCAN_
 

--- a/devices/stm32g431.yaml
+++ b/devices/stm32g431.yaml
@@ -4,6 +4,7 @@ _include:
  - ./common_patches/g4_rcc.yaml
  - ./common_patches/g4_exti.yaml
  - ./common_patches/g4_adc_common.yaml
+ - ./common_patches/fdcan/fdcan_g4.yaml
  - ../peripherals/exti/exti.yaml
  - ../peripherals/adc/adc_v3_g4.yaml
  - ../peripherals/adc/adc_v3_common_g4.yaml

--- a/devices/stm32g441.yaml
+++ b/devices/stm32g441.yaml
@@ -4,6 +4,7 @@ _include:
  - ./common_patches/g4_rcc.yaml
  - ./common_patches/g4_exti.yaml
  - ./common_patches/g4_adc_common.yaml
+ - ./common_patches/fdcan/fdcan_g4.yaml
  - ../peripherals/exti/exti.yaml
  - ../peripherals/adc/adc_v3_g4.yaml
  - ../peripherals/adc/adc_v3_common_g4.yaml

--- a/devices/stm32g471.yaml
+++ b/devices/stm32g471.yaml
@@ -4,6 +4,7 @@ _include:
  - ./common_patches/g4_rcc.yaml
  - ./common_patches/g4_exti.yaml
  - ./common_patches/g4_adc_common.yaml
+ - ./common_patches/fdcan/fdcan_g4.yaml
  - ../peripherals/exti/exti.yaml
  - ../peripherals/adc/adc_v3_g4.yaml
  - ../peripherals/adc/adc_v3_common_g4.yaml

--- a/devices/stm32g473.yaml
+++ b/devices/stm32g473.yaml
@@ -4,6 +4,7 @@ _include:
  - ./common_patches/g4_rcc.yaml
  - ./common_patches/g4_exti.yaml
  - ./common_patches/g4_adc_common.yaml
+ - ./common_patches/fdcan/fdcan_g4.yaml
  - ../peripherals/exti/exti.yaml
  - ../peripherals/adc/adc_v3_g4.yaml
  - ../peripherals/adc/adc_v3_common_g4.yaml

--- a/devices/stm32g474.yaml
+++ b/devices/stm32g474.yaml
@@ -4,6 +4,7 @@ _include:
  - ./common_patches/g4_rcc.yaml
  - ./common_patches/g4_exti.yaml
  - ./common_patches/g4_adc_common.yaml
+ - ./common_patches/fdcan/fdcan_g4.yaml
  - ../peripherals/exti/exti.yaml
  - ../peripherals/adc/adc_v3_g4.yaml
  - ../peripherals/adc/adc_v3_common_g4.yaml

--- a/devices/stm32g483.yaml
+++ b/devices/stm32g483.yaml
@@ -4,6 +4,7 @@ _include:
  - ./common_patches/g4_rcc.yaml
  - ./common_patches/g4_exti.yaml
  - ./common_patches/g4_adc_common.yaml
+ - ./common_patches/fdcan/fdcan_g4.yaml
  - ../peripherals/exti/exti.yaml
  - ../peripherals/adc/adc_v3_g4.yaml
  - ../peripherals/adc/adc_v3_common_g4.yaml

--- a/devices/stm32g484.yaml
+++ b/devices/stm32g484.yaml
@@ -4,6 +4,7 @@ _include:
  - ./common_patches/g4_rcc.yaml
  - ./common_patches/g4_exti.yaml
  - ./common_patches/g4_adc_common.yaml
+ - ./common_patches/fdcan/fdcan_g4.yaml
  - ../peripherals/exti/exti.yaml
  - ../peripherals/adc/adc_v3_g4.yaml
  - ../peripherals/adc/adc_v3_common_g4.yaml

--- a/devices/stm32h743.yaml
+++ b/devices/stm32h743.yaml
@@ -6,6 +6,7 @@ _include:
  - common_patches/dma/bdma.yaml
  - common_patches/dma/dma_v3.yaml
  - common_patches/dma/mdma.yaml
+ - common_patches/fdcan/fdcan_h7.yaml
  - common_patches/fsmc/fsmc_sdram_cluster.yaml
  - common_patches/h7_rcc_src_sel.yaml
  - common_patches/h7_ethernet_desc.yaml

--- a/devices/stm32h743v.yaml
+++ b/devices/stm32h743v.yaml
@@ -6,6 +6,7 @@ _include:
  - common_patches/dma/bdma.yaml
  - common_patches/dma/dma_v3.yaml
  - common_patches/dma/mdma.yaml
+ - common_patches/fdcan/fdcan_h7.yaml
  - common_patches/fsmc/fsmc_sdram_cluster.yaml
  - common_patches/h7_rcc_src_sel.yaml
  - common_patches/h7_ethernet_desc.yaml

--- a/devices/stm32h747cm4.yaml
+++ b/devices/stm32h747cm4.yaml
@@ -20,6 +20,7 @@ _include:
  - common_patches/dma/bdma.yaml
  - common_patches/dma/dma_v3.yaml
  - common_patches/dma/mdma.yaml
+ - common_patches/fdcan/fdcan_h7.yaml
  - common_patches/fsmc/fsmc_sdram_cluster.yaml
  - common_patches/h7_rcc_src_sel.yaml
  - common_patches/h7_ethernet_combined_desc.yaml

--- a/devices/stm32h747cm7.yaml
+++ b/devices/stm32h747cm7.yaml
@@ -19,6 +19,7 @@ _include:
  - common_patches/dma/bdma.yaml
  - common_patches/dma/dma_v3.yaml
  - common_patches/dma/mdma.yaml
+ - common_patches/fdcan/fdcan_h7.yaml
  - common_patches/fsmc/fsmc_sdram_cluster.yaml
  - common_patches/h7_rcc_src_sel.yaml
  - common_patches/h7_ethernet_combined_desc.yaml

--- a/devices/stm32h753.yaml
+++ b/devices/stm32h753.yaml
@@ -16,6 +16,7 @@ _include:
  - common_patches/dma/bdma.yaml
  - common_patches/dma/dma_v3.yaml
  - common_patches/dma/mdma.yaml
+ - common_patches/fdcan/fdcan_h7.yaml
  - common_patches/fsmc/fsmc_sdram_cluster.yaml
  - common_patches/h7_rcc_src_sel.yaml
  - common_patches/h7_ethernet_desc.yaml

--- a/devices/stm32h753v.yaml
+++ b/devices/stm32h753v.yaml
@@ -16,6 +16,7 @@ _include:
  - common_patches/dma/bdma.yaml
  - common_patches/dma/dma_v3.yaml
  - common_patches/dma/mdma.yaml
+ - common_patches/fdcan/fdcan_h7.yaml
  - common_patches/fsmc/fsmc_sdram_cluster.yaml
  - common_patches/h7_rcc_src_sel.yaml
  - common_patches/h7_ethernet_desc.yaml

--- a/devices/stm32h7b3.yaml
+++ b/devices/stm32h7b3.yaml
@@ -24,6 +24,7 @@ _include:
  - common_patches/dma/bdma_v2.yaml
  - common_patches/dma/dma_v3.yaml
  - common_patches/dma/mdma.yaml
+ - common_patches/fdcan/fdcan_h7.yaml
  - common_patches/fsmc/fsmc_sdram_cluster.yaml
  - common_patches/h7_exti_singlecore.yaml
  - common_patches/h7_dbgmcu.yaml


### PR DESCRIPTION
FDCAN appears in the H7, G4, L5 and MP1 families. The peripheral varies between the families, with the G4/L5 versions being somewhat simpler. I don't see any variation within families, but haven't exhaustively checked for this.

On the H7, the FDCAN2 doesn't support TTCAN. However FDCAN2 is `derivedFrom="FDCAN1"` in the original ST SVDs (and remains so). The RM isn't very clear about which registers are missing from FDCAN2, but we could to remove the `TT*` registers from FDCAN2 if this is important.

G4 devices have either 1 or 3 FDCANs.

Checked against:
H7 RM0399
G4 RM0440