### PR TITLE
Rename SP3EN to SPI3EN for G4 Family

### DIFF
--- a/devices/common_patches/g4_rcc.yaml
+++ b/devices/common_patches/g4_rcc.yaml
@@ -129,6 +129,9 @@ RCC:
       I2C3:
         name: I2C3EN
         description: I2C3 clock enable
+      SP3EN:
+        name: SPI3EN
+        description: SPI3 clock enable
 
   APB1ENR2:
     _modify:


### PR DESCRIPTION
Closes #480.

Modifies SP3EN to SPI3EN for APB1ENR1 register for the G4 Family. 