### PR TITLE
WWDG prescaler fix for H7

### DIFF
--- a/devices/common_patches/h7_wwdg.yaml
+++ b/devices/common_patches/h7_wwdg.yaml
@@ -1,6 +1,5 @@
 WWDG:
-  CFG:
+  CFR:
     _modify:
       WDGTB:
         bitWidth: 3
-        

--- a/devices/common_patches/h7_wwdg.yaml
+++ b/devices/common_patches/h7_wwdg.yaml
@@ -1,4 +1,4 @@
-WWDG:
+"WWDG,WWDG?":
   CFR:
     _modify:
       WDGTB:

--- a/devices/common_patches/h7_wwdg.yaml
+++ b/devices/common_patches/h7_wwdg.yaml
@@ -1,0 +1,6 @@
+WWDG:
+  CFG:
+    _modify:
+      WDGTB:
+        bitWidth: 3
+        

--- a/devices/common_patches/h7_wwdg1.yaml
+++ b/devices/common_patches/h7_wwdg1.yaml
@@ -1,0 +1,5 @@
+WWDG1:
+  CFR:
+    _modify:
+      WDGTB:
+        bitWidth: 3

--- a/devices/common_patches/h7_wwdg1.yaml
+++ b/devices/common_patches/h7_wwdg1.yaml
@@ -1,5 +1,0 @@
-WWDG1:
-  CFR:
-    _modify:
-      WDGTB:
-        bitWidth: 3

--- a/devices/stm32g431.yaml
+++ b/devices/stm32g431.yaml
@@ -10,7 +10,7 @@ _include:
  - ./common_patches/g4_comp.yaml
  - ./common_patches/g4_adc.yaml
  - ../peripherals/iwdg/iwdg_with_WINR.yaml
- - ../peripherals/wwdg/g4_wwdg.yaml
+ - ../peripherals/wwdg/wwdg_v2.yaml
  - ./common_patches/g4_cordic.yaml
  - ../peripherals/cordic/cordic_g4.yaml
  - ./common_patches/sai/sai_v1.yaml

--- a/devices/stm32g441.yaml
+++ b/devices/stm32g441.yaml
@@ -10,7 +10,7 @@ _include:
  - ./common_patches/g4_comp.yaml
  - ./common_patches/g4_adc.yaml
  - ../peripherals/iwdg/iwdg_with_WINR.yaml
- - ../peripherals/wwdg/g4_wwdg.yaml
+ - ../peripherals/wwdg/wwdg_v2.yaml
  - ./common_patches/g4_cordic.yaml
  - ../peripherals/cordic/cordic_g4.yaml
  - ./common_patches/sai/sai_v1.yaml

--- a/devices/stm32g471.yaml
+++ b/devices/stm32g471.yaml
@@ -10,7 +10,7 @@ _include:
  - ./common_patches/g4_comp.yaml
  - ./common_patches/g4_adc.yaml
  - ../peripherals/iwdg/iwdg_with_WINR.yaml
- - ../peripherals/wwdg/g4_wwdg.yaml
+ - ../peripherals/wwdg/wwdg_v2.yaml
  - ./common_patches/g4_cordic.yaml
  - ../peripherals/cordic/cordic_g4.yaml
  - ./common_patches/sai/sai_v1.yaml

--- a/devices/stm32g473.yaml
+++ b/devices/stm32g473.yaml
@@ -10,7 +10,7 @@ _include:
  - ./common_patches/g4_comp.yaml
  - ./common_patches/g4_adc.yaml
  - ../peripherals/iwdg/iwdg_with_WINR.yaml
- - ../peripherals/wwdg/g4_wwdg.yaml
+ - ../peripherals/wwdg/wwdg_v2.yaml
  - ./common_patches/g4_cordic.yaml
  - ../peripherals/cordic/cordic_g4.yaml 
  - ./common_patches/sai/sai_v1.yaml

--- a/devices/stm32g474.yaml
+++ b/devices/stm32g474.yaml
@@ -10,7 +10,7 @@ _include:
  - ./common_patches/g4_comp.yaml
  - ./common_patches/g4_adc.yaml
  - ../peripherals/iwdg/iwdg_with_WINR.yaml
- - ../peripherals/wwdg/g4_wwdg.yaml
+ - ../peripherals/wwdg/wwdg_v2.yaml
  - ./common_patches/g4_cordic.yaml
  - ../peripherals/cordic/cordic_g4.yaml
  - ./common_patches/sai/sai_v1.yaml

--- a/devices/stm32g483.yaml
+++ b/devices/stm32g483.yaml
@@ -10,7 +10,7 @@ _include:
  - ./common_patches/g4_comp.yaml
  - ./common_patches/g4_adc.yaml
  - ../peripherals/iwdg/iwdg_with_WINR.yaml
- - ../peripherals/wwdg/g4_wwdg.yaml
+ - ../peripherals/wwdg/wwdg_v2.yaml
  - ./common_patches/g4_cordic.yaml
  - ../peripherals/cordic/cordic_g4.yaml
  - ./common_patches/sai/sai_v1.yaml

--- a/devices/stm32g484.yaml
+++ b/devices/stm32g484.yaml
@@ -10,7 +10,7 @@ _include:
  - ./common_patches/g4_comp.yaml
  - ./common_patches/g4_adc.yaml
  - ../peripherals/iwdg/iwdg_with_WINR.yaml
- - ../peripherals/wwdg/g4_wwdg.yaml
+ - ../peripherals/wwdg/wwdg_v2.yaml
  - ./common_patches/g4_cordic.yaml
  - ../peripherals/cordic/cordic_g4.yaml
  - ./common_patches/sai/sai_v1.yaml

--- a/devices/stm32g491.yaml
+++ b/devices/stm32g491.yaml
@@ -21,7 +21,7 @@ _include:
  - ./common_patches/g4_comp.yaml
  - ./common_patches/g4_adc.yaml
  - ../peripherals/iwdg/iwdg_with_WINR.yaml
- - ../peripherals/wwdg/g4_wwdg.yaml
+ - ../peripherals/wwdg/wwdg_v2.yaml
  - ./common_patches/g4_cordic.yaml
  - ../peripherals/cordic/cordic_g4.yaml
  - ./common_patches/rtc/rtc_cr.yaml

--- a/devices/stm32g4a1.yaml
+++ b/devices/stm32g4a1.yaml
@@ -21,7 +21,7 @@ _include:
  - ./common_patches/g4_comp.yaml
  - ./common_patches/g4_adc.yaml
  - ../peripherals/iwdg/iwdg_with_WINR.yaml
- - ../peripherals/wwdg/g4_wwdg.yaml
+ - ../peripherals/wwdg/wwdg_v2.yaml
  - ./common_patches/g4_cordic.yaml
  - ../peripherals/cordic/cordic_g4.yaml
  - ./common_patches/rtc/rtc_cr.yaml

--- a/devices/stm32h743.yaml
+++ b/devices/stm32h743.yaml
@@ -64,7 +64,7 @@ _include:
  - ../peripherals/iwdg/iwdg_with_WINR.yaml
  - ../peripherals/exti/exti_h7.yaml
  - ../peripherals/i2c/i2c_v2.yaml
- - ../peripherals/wwdg/wwdg.yaml
+ - ../peripherals/wwdg/wwdg_v2.yaml
  - ../peripherals/usart/usart_v2B1.yaml
  - common_patches/tim/tim_ccr.yaml
  - ../peripherals/tim/tim_ccm_v2.yaml
@@ -75,3 +75,4 @@ _include:
  - ../peripherals/rtc/rtc_common.yaml
  - ../peripherals/rtc/rtc_h7.yaml
  - common_patches/h7_crc_addr_fix.yaml
+ - common_patches/h7_wwdg.yaml

--- a/devices/stm32h743v.yaml
+++ b/devices/stm32h743v.yaml
@@ -66,7 +66,7 @@ _include:
  - ../peripherals/iwdg/iwdg_with_WINR.yaml
  - ../peripherals/exti/exti_h7.yaml
  - ../peripherals/i2c/i2c_v2.yaml
- - ../peripherals/wwdg/wwdg.yaml
+ - ../peripherals/wwdg/wwdg_v2.yaml
  - ../peripherals/usart/usart_v2B1.yaml
  - common_patches/tim/tim_ccr.yaml
  - ../peripherals/tim/tim_ccm_v2.yaml
@@ -77,3 +77,4 @@ _include:
  - ../peripherals/rtc/rtc_common.yaml
  - ../peripherals/rtc/rtc_h7.yaml
  - common_patches/h7_crc_addr_fix.yaml
+ - common_patches/h7_wwdg.yaml

--- a/devices/stm32h747cm4.yaml
+++ b/devices/stm32h747cm4.yaml
@@ -82,10 +82,11 @@ _include:
  - ../peripherals/iwdg/iwdg_with_WINR.yaml
  - ../peripherals/exti/exti_h7.yaml
  - ../peripherals/i2c/i2c_v2.yaml
- - ../peripherals/wwdg/wwdg.yaml
+ - ../peripherals/wwdg/wwdg_v2.yaml
  - ../peripherals/usart/usart_v2B1.yaml
  - common_patches/tim/tim_ccr.yaml
  - ../peripherals/tim/tim_ccm_v2.yaml
  - ../peripherals/tim/tim1234_1567_ccm_v2.yaml
  - ../peripherals/sai/sai.yaml
  - common_patches/h7_crc_addr_fix.yaml
+ - common_patches/h7_wwdg.yaml

--- a/devices/stm32h747cm4.yaml
+++ b/devices/stm32h747cm4.yaml
@@ -89,4 +89,4 @@ _include:
  - ../peripherals/tim/tim1234_1567_ccm_v2.yaml
  - ../peripherals/sai/sai.yaml
  - common_patches/h7_crc_addr_fix.yaml
- - common_patches/h7_wwdg1.yaml
+ - common_patches/h7_wwdg.yaml

--- a/devices/stm32h747cm4.yaml
+++ b/devices/stm32h747cm4.yaml
@@ -89,4 +89,4 @@ _include:
  - ../peripherals/tim/tim1234_1567_ccm_v2.yaml
  - ../peripherals/sai/sai.yaml
  - common_patches/h7_crc_addr_fix.yaml
- - common_patches/h7_wwdg.yaml
+ - common_patches/h7_wwdg1.yaml

--- a/devices/stm32h747cm7.yaml
+++ b/devices/stm32h747cm7.yaml
@@ -93,4 +93,4 @@ _include:
  - ../peripherals/rtc/rtc_common.yaml
  - ../peripherals/rtc/rtc_h7.yaml
  - common_patches/h7_crc_addr_fix.yaml
- - common_patches/h7_wwdg.yaml
+ - common_patches/h7_wwdg1.yaml

--- a/devices/stm32h747cm7.yaml
+++ b/devices/stm32h747cm7.yaml
@@ -93,4 +93,4 @@ _include:
  - ../peripherals/rtc/rtc_common.yaml
  - ../peripherals/rtc/rtc_h7.yaml
  - common_patches/h7_crc_addr_fix.yaml
- - common_patches/h7_wwdg1.yaml
+ - common_patches/h7_wwdg.yaml

--- a/devices/stm32h747cm7.yaml
+++ b/devices/stm32h747cm7.yaml
@@ -82,7 +82,7 @@ _include:
  - ../peripherals/iwdg/iwdg_with_WINR.yaml
  - ../peripherals/exti/exti_h7.yaml
  - ../peripherals/i2c/i2c_v2.yaml
- - ../peripherals/wwdg/wwdg.yaml
+ - ../peripherals/wwdg/wwdg_v2.yaml
  - ../peripherals/usart/usart_v2B1.yaml
  - common_patches/tim/tim_ccr.yaml
  - ../peripherals/tim/tim_ccm_v2.yaml
@@ -93,3 +93,4 @@ _include:
  - ../peripherals/rtc/rtc_common.yaml
  - ../peripherals/rtc/rtc_h7.yaml
  - common_patches/h7_crc_addr_fix.yaml
+ - common_patches/h7_wwdg.yaml

--- a/devices/stm32h753.yaml
+++ b/devices/stm32h753.yaml
@@ -73,7 +73,7 @@ _include:
  - ../peripherals/iwdg/iwdg_with_WINR.yaml
  - ../peripherals/exti/exti_h7.yaml
  - ../peripherals/i2c/i2c_v2.yaml
- - ../peripherals/wwdg/wwdg.yaml
+ - ../peripherals/wwdg/wwdg_v2.yaml
  - ../peripherals/usart/usart_v2B1.yaml
  - common_patches/tim/tim_ccr.yaml
  - ../peripherals/tim/tim_ccm_v2.yaml
@@ -84,3 +84,4 @@ _include:
  - ../peripherals/rtc/rtc_common.yaml
  - ../peripherals/rtc/rtc_h7.yaml
  - common_patches/h7_crc_addr_fix.yaml
+ - common_patches/h7_wwdg.yaml

--- a/devices/stm32h753v.yaml
+++ b/devices/stm32h753v.yaml
@@ -76,7 +76,7 @@ _include:
  - ../peripherals/iwdg/iwdg_with_WINR.yaml
  - ../peripherals/exti/exti_h7.yaml
  - ../peripherals/i2c/i2c_v2.yaml
- - ../peripherals/wwdg/wwdg.yaml
+ - ../peripherals/wwdg/wwdgv2.yaml
  - ../peripherals/usart/usart_v2B1.yaml
  - common_patches/tim/tim_ccr.yaml
  - ../peripherals/tim/tim_ccm_v2.yaml
@@ -87,3 +87,4 @@ _include:
  - ../peripherals/rtc/rtc_common.yaml
  - ../peripherals/rtc/rtc_h7.yaml
  - common_patches/h7_crc_addr_fix.yaml
+ - common_patches/h7_wwdg.yaml

--- a/devices/stm32h753v.yaml
+++ b/devices/stm32h753v.yaml
@@ -76,7 +76,7 @@ _include:
  - ../peripherals/iwdg/iwdg_with_WINR.yaml
  - ../peripherals/exti/exti_h7.yaml
  - ../peripherals/i2c/i2c_v2.yaml
- - ../peripherals/wwdg/wwdgv2.yaml
+ - ../peripherals/wwdg/wwdg_v2.yaml
  - ../peripherals/usart/usart_v2B1.yaml
  - common_patches/tim/tim_ccr.yaml
  - ../peripherals/tim/tim_ccm_v2.yaml

--- a/devices/stm32h7b3.yaml
+++ b/devices/stm32h7b3.yaml
@@ -152,7 +152,7 @@ _include:
  - ../peripherals/iwdg/iwdg_with_WINR.yaml
  - ../peripherals/exti/exti_h7.yaml
  - ../peripherals/i2c/i2c_v2.yaml
- - ../peripherals/wwdg/wwdg.yaml
+ - ../peripherals/wwdg/wwdg_v2.yaml
  - ../peripherals/usart/usart_v2B1.yaml
  - common_patches/tim/tim_ccr.yaml
  - ../peripherals/tim/tim_ccm_v2.yaml
@@ -163,3 +163,4 @@ _include:
  - ../peripherals/rtc/rtc_common.yaml
  - ../peripherals/rtc/rtc_h7.yaml
  - common_patches/h7_crc_addr_fix.yaml
+ - common_patches/h7_wwdg.yaml

--- a/peripherals/wwdg/wwdg_v2.yaml
+++ b/peripherals/wwdg/wwdg_v2.yaml
@@ -1,4 +1,4 @@
-# WWDG peripheral for the g4 family.
+# WWDG peripheral for the g4 and h7 families.
 # Extend `wwdg.yaml`.
 
 _include:


### PR DESCRIPTION
Fixes #501 

- Renamed the G4 wwdg to wwdg_v2
- Created patch for the bit width
- Added the patch to the H7 devices (I checked the datasheets and they all have the bigger prescaler)