### PR TITLE
Fix misspelled WCKSEL->WUCKSEL field in RTC CR register in several de…

### DIFF
--- a/devices/common_patches/rtc/rtc_cr.yaml
+++ b/devices/common_patches/rtc/rtc_cr.yaml
@@ -3,4 +3,5 @@ RTC:
     _modify:
       WCKSEL:
         name: WUCKSEL
+        description: Wakeup clock selection
 

--- a/devices/stm32f215.yaml
+++ b/devices/stm32f215.yaml
@@ -82,6 +82,7 @@ _include:
  - ../peripherals/i2c/i2c_v1.yaml
  - common_patches/hash/hash_v1.yaml
  - common_patches/rtc/rtc_bkpr.yaml
+ - common_patches/rtc/rtc_cr.yaml
  - common_patches/tim/tim_ccr.yaml
  - common_patches/dbgmcu.yaml
  - ../peripherals/tim/tim_ccm_v1.yaml

--- a/devices/stm32f217.yaml
+++ b/devices/stm32f217.yaml
@@ -81,6 +81,7 @@ _include:
  - ../peripherals/i2c/i2c_v1.yaml
  - common_patches/hash/hash_v1.yaml
  - common_patches/rtc/rtc_bkpr.yaml
+ - common_patches/rtc/rtc_cr.yaml
  - common_patches/tim/tim_ccr.yaml
  - common_patches/dbgmcu.yaml
  - ../peripherals/tim/tim_ccm_v1.yaml

--- a/devices/stm32g431.yaml
+++ b/devices/stm32g431.yaml
@@ -14,3 +14,4 @@ _include:
  - ./common_patches/g4_cordic.yaml
  - ../peripherals/cordic/cordic_g4.yaml
  - ./common_patches/sai/sai_v1.yaml
+ - ./common_patches/rtc/rtc_cr.yaml

--- a/devices/stm32g441.yaml
+++ b/devices/stm32g441.yaml
@@ -14,4 +14,4 @@ _include:
  - ./common_patches/g4_cordic.yaml
  - ../peripherals/cordic/cordic_g4.yaml
  - ./common_patches/sai/sai_v1.yaml
- 
+ - ./common_patches/rtc/rtc_cr.yaml

--- a/devices/stm32g471.yaml
+++ b/devices/stm32g471.yaml
@@ -14,4 +14,4 @@ _include:
  - ./common_patches/g4_cordic.yaml
  - ../peripherals/cordic/cordic_g4.yaml
  - ./common_patches/sai/sai_v1.yaml
-
+ - ./common_patches/rtc/rtc_cr.yaml

--- a/devices/stm32g473.yaml
+++ b/devices/stm32g473.yaml
@@ -14,3 +14,4 @@ _include:
  - ./common_patches/g4_cordic.yaml
  - ../peripherals/cordic/cordic_g4.yaml 
  - ./common_patches/sai/sai_v1.yaml
+ - ./common_patches/rtc/rtc_cr.yaml

--- a/devices/stm32g474.yaml
+++ b/devices/stm32g474.yaml
@@ -14,3 +14,4 @@ _include:
  - ./common_patches/g4_cordic.yaml
  - ../peripherals/cordic/cordic_g4.yaml
  - ./common_patches/sai/sai_v1.yaml
+ - ./common_patches/rtc/rtc_cr.yaml

--- a/devices/stm32g483.yaml
+++ b/devices/stm32g483.yaml
@@ -14,3 +14,4 @@ _include:
  - ./common_patches/g4_cordic.yaml
  - ../peripherals/cordic/cordic_g4.yaml
  - ./common_patches/sai/sai_v1.yaml
+ - ./common_patches/rtc/rtc_cr.yaml

--- a/devices/stm32g484.yaml
+++ b/devices/stm32g484.yaml
@@ -14,3 +14,4 @@ _include:
  - ./common_patches/g4_cordic.yaml
  - ../peripherals/cordic/cordic_g4.yaml
  - ./common_patches/sai/sai_v1.yaml
+ - ./common_patches/rtc/rtc_cr.yaml

--- a/devices/stm32g491.yaml
+++ b/devices/stm32g491.yaml
@@ -13,4 +13,4 @@ _include:
  - ../peripherals/wwdg/g4_wwdg.yaml
  - ./common_patches/g4_cordic.yaml
  - ../peripherals/cordic/cordic_g4.yaml
-
+ - ./common_patches/rtc/rtc_cr.yaml

--- a/devices/stm32g4a1.yaml
+++ b/devices/stm32g4a1.yaml
@@ -13,4 +13,4 @@ _include:
  - ../peripherals/wwdg/g4_wwdg.yaml
  - ./common_patches/g4_cordic.yaml
  - ../peripherals/cordic/cordic_g4.yaml
-
+ - ./common_patches/rtc/rtc_cr.yaml

--- a/devices/stm32l100.yaml
+++ b/devices/stm32l100.yaml
@@ -86,6 +86,7 @@ _include:
  - ../peripherals/rcc/rcc_l1.yaml
  - ../peripherals/i2c/i2c_v1.yaml
  - common_patches/rtc/rtc_bkpr.yaml
+ - common_patches/rtc/rtc_cr.yaml
  - common_patches/tim/tim_ccr.yaml
  - ../peripherals/usb/usb.yaml
  - ../peripherals/tim/tim_ccm_v1.yaml

--- a/devices/stm32l151.yaml
+++ b/devices/stm32l151.yaml
@@ -36,6 +36,7 @@ _include:
  - ../peripherals/exti/exti.yaml
  - ../peripherals/i2c/i2c_v1.yaml
  - common_patches/rtc/rtc_bkpr.yaml
+ - common_patches/rtc/rtc_cr.yaml
  - common_patches/tim/tim_ccr.yaml
  - ../peripherals/usb/usb.yaml
  - ../peripherals/tim/tim_ccm_v1.yaml

--- a/devices/stm32l162.yaml
+++ b/devices/stm32l162.yaml
@@ -36,6 +36,7 @@ _include:
  - ../peripherals/exti/exti.yaml
  - ../peripherals/i2c/i2c_v1.yaml
  - common_patches/rtc/rtc_bkpr.yaml
+ - common_patches/rtc/rtc_cr.yaml
  - common_patches/tim/tim_ccr.yaml
  - ../peripherals/usb/usb.yaml
  - ../peripherals/tim/tim_ccm_v1.yaml

--- a/devices/stm32l4x1.yaml
+++ b/devices/stm32l4x1.yaml
@@ -88,6 +88,7 @@ _include:
  - ../peripherals/usart/lpuart_v2A.yaml
  - ../peripherals/usart/usart_v2B2.yaml
  - common_patches/rtc/rtc_bkpr.yaml
+ - common_patches/rtc/rtc_cr.yaml
  - common_patches/tsc/tsc.yaml
  - common_patches/tim/tim_ccr.yaml
  - common_patches/fpu_interrupt.yaml

--- a/devices/stm32l4x2.yaml
+++ b/devices/stm32l4x2.yaml
@@ -118,6 +118,7 @@ _include:
  - ../peripherals/usart/lpuart_v2A.yaml
  - ../peripherals/usart/usart_v2B2.yaml
  - common_patches/rtc/rtc_bkpr.yaml
+ - common_patches/rtc/rtc_cr.yaml
  - common_patches/tsc/tsc.yaml
  - common_patches/tim/tim_ccr.yaml
  - common_patches/fpu_interrupt.yaml

--- a/devices/stm32l4x3.yaml
+++ b/devices/stm32l4x3.yaml
@@ -66,6 +66,7 @@ _include:
  - ../peripherals/usart/lpuart_v2A.yaml
  - ../peripherals/usart/usart_v2B1.yaml
  - common_patches/rtc/rtc_bkpr.yaml
+ - common_patches/rtc/rtc_cr.yaml
  - common_patches/tsc/tsc.yaml
  - common_patches/tim/tim_ccr.yaml
  - ./common_patches/flash/flash_boot0s.yaml

--- a/devices/stm32l4x5.yaml
+++ b/devices/stm32l4x5.yaml
@@ -150,6 +150,7 @@ _include:
  - ../peripherals/usart/lpuart_v2A.yaml
  - ../peripherals/usart/usart_v2B1.yaml
  - common_patches/rtc/rtc_bkpr.yaml
+ - common_patches/rtc/rtc_cr.yaml
  - common_patches/tsc/tsc.yaml
  - common_patches/tim/tim_ccr.yaml
  - ./common_patches/flash/flash_boot0s.yaml

--- a/devices/stm32l4x6.yaml
+++ b/devices/stm32l4x6.yaml
@@ -65,6 +65,7 @@ _include:
  - ../peripherals/usart/lpuart_v2A.yaml
  - ../peripherals/usart/usart_v2B1.yaml
  - common_patches/rtc/rtc_bkpr.yaml
+ - common_patches/rtc/rtc_cr.yaml
  - common_patches/tsc/tsc.yaml
  - common_patches/tim/tim_ccr.yaml
  - ./common_patches/flash/flash_boot0s.yaml

--- a/devices/stm32wb55.yaml
+++ b/devices/stm32wb55.yaml
@@ -17,3 +17,4 @@ PWR:
 
 _include:
  - ./common_patches/sai/sai_v1.yaml
+ - ./common_patches/rtc/rtc_cr.yaml


### PR DESCRIPTION
…vices

This PR closes #417. This issue affects devices across several
families, some of which have been dealt with previously. This PR
corrects the misspelled field for the additional devices listed below,
plus corrects the field description for l100, l151, and l162.

There does seem to be a typo in some reference manuals where the RTC
register map refers to "WCKSEL" instead of "WUCKSEL". For example, see
RM0351 38.6.21 (p1267) vs. RM0038 20.6.21 (p546). However, all
reference manuals correctly refer to "WUCKSEL" in the individual field
descriptions. "WUCKSEL" should be the proper name for this field
across all devices that have this field.

stm32f215
stm32f217
stm32g431
stm32g441
stm32g471
stm32g473
stm32g474
stm32g483
stm32g484
stm32g491
stm32g4a1
stm32l100
stm32l151
stm32l162
stm32l4x1
stm32l4x2
stm32l4x3
stm32l4x5
stm32l4x6
stm32wb55