### PR TITLE
Add CORDIC math function accelerator support to stm32g4

### DIFF
--- a/devices/common_patches/g4_cordic.yaml
+++ b/devices/common_patches/g4_cordic.yaml
@@ -1,0 +1,12 @@
+CORDIC:
+  CSR:
+    _modify:
+      PRECISION: 
+        description: Precision (number of iterations/cycles) required
+      SCALE:
+        description: Scaling factor (2^-n for arguments, 2^n for results)
+  _modify:
+    WDATA:
+      description: "CORDIC argument register"
+    RDATA:
+      description: "CORDIC result register"

--- a/devices/stm32g431.yaml
+++ b/devices/stm32g431.yaml
@@ -12,3 +12,5 @@ _include:
  - ./common_patches/g4_swap_IWDG_WWDG.yaml
  - ../peripherals/iwdg/iwdg_with_WINR.yaml
  - ../peripherals/wwdg/g4_wwdg.yaml
+ - ./common_patches/g4_cordic.yaml
+ - ../peripherals/cordic/cordic_g4.yaml

--- a/devices/stm32g441.yaml
+++ b/devices/stm32g441.yaml
@@ -12,4 +12,6 @@ _include:
  - ./common_patches/g4_swap_IWDG_WWDG.yaml
  - ../peripherals/iwdg/iwdg_with_WINR.yaml
  - ../peripherals/wwdg/g4_wwdg.yaml
+ - ./common_patches/g4_cordic.yaml
+ - ../peripherals/cordic/cordic_g4.yaml
  

--- a/devices/stm32g471.yaml
+++ b/devices/stm32g471.yaml
@@ -12,4 +12,6 @@ _include:
  - ./common_patches/g4_swap_IWDG_WWDG.yaml
  - ../peripherals/iwdg/iwdg_with_WINR.yaml
  - ../peripherals/wwdg/g4_wwdg.yaml
- 
+ - ./common_patches/g4_cordic.yaml
+ - ../peripherals/cordic/cordic_g4.yaml
+

--- a/devices/stm32g473.yaml
+++ b/devices/stm32g473.yaml
@@ -12,4 +12,5 @@ _include:
  - ./common_patches/g4_swap_IWDG_WWDG.yaml
  - ../peripherals/iwdg/iwdg_with_WINR.yaml
  - ../peripherals/wwdg/g4_wwdg.yaml
- 
+ - ./common_patches/g4_cordic.yaml
+ - ../peripherals/cordic/cordic_g4.yaml 

--- a/devices/stm32g474.yaml
+++ b/devices/stm32g474.yaml
@@ -12,4 +12,6 @@ _include:
  - ./common_patches/g4_swap_IWDG_WWDG.yaml
  - ../peripherals/iwdg/iwdg_with_WINR.yaml
  - ../peripherals/wwdg/g4_wwdg.yaml
+ - ./common_patches/g4_cordic.yaml
+ - ../peripherals/cordic/cordic_g4.yaml
  

--- a/devices/stm32g483.yaml
+++ b/devices/stm32g483.yaml
@@ -12,4 +12,5 @@ _include:
  - ./common_patches/g4_swap_IWDG_WWDG.yaml
  - ../peripherals/iwdg/iwdg_with_WINR.yaml
  - ../peripherals/wwdg/g4_wwdg.yaml
- 
+ - ./common_patches/g4_cordic.yaml
+ - ../peripherals/cordic/cordic_g4.yaml 

--- a/devices/stm32g484.yaml
+++ b/devices/stm32g484.yaml
@@ -12,4 +12,5 @@ _include:
  - ./common_patches/g4_swap_IWDG_WWDG.yaml
  - ../peripherals/iwdg/iwdg_with_WINR.yaml
  - ../peripherals/wwdg/g4_wwdg.yaml
- 
+ - ./common_patches/g4_cordic.yaml
+ - ../peripherals/cordic/cordic_g4.yaml

--- a/peripherals/cordic/cordic_g4.yaml
+++ b/peripherals/cordic/cordic_g4.yaml
@@ -7,14 +7,12 @@ CORDIC:
       _read:
         NotReady: [0, "Results from computation are not read"]
         Ready: [1, "Results are ready, this flag will be automatically cleared once value is read"]
-      _write:
-        Clear: [0, "Clear the computation results"]
     ARGSIZE:
-      Size32: [0, "Use 32 bit input values"]
-      Size16: [1, "Use 16 bit input values"]
+      Bits32: [0, "Use 32 bit input values"]
+      Bits16: [1, "Use 16 bit input values"]
     RESSIZE:
-      Size32: [0, "Use 32 bit output values"]
-      Size16: [1, "Use 16 bit output values"]
+      Bits32: [0, "Use 32 bit output values"]
+      Bits16: [1, "Use 16 bit output values"]
     NARGS:
       Num1: [0, "Only single argument write is needed for next calculation"]
       Num2: [1, "Two argument writes need to be performed for next calculation"]
@@ -31,7 +29,7 @@ CORDIC:
       Disabled: [0, "Disable interrupt request generation"]
       Enabled: [1, "Enable intterrupt request generation"]
     PRECISION: [1, 15]
-    SCALE: [0, 3]
+    SCALE: [0, 7]
     FUNC:
       Cosine: [0, "Cosine funciton"]
       Sine: [1, "Sine function"]

--- a/peripherals/cordic/cordic_g4.yaml
+++ b/peripherals/cordic/cordic_g4.yaml
@@ -1,0 +1,50 @@
+# CORDIC coprocessor provides hardware acceleration
+# for computing math funcitons
+
+CORDIC:
+  CSR:
+    RRDY:
+      _read:
+        NotReady: [0, "Results from computation are not read"]
+        Ready: [1, "Results are ready, this flag will be automatically cleared once value is read"]
+      _write:
+        Clear: [0, "Clear the computation results"]
+    ARGSIZE:
+      Size32: [0, "Use 32 bit input values"]
+      Size16: [1, "Use 16 bit input values"]
+    RESSIZE:
+      Size32: [0, "Use 32 bit output values"]
+      Size16: [1, "Use 16 bit output values"]
+    NARGS:
+      Num1: [0, "Only single argument write is needed for next calculation"]
+      Num2: [1, "Two argument writes need to be performed for next calculation"]
+    NRES:
+      Num1: [0, "Only single result value will be returned. After a single read RRDY will be automatically cleared"]
+      Num2: [1, "Two return reads need to be performed. After two reads RRDY will be automatically cleared"]
+    DMAWEN:
+      Disabled: [0, "No DMA channel writes are generated"]
+      Enabled: [1, "Write requests are generated on the DMA channel when no operation is pending"]
+    DMAREN:
+      Disabled: [0, "No DMA channel reads are generated"]
+      Enabled: [1, "Read requests are generated on the DMA channel when RRDY flag is set"]
+    IEN:
+      Disabled: [0, "Disable interrupt request generation"]
+      Enabled: [1, "Enable intterrupt request generation"]
+    PRECISION: [1, 15]
+    SCALE: [0, 3]
+    FUNC:
+      Cosine: [0, "Cosine funciton"]
+      Sine: [1, "Sine function"]
+      Phase: [2, "Phase function"]
+      Modulus: [3, "Modulus function"]
+      Arctangent: [4, "Arctangent function"]
+      HyperbolicCosine: [5, "Hyperbolic Cosine function"]
+      HyperbolicSine: [6, "Hyperbolic Sine function"]
+      Arctanh: [7, "Arctanh function"]
+      NaturalLogarithm: [8, "Natural Logarithm function"]
+      SquareRoot: [9, "Square Root function"]
+  WDATA:
+    ARG: [0, 0xFFFFFFFF]
+
+  RDATA:
+    RES: [0, 0xFFFFFFFF]


### PR DESCRIPTION
Add CORDIC math accellerator enum definitions to stm32g4 family    
    - modified description on mislabeled registiers
    - added clarifying descriptions for two CORDICs CSR fields
