### PR TITLE
Add OPAMP enums for STM32G4

### DIFF
--- a/devices/stm32g431.yaml
+++ b/devices/stm32g431.yaml
@@ -15,3 +15,4 @@ _include:
  - ../peripherals/cordic/cordic_g4.yaml
  - ./common_patches/sai/sai_v1.yaml
  - ./common_patches/rtc/rtc_cr.yaml
+ - ../peripherals/opamp/opamp_g4_common.yaml

--- a/devices/stm32g441.yaml
+++ b/devices/stm32g441.yaml
@@ -15,3 +15,4 @@ _include:
  - ../peripherals/cordic/cordic_g4.yaml
  - ./common_patches/sai/sai_v1.yaml
  - ./common_patches/rtc/rtc_cr.yaml
+ - ../peripherals/opamp/opamp_g4_common.yaml 

--- a/devices/stm32g471.yaml
+++ b/devices/stm32g471.yaml
@@ -15,3 +15,4 @@ _include:
  - ../peripherals/cordic/cordic_g4.yaml
  - ./common_patches/sai/sai_v1.yaml
  - ./common_patches/rtc/rtc_cr.yaml
+ - ../peripherals/opamp/opamp_g4_common.yaml 

--- a/devices/stm32g473.yaml
+++ b/devices/stm32g473.yaml
@@ -15,3 +15,6 @@ _include:
  - ../peripherals/cordic/cordic_g4.yaml 
  - ./common_patches/sai/sai_v1.yaml
  - ./common_patches/rtc/rtc_cr.yaml
+ - ../peripherals/opamp/opamp_g4_common.yaml 
+ - ../peripherals/opamp/opamp_g4_opamp4_5.yaml 
+ - ../peripherals/opamp/opamp_g4_opamp6.yaml 

--- a/devices/stm32g474.yaml
+++ b/devices/stm32g474.yaml
@@ -15,3 +15,6 @@ _include:
  - ../peripherals/cordic/cordic_g4.yaml
  - ./common_patches/sai/sai_v1.yaml
  - ./common_patches/rtc/rtc_cr.yaml
+ - ../peripherals/opamp/opamp_g4_common.yaml 
+ - ../peripherals/opamp/opamp_g4_opamp4_5.yaml 
+ - ../peripherals/opamp/opamp_g4_opamp6.yaml 

--- a/devices/stm32g483.yaml
+++ b/devices/stm32g483.yaml
@@ -15,3 +15,7 @@ _include:
  - ../peripherals/cordic/cordic_g4.yaml
  - ./common_patches/sai/sai_v1.yaml
  - ./common_patches/rtc/rtc_cr.yaml
+ - ../peripherals/cordic/cordic_g4.yaml 
+ - ../peripherals/opamp/opamp_g4_common.yaml 
+ - ../peripherals/opamp/opamp_g4_opamp4_5.yaml 
+ - ../peripherals/opamp/opamp_g4_opamp6.yaml 

--- a/devices/stm32g484.yaml
+++ b/devices/stm32g484.yaml
@@ -15,3 +15,6 @@ _include:
  - ../peripherals/cordic/cordic_g4.yaml
  - ./common_patches/sai/sai_v1.yaml
  - ./common_patches/rtc/rtc_cr.yaml
+ - ../peripherals/opamp/opamp_g4_common.yaml 
+ - ../peripherals/opamp/opamp_g4_opamp4_5.yaml 
+ - ../peripherals/opamp/opamp_g4_opamp6.yaml

--- a/devices/stm32g491.yaml
+++ b/devices/stm32g491.yaml
@@ -1,5 +1,16 @@
 _svd: ../svd/stm32g491.svd
 
+OPAMP:
+  _derive:
+    OPAMP6_CSR:
+      _from: OPAMP1_CSR
+      addressOffset: "0x14"
+      description: OPAMP6 control/status register
+    OPAMP6_TCMR:
+      _from: OPAMP1_TCMR
+      addressOffset: "0x2C"
+      description: OPAMP6 control/status register
+
 _include:
  - ./common_patches/g4_rcc.yaml
  - ./common_patches/g4_exti.yaml
@@ -14,3 +25,5 @@ _include:
  - ./common_patches/g4_cordic.yaml
  - ../peripherals/cordic/cordic_g4.yaml
  - ./common_patches/rtc/rtc_cr.yaml
+ - ../peripherals/opamp/opamp_g4_common.yaml 
+ - ../peripherals/opamp/opamp_g4_opamp6.yaml 

--- a/devices/stm32g4a1.yaml
+++ b/devices/stm32g4a1.yaml
@@ -1,5 +1,16 @@
 _svd: ../svd/stm32g4a1.svd
 
+OPAMP:
+  _derive:
+    OPAMP6_CSR:
+      _from: OPAMP1_CSR
+      addressOffset: "0x14"
+      description: OPAMP6 control/status register
+    OPAMP6_TCMR:
+      _from: OPAMP1_TCMR
+      addressOffset: "0x2C"
+      description: OPAMP6 control/status register
+
 _include:
  - ./common_patches/g4_rcc.yaml
  - ./common_patches/g4_exti.yaml
@@ -14,3 +25,5 @@ _include:
  - ./common_patches/g4_cordic.yaml
  - ../peripherals/cordic/cordic_g4.yaml
  - ./common_patches/rtc/rtc_cr.yaml
+ - ../peripherals/opamp/opamp_g4_common.yaml
+ - ../peripherals/opamp/opamp_g4_opamp6.yaml

--- a/peripherals/opamp/opamp_g4_common.yaml
+++ b/peripherals/opamp/opamp_g4_common.yaml
@@ -44,19 +44,19 @@ OPAMP:
       OutputPin: [0, "Output is connected to the output Pin"]
       ADCChannel: [1, "Output is connected internally to ADC channel"]
     OPAHSM:
-      NormalMode: [0, "OpAmp in normal mode"]
-      HighSpeedMode: [1, "OpAmp in high speed mode"]
+      Normal: [0, "OpAmp in normal mode"]
+      HighSpeed: [1, "OpAmp in high speed mode"]
     VM_SEL:
       VINM0: [0, "VINM0 connected to VINM input"]
       VINM1: [1, "VINM1 connected to VINM input"]
       PGA: [2, "Feedback resistor connected to VINM (PGA mode)"]
       Output: [3, "OpAmp output connected to VINM (Follower mode)"]
     USERTRIM:
-      FactoryTrim: [0, "Factory trim used"]
-      UserTrim: [1, "User trim used"]
+      Factory: [0, "Factory trim used"]
+      User: [1, "User trim used"]
     FORCE_VP:
-      NormalMode: [0, "Non-inverting input connected configured inputs"]
-      CalibrationVerificationMode: [1, "Non-inverting input connected to calibration reference voltage"]
+      Normal: [0, "Non-inverting input connected configured inputs"]
+      CalibrationVerification: [1, "Non-inverting input connected to calibration reference voltage"]
     OPAEN:
       Disabled: [0, "OpAmp disabled"]
       Enabled: [1, "OpAmp enabled"]
@@ -65,14 +65,14 @@ OPAMP:
       ReadWrite: [0, "TCMR is read-write"]
       ReadOnly: [1, "TCMR is read-only, can only be cleared by system reset"]
     T20CM_EN:
-      AutoSwitchDisabled: [0, "Automatic input switch triggered by TIM20 disabled"]
-      AutoSwitchEnabled: [1, "Automatic input switch triggered by TIM20 enabled"]
+      Disabled: [0, "Automatic input switch triggered by TIM20 disabled"]
+      Enabled: [1, "Automatic input switch triggered by TIM20 enabled"]
     T8CM_EN:
-      AutoSwitchDisabled: [0, "Automatic input switch triggered by TIM8 disabled"]
-      AutoSwitchEnabled: [1, "Automatic input switch triggered by TIM8 enabled"]
+      Disabled: [0, "Automatic input switch triggered by TIM8 disabled"]
+      Enabled: [1, "Automatic input switch triggered by TIM8 enabled"]
     T1CM_EN:
-      AutoSwitchDisabled: [0, "Automatic input switch triggered by TIM1 disabled"]
-      AutoSwitchEnabled: [1, "Automatic input switch triggered by TIM1 enabled"]
+      Disabled: [0, "Automatic input switch triggered by TIM1 disabled"]
+      Enabled: [1, "Automatic input switch triggered by TIM1 enabled"]
   
   OPAMP1_CSR:
     _replace_enum:

--- a/peripherals/opamp/opamp_g4_common.yaml
+++ b/peripherals/opamp/opamp_g4_common.yaml
@@ -1,0 +1,133 @@
+
+OPAMP:
+  OPAMP?_CSR:
+    LOCK:
+      ReadWrite: [0, "CSR is read-write"]
+      ReadOnly: [1, "CSR is read-only, can only be cleared by system reset"]
+    CALOUT: [0, 1]
+    TRIMOFFSETN: [0, 31] 
+    TRIMOFFSETP: [0, 31]
+    PGA_GAIN:
+      Gain2: [0, "Gain 2"]
+      Gain4: [1, "Gain 4"]
+      Gain8: [2, "Gain 8"]
+      Gain16: [3, "Gain 16"]
+      Gain32: [4, "Gain 32"]
+      Gain64: [5, "Gain 64"]
+      Gain2_InputVINM0: [8, "Gain 2, input/bias connected to VINM0 or inverting gain"]
+      Gain4_InputVINM0: [9, "Gain 4, input/bias connected to VINM0 or inverting gain"]
+      Gain8_InputVINM0: [10, "Gain 8, input/bias connected to VINM0 or inverting gain"]
+      Gain16_InputVINM0: [11, "Gain 16, input/bias connected to VINM0 or inverting gain"]
+      Gain32_InputVINM0: [12, "Gain 32, input/bias connected to VINM0 or inverting gain"]
+      Gain64_InputVINM0: [13, "Gain 64, input/bias connected to VINM0 or inverting gain"]
+      Gain2_FilteringVINM0: [16, "Gain 2, with filtering on VINM0"]
+      Gain4_FilteringVINM0: [17, "Gain 4, with filtering on VINM0"]
+      Gain8_FilteringVINM0: [18, "Gain 8, with filtering on VINM0"]
+      Gain16_FilteringVINM0: [19, "Gain 16, with filtering on VINM0"]
+      Gain32_FilteringVINM0: [20, "Gain 32, with filtering on VINM0"]
+      Gain64_FilteringVINM0: [21, "Gain 64, with filtering on VINM0"]
+      Gain2_InputVINM0FilteringVINM1: [24, "Gain 2, input/bias connected to VINM0 with filtering on VINM1 or inverting gain"]
+      Gain4_InputVINM0FilteringVINM1: [25, "Gain 4, input/bias connected to VINM0 with filtering on VINM1 or inverting gain"]
+      Gain8_InputVINM0FilteringVINM1: [26, "Gain 8, input/bias connected to VINM0 with filtering on VINM1 or inverting gain"]
+      Gain16_InputVINM0FilteringVINM1: [27, "Gain 16, input/bias connected to VINM0 with filtering on VINM1 or inverting gain"]
+      Gain32_InputVINM0FilteringVINM1: [28, "Gain 32, input/bias connected to VINM0 with filtering on VINM1 or inverting gain"]
+      Gain64_InputVINM0FilteringVINM1: [29, "Gain 64, input/bias connected to VINM0 with filtering on VINM1 or inverting gain"]   
+    CALSEL:
+      Percent3_3: [0, "0.033*VDDA applied to OPAMP inputs during calibration"]
+      Percent10: [1, "0.1*VDDA applied to OPAMP inputs during calibration"]
+      Percent50: [2, "0.5*VDDA applied to OPAMP inputs during calibration"]
+      Percent90: [3, "0.9*VDDA applied to OPAMP inputs during calibration"]
+    CALON:
+      Disabled: [0, "Calibration mode disabled"]
+      Enabled: [1, "Calibration mode enabled"]
+    OPAINTOEN:
+      OutputPin: [0, "Output is connected to the output Pin"]
+      ADCChannel: [1, "Output is connected internally to ADC channel"]
+    OPAHSM:
+      NormalMode: [0, "OpAmp in normal mode"]
+      HighSpeedMode: [1, "OpAmp in high speed mode"]
+    VM_SEL:
+      VINM0: [0, "VINM0 connected to VINM input"]
+      VINM1: [1, "VINM1 connected to VINM input"]
+      PGA: [2, "Feedback resistor connected to VINM (PGA mode)"]
+      Output: [3, "OpAmp output connected to VINM (Follower mode)"]
+    USERTRIM:
+      FactoryTrim: [0, "Factory trim used"]
+      UserTrim: [1, "User trim used"]
+    FORCE_VP:
+      NormalMode: [0, "Non-inverting input connected configured inputs"]
+      CalibrationVerificationMode: [1, "Non-inverting input connected to calibration reference voltage"]
+    OPAEN:
+      Disabled: [0, "OpAmp disabled"]
+      Enabled: [1, "OpAmp enabled"]
+  OPAMP?_TCMR:
+    LOCK:
+      ReadWrite: [0, "TCMR is read-write"]
+      ReadOnly: [1, "TCMR is read-only, can only be cleared by system reset"]
+    T20CM_EN:
+      AutoSwitchDisabled: [0, "Automatic input switch triggered by TIM20 disabled"]
+      AutoSwitchEnabled: [1, "Automatic input switch triggered by TIM20 enabled"]
+    T8CM_EN:
+      AutoSwitchDisabled: [0, "Automatic input switch triggered by TIM8 disabled"]
+      AutoSwitchEnabled: [1, "Automatic input switch triggered by TIM8 enabled"]
+    T1CM_EN:
+      AutoSwitchDisabled: [0, "Automatic input switch triggered by TIM1 disabled"]
+      AutoSwitchEnabled: [1, "Automatic input switch triggered by TIM1 enabled"]
+  
+  OPAMP1_CSR:
+    _replace_enum:
+      VM_SEL:
+        PA3: [0, "PA3 connected to VINM input"]
+        PC5: [1, "PC5 connected to VINM input"]
+    VP_SEL:
+      PA1: [0, "PA1 connected to VINP input"]
+      PA3: [1, "PA3 connected to VINP input"]
+      PA7: [2, "PA7 connected to VINP input"]
+      DAC3_CH1: [3, "DAC3_CH1 connected to VINP input"]
+  OPAMP1_TCMR:
+    VPS_SEL:
+      PA1: [0, "PA1 connected to VINP input"]
+      PA3: [1, "PA3 connected to VINP input"]
+      PA7: [2, "PA7 connected to VINP input"]
+      DAC3_CH1: [3, "VINP3 connected to VINP input"]      
+    VMS_SEL:
+      PA3: [0, "PA3 connected to VINM input"]
+      PC5: [1, "PC5 connected to VINM input"]
+  OPAMP2_CSR:
+    VM_SEL:
+      _replace_enum:
+        PA5: [0, "PA5 connected to VINM input"]
+        PC5: [1, "PC5 connected to VINM input"]
+    VP_SEL: 
+      PA7: [0, "PA7 connected to VINP input"]
+      PB14: [1, "PB14 connected to VINP input"]
+      PB0: [2, "PB0 connected to VINP input"]
+      PD1: [3, "PD1 connected to VINP input"]
+  OPAMP2_TCMR: 
+    VPS_SEL:
+      PA7: [0, "PA7 connected to VINP input"]
+      PB14: [1, "PB14 connected to VINP input"]
+      PB0: [2, "PB0 connected to VINP input"]
+      PD13: [3, "PD13 connected to VINP input"]      
+    VMS_SEL:
+      PA5: [0, "PA5 connected to VINM input"]
+      PC5: [1, "PC5 connected to VINM input"]
+  OPAMP3_CSR:
+    VM_SEL:
+      _replace_enum:
+        PB2: [0, "PB2 connected to VINM input"]
+        PB10: [1, "PB10 connected to VINM input"]
+    VP_SEL: 
+      PB0: [0, "PB0 connected to VINP input"]
+      PB13: [1, "PB13 connected to VINP input"]
+      PA1: [2, "PA1 connected to VINP input"]
+      DAC3_CH2: [3, "DAC3_CH2 connected to VINP input"]
+  OPAMP3_TCMR:
+    VPS_SEL:
+      PB0: [0, "PB0 connected to VINP input"]
+      PB13: [1, "PB13 connected to VINP input"]
+      PA1: [2, "PA1 connected to VINP input"]
+      DAC3_CH2: [3, "DAC3_CH2 connected to VINP input"]      
+    VMS_SEL:
+      PB2: [0, "PB2 connected to VINM input"]
+      PB10: [1, "PB10 connected to VINM input"]

--- a/peripherals/opamp/opamp_g4_common.yaml
+++ b/peripherals/opamp/opamp_g4_common.yaml
@@ -75,59 +75,38 @@ OPAMP:
       Enabled: [1, "Automatic input switch triggered by TIM1 enabled"]
   
   OPAMP1_CSR:
-    _replace_enum:
-      VM_SEL:
-        PA3: [0, "PA3 connected to VINM input"]
-        PC5: [1, "PC5 connected to VINM input"]
     VP_SEL:
-      PA1: [0, "PA1 connected to VINP input"]
-      PA3: [1, "PA3 connected to VINP input"]
-      PA7: [2, "PA7 connected to VINP input"]
+      VINP0: [0, "VINP0 connected to VINP input"]
+      VINP1: [1, "VINP1 connected to VINP input"]
+      VINP2: [2, "VINP2 connected to VINP input"]
       DAC3_CH1: [3, "DAC3_CH1 connected to VINP input"]
   OPAMP1_TCMR:
     VPS_SEL:
-      PA1: [0, "PA1 connected to VINP input"]
-      PA3: [1, "PA3 connected to VINP input"]
-      PA7: [2, "PA7 connected to VINP input"]
-      DAC3_CH1: [3, "VINP3 connected to VINP input"]      
-    VMS_SEL:
-      PA3: [0, "PA3 connected to VINM input"]
-      PC5: [1, "PC5 connected to VINM input"]
+      VINP0: [0, "VINP0 connected to VINP input"]
+      VINP1: [1, "VINP1 connected to VINP input"]
+      VINP2: [2, "VINP2 connected to VINP input"]
+      DAC3_CH1: [3, "DAC3_CH1 connected to VINP input"]   
   OPAMP2_CSR:
-    VM_SEL:
-      _replace_enum:
-        PA5: [0, "PA5 connected to VINM input"]
-        PC5: [1, "PC5 connected to VINM input"]
     VP_SEL: 
-      PA7: [0, "PA7 connected to VINP input"]
-      PB14: [1, "PB14 connected to VINP input"]
-      PB0: [2, "PB0 connected to VINP input"]
-      PD1: [3, "PD1 connected to VINP input"]
-  OPAMP2_TCMR: 
+      VINP0: [0, "VINP0 connected to VINP input"]
+      VINP1: [1, "VINP1 connected to VINP input"]
+      VINP2: [2, "VINP2 connected to VINP input"]
+      VINP3: [3, "VINP3 connected to VINP input"]
+  OPAMP2_TCMR:
     VPS_SEL:
-      PA7: [0, "PA7 connected to VINP input"]
-      PB14: [1, "PB14 connected to VINP input"]
-      PB0: [2, "PB0 connected to VINP input"]
-      PD13: [3, "PD13 connected to VINP input"]      
-    VMS_SEL:
-      PA5: [0, "PA5 connected to VINM input"]
-      PC5: [1, "PC5 connected to VINM input"]
+      VINP0: [0, "VINP0 connected to VINP input"]
+      VINP1: [1, "VINP1 connected to VINP input"]
+      VINP2: [2, "VINP2 connected to VINP input"]
+      VINP3: [3, "VINP3 connected to VINP input"]   
   OPAMP3_CSR:
-    VM_SEL:
-      _replace_enum:
-        PB2: [0, "PB2 connected to VINM input"]
-        PB10: [1, "PB10 connected to VINM input"]
     VP_SEL: 
-      PB0: [0, "PB0 connected to VINP input"]
-      PB13: [1, "PB13 connected to VINP input"]
-      PA1: [2, "PA1 connected to VINP input"]
+      VINP0: [0, "VINP0 connected to VINP input"]
+      VINP1: [1, "VINP1 connected to VINP input"]
+      VINP2: [2, "VINP2 connected to VINP input"]
       DAC3_CH2: [3, "DAC3_CH2 connected to VINP input"]
   OPAMP3_TCMR:
     VPS_SEL:
-      PB0: [0, "PB0 connected to VINP input"]
-      PB13: [1, "PB13 connected to VINP input"]
-      PA1: [2, "PA1 connected to VINP input"]
+      VINP0: [0, "VINP0 connected to VINP input"]
+      VINP1: [1, "VINP1 connected to VINP input"]
+      VINP2: [2, "VINP2 connected to VINP input"]
       DAC3_CH2: [3, "DAC3_CH2 connected to VINP input"]      
-    VMS_SEL:
-      PB2: [0, "PB2 connected to VINM input"]
-      PB10: [1, "PB10 connected to VINM input"]

--- a/peripherals/opamp/opamp_g4_opamp4_5.yaml
+++ b/peripherals/opamp/opamp_g4_opamp4_5.yaml
@@ -1,0 +1,39 @@
+OPAMP:
+  OPAMP4_CSR:
+    VM_SEL:
+      _replace_enum:
+        PB10: [0, "PB10 connected to VINM input"]
+        PD8: [1, "PD8 connected to VINM input"]
+    VP_SEL: 
+      PB13: [0, "PB13 connected to VINP input"]
+      PD11: [1, "PD11 connected to VINP input"]
+      PB11: [2, "PB11 connected to VINP input"]
+      DAC4_CH1: [3, "DAC4_CH1 connected to VINP input"]
+  OPAMP4_TCMR:
+    VPS_SEL:
+      PB13: [0, "PB13 connected to VINP input"]
+      PD11: [1, "PD11 connected to VINP input"]
+      PB11: [2, "PB11 connected to VINP input"]
+      DAC4_CH1: [3, "DAC4_CH1 connected to VINP input"]      
+    VMS_SEL:
+      PB10: [0, "PB10 connected to VINM input"]
+      PD8: [1, "PD8 connected to VINM input"]
+  OPAMP5_CSR:
+    VM_SEL:
+      _replace_enum:
+        PB15: [0, "PB15 connected to VINM input"]
+        PA3: [1, "PA3 connected to VINM input"]
+    VP_SEL: 
+      PB14: [0, "PB14 connected to VINP input"]
+      PD12: [1, "PD12 connected to VINP input"]
+      PC3: [2, "PC3 connected to VINP input"]
+      DAC4_CH2: [3, "DAC4_CH2 connected to VINP input"]
+  OPAMP5_TCMR:
+    VPS_SEL:
+      PB14: [0, "PB14 connected to VINP input"]
+      PD12: [1, "PD12 connected to VINP input"]
+      PC3: [2, "PC3 connected to VINP input"]
+      DAC4_CH2: [3, "DAC4_CH2 connected to VINP input"]      
+    VMS_SEL:
+      PB15: [0, "PB15 connected to VINM input"]
+      PA3: [1, "PA3 connected to VINM input"]

--- a/peripherals/opamp/opamp_g4_opamp4_5.yaml
+++ b/peripherals/opamp/opamp_g4_opamp4_5.yaml
@@ -1,39 +1,26 @@
 OPAMP:
   OPAMP4_CSR:
-    VM_SEL:
-      _replace_enum:
-        PB10: [0, "PB10 connected to VINM input"]
-        PD8: [1, "PD8 connected to VINM input"]
     VP_SEL: 
-      PB13: [0, "PB13 connected to VINP input"]
-      PD11: [1, "PD11 connected to VINP input"]
-      PB11: [2, "PB11 connected to VINP input"]
+      VINP0: [0, "VINP0 connected to VINP input"]
+      VINP1: [1, "VINP1 connected to VINP input"]
+      VINP2: [2, "VINP2 connected to VINP input"]
       DAC4_CH1: [3, "DAC4_CH1 connected to VINP input"]
   OPAMP4_TCMR:
     VPS_SEL:
-      PB13: [0, "PB13 connected to VINP input"]
-      PD11: [1, "PD11 connected to VINP input"]
-      PB11: [2, "PB11 connected to VINP input"]
+      VINP0: [0, "VINP0 connected to VINP input"]
+      VINP1: [1, "VINP1 connected to VINP input"]
+      VINP2: [2, "VINP2 connected to VINP input"]
       DAC4_CH1: [3, "DAC4_CH1 connected to VINP input"]      
-    VMS_SEL:
-      PB10: [0, "PB10 connected to VINM input"]
-      PD8: [1, "PD8 connected to VINM input"]
   OPAMP5_CSR:
-    VM_SEL:
-      _replace_enum:
-        PB15: [0, "PB15 connected to VINM input"]
-        PA3: [1, "PA3 connected to VINM input"]
     VP_SEL: 
-      PB14: [0, "PB14 connected to VINP input"]
-      PD12: [1, "PD12 connected to VINP input"]
-      PC3: [2, "PC3 connected to VINP input"]
+      VINP0: [0, "VINP0 connected to VINP input"]
+      VINP1: [1, "VINP1 connected to VINP input"]
+      VINP2: [2, "VINP2 connected to VINP input"]
       DAC4_CH2: [3, "DAC4_CH2 connected to VINP input"]
   OPAMP5_TCMR:
     VPS_SEL:
-      PB14: [0, "PB14 connected to VINP input"]
-      PD12: [1, "PD12 connected to VINP input"]
-      PC3: [2, "PC3 connected to VINP input"]
-      DAC4_CH2: [3, "DAC4_CH2 connected to VINP input"]      
-    VMS_SEL:
-      PB15: [0, "PB15 connected to VINM input"]
-      PA3: [1, "PA3 connected to VINM input"]
+      VINP0: [0, "VINP0 connected to VINP input"]
+      VINP1: [1, "VINP1 connected to VINP input"]
+      VINP2: [2, "VINP2 connected to VINP input"]
+      DAC4_CH2: [3, "DAC4_CH2 connected to VINP input"]
+

--- a/peripherals/opamp/opamp_g4_opamp6.yaml
+++ b/peripherals/opamp/opamp_g4_opamp6.yaml
@@ -1,20 +1,13 @@
 OPAMP:
   OPAMP6_CSR:
-    VM_SEL:
-      _replace_enum:
-        PA1: [0, "PA1 connected to VINM input"]
-        PB1: [1, "PB1 connected to VINM input"]
     VP_SEL: 
-      PB12: [0, "PB12 connected to VINP input"]
-      PD9: [1, "PD9 connected to VINP input"]
-      PB13: [2, "PB13 connected to VINP input"]
+      VINP0: [0, "VINP0 connected to VINP input"]
+      VINP1: [1, "VINP1 connected to VINP input"]
+      VINP2: [2, "VINP2 connected to VINP input"]
       DAC3_CH1: [3, "DAC3_CH1 connected to VINP input"]
   OPAMP6_TCMR:
     VPS_SEL:
-      PB12: [0, "PB12 connected to VINP input"]
-      PD9: [1, "PD9 connected to VINP input"]
-      PB13: [2, "PB13 connected to VINP input"]
+      VINP0: [0, "VINP0 connected to VINP input"]
+      VINP1: [1, "VINP1 connected to VINP input"]
+      VINP2: [2, "VINP2 connected to VINP input"]
       DAC3_CH1: [3, "DAC3_CH1 connected to VINP input"]      
-    VMS_SEL:
-      PA1: [0, "PA1 connected to VINM input"]
-      PB1: [1, "PB1 connected to VINM input"]

--- a/peripherals/opamp/opamp_g4_opamp6.yaml
+++ b/peripherals/opamp/opamp_g4_opamp6.yaml
@@ -1,0 +1,20 @@
+OPAMP:
+  OPAMP6_CSR:
+    VM_SEL:
+      _replace_enum:
+        PA1: [0, "PA1 connected to VINM input"]
+        PB1: [1, "PB1 connected to VINM input"]
+    VP_SEL: 
+      PB12: [0, "PB12 connected to VINP input"]
+      PD9: [1, "PD9 connected to VINP input"]
+      PB13: [2, "PB13 connected to VINP input"]
+      DAC3_CH1: [3, "DAC3_CH1 connected to VINP input"]
+  OPAMP6_TCMR:
+    VPS_SEL:
+      PB12: [0, "PB12 connected to VINP input"]
+      PD9: [1, "PD9 connected to VINP input"]
+      PB13: [2, "PB13 connected to VINP input"]
+      DAC3_CH1: [3, "DAC3_CH1 connected to VINP input"]      
+    VMS_SEL:
+      PA1: [0, "PA1 connected to VINM input"]
+      PB1: [1, "PB1 connected to VINM input"]


### PR DESCRIPTION
Verified with RM0440 the OpAmp register count for each chip in the family.
+ stm32g491 was missing OPAMP6

### Table from RM0440:
| Feature | STM32G474/STM32G484 | STM32G473/STM32G483 | STM32G471 | STM32G431/STM32G441 | STM32G491/STM32G4A1 |
|---|---|---|---|---|---|
| OPAMP | 6 (OPAMP1..6) | 6 (OPAMP1..6) | 4 (OPAMP1.2,3,6) | 3 (OPAMP1..3) | 4 (OPAMP1.2,3,6) |

Note that actually in STM32Cube header files stm32g471 doesn't have 4th Opamp, so leaving it off from this change - until actual hardware can be checked 