### PR TITLE
F3 EXTI fix

### DIFF
--- a/devices/common_patches/f3_exti_offset.yaml
+++ b/devices/common_patches/f3_exti_offset.yaml
@@ -1,0 +1,14 @@
+EXTI:
+  _modify:
+    IMR2:
+      addressOffset: "0x20"
+    EMR2:
+      addressOffset: "0x24"
+    RTSR2:
+      addressOffset: "0x28"
+    FTSR2:
+      addressOffset: "0x2C"
+    SWIER2:
+      addressOffset: "0x30"
+    PR2:
+      addressOffset: "0x34"

--- a/devices/stm32f301.yaml
+++ b/devices/stm32f301.yaml
@@ -153,6 +153,7 @@ _include:
  - common_patches/dma/dma_v1.yaml
  - ../peripherals/dma/dma_v1.yaml
  - ../peripherals/iwdg/iwdg_with_WINR.yaml
+ - common_patches/f3_exti_offset.yaml
  - ../peripherals/exti/exti.yaml
  - ../peripherals/i2c/i2c_v2.yaml
  - ../peripherals/usart/usart_v2B.yaml

--- a/devices/stm32f301.yaml
+++ b/devices/stm32f301.yaml
@@ -1,10 +1,15 @@
 _svd: ../svd/stm32f301.svd
 
+_delete:
+  - EXTI
+
 _copy:
-  TIM1:
-    from: ../svd/stm32f302.svd:TIM1
   ADC1_2:
     from: ADC
+  EXTI:
+    from: ../svd/stm32f302.svd:EXTI
+  TIM1:
+    from: ../svd/stm32f302.svd:TIM1
 
 _add:
   I2C3:
@@ -57,6 +62,22 @@ ADC1_2:
       name: CCR
       displayName: CCR
       alternateRegister: ""
+
+EXTI:
+  _delete:
+    _interrupts:
+      - UART4_EXTI34
+      - UART5_EXTI35
+  _modify:
+    IMR2:
+      resetValue: "0xFFFFFFFE"
+
+PWR:
+  _add:
+    _interrupts:
+      PVD:
+        description: "PVD through EXTI line detection interrupt"
+        value: 1
 
 "SPI*":
   SR:

--- a/devices/stm32f302.yaml
+++ b/devices/stm32f302.yaml
@@ -146,6 +146,7 @@ _include:
  - common_patches/dma/dma_v1.yaml
  - ../peripherals/dma/dma_v1.yaml
  - ../peripherals/iwdg/iwdg_with_WINR.yaml
+ - common_patches/f3_exti_offset.yaml
  - ../peripherals/exti/exti.yaml
  - ../peripherals/i2c/i2c_v2.yaml
  - ../peripherals/usart/usart_v2B.yaml

--- a/devices/stm32f303.yaml
+++ b/devices/stm32f303.yaml
@@ -130,6 +130,7 @@ _include:
  - common_patches/dma/dma_v1.yaml
  - ../peripherals/dma/dma_v1.yaml
  - ../peripherals/iwdg/iwdg_with_WINR.yaml
+ - common_patches/f3_exti_offset.yaml
  - ../peripherals/exti/exti.yaml
  - ../peripherals/i2c/i2c_v2.yaml
  - ../peripherals/usart/usart_v2B.yaml

--- a/devices/stm32f3x4.yaml
+++ b/devices/stm32f3x4.yaml
@@ -262,6 +262,7 @@ _include:
  - common_patches/dma/dma_v1.yaml
  - ../peripherals/dma/dma_v1.yaml
  - ../peripherals/iwdg/iwdg_with_WINR.yaml
+ - common_patches/f3_exti_offset.yaml
  - ../peripherals/exti/exti.yaml
  - ../peripherals/i2c/i2c_v2.yaml
  - ../peripherals/usart/usart_v2B.yaml


### PR DESCRIPTION
Fix for f3 EXTI peripheral

* Address offset is wrong for `*2` registers
* f301 should have `*1` and `*2` registers
  * The same problem exists on f3x8, will be fixed by #495 