### PR TITLE
Add comprehensive CEC support

### DIFF
--- a/devices/common_patches/cec/cec_RM0041.yaml
+++ b/devices/common_patches/cec/cec_RM0041.yaml
@@ -1,7 +1,3 @@
-_delete:
-  - CEC
-  - HDMI_CEC
-
 _add:
   CEC:
     description: "HDMI-CEC controller"

--- a/devices/common_patches/cec/cec_RM0041.yaml
+++ b/devices/common_patches/cec/cec_RM0041.yaml
@@ -1,0 +1,21 @@
+_delete:
+  - CEC
+  - HDMI_CEC
+
+_add:
+  CEC:
+    description: "HDMI-CEC controller"
+    baseAddress: 0x40007800
+    addressBlock:
+      offset: 0x0
+      size: 0x400
+      usage: "registers"
+    interrupts:
+      CEC:
+        description: "HDMI-CEC global interrupt"
+        value: 42
+    registers: {}
+
+CEC:
+  _include:
+    - registers/cec_v1_registers_common.yaml

--- a/devices/common_patches/cec/cec_RM0091.yaml
+++ b/devices/common_patches/cec/cec_RM0091.yaml
@@ -1,5 +1,6 @@
 _delete:
   - CEC
+  - HDMI_CEC
 
 _add:
   CEC:

--- a/devices/common_patches/cec/cec_RM0091.yaml
+++ b/devices/common_patches/cec/cec_RM0091.yaml
@@ -7,8 +7,8 @@ _add:
       size: 0x400
       usage: "registers"
     interrupts:
-      CEC:
-        description: "HDMI-CEC global interrupt"
+      CEC_CAN:
+        description: "HDMI-CEC and CAN global interrupt"
         value: 30
     registers: {}
 

--- a/devices/common_patches/cec/cec_RM0091.yaml
+++ b/devices/common_patches/cec/cec_RM0091.yaml
@@ -1,0 +1,20 @@
+_delete:
+  - CEC
+
+_add:
+  CEC:
+    description: "HDMI-CEC controller"
+    baseAddress: 0x40007800
+    addressBlock:
+      offset: 0x0
+      size: 0x400
+      usage: "registers"
+    interrupts:
+      CEC:
+        description: "HDMI-CEC global interrupt"
+        value: 30
+    registers: {}
+
+CEC:
+  _include:
+    - registers/cec_v2_registers_common.yaml

--- a/devices/common_patches/cec/cec_RM0091.yaml
+++ b/devices/common_patches/cec/cec_RM0091.yaml
@@ -1,7 +1,3 @@
-_delete:
-  - CEC
-  - HDMI_CEC
-
 _add:
   CEC:
     description: "HDMI-CEC controller"

--- a/devices/common_patches/cec/cec_RM0313.yaml
+++ b/devices/common_patches/cec/cec_RM0313.yaml
@@ -1,0 +1,20 @@
+_delete:
+  - CEC
+
+_add:
+  CEC:
+    description: "HDMI-CEC controller"
+    baseAddress: 0x40007800
+    addressBlock:
+      offset: 0x0
+      size: 0x400
+      usage: "registers"
+    interrupts:
+      CEC:
+        description: "HDMI-CEC global interrupt"
+        value: 42
+    registers: {}
+
+CEC:
+  _include:
+    - registers/cec_v2_registers_common.yaml

--- a/devices/common_patches/cec/cec_RM0313.yaml
+++ b/devices/common_patches/cec/cec_RM0313.yaml
@@ -1,5 +1,6 @@
 _delete:
   - CEC
+  - HDMI_CEC
 
 _add:
   CEC:

--- a/devices/common_patches/cec/cec_RM0313.yaml
+++ b/devices/common_patches/cec/cec_RM0313.yaml
@@ -1,7 +1,3 @@
-_delete:
-  - CEC
-  - HDMI_CEC
-
 _add:
   CEC:
     description: "HDMI-CEC controller"

--- a/devices/common_patches/cec/cec_RM0385.yaml
+++ b/devices/common_patches/cec/cec_RM0385.yaml
@@ -1,0 +1,20 @@
+_delete:
+  - CEC
+
+_add:
+  CEC:
+    description: "HDMI-CEC controller"
+    baseAddress: 0x40006C00
+    addressBlock:
+      offset: 0x0
+      size: 0x400
+      usage: "registers"
+    interrupts:
+      CEC:
+        description: "HDMI-CEC global interrupt"
+        value: 94
+    registers: {}
+
+CEC:
+  _include:
+    - registers/cec_v2_registers_common.yaml

--- a/devices/common_patches/cec/cec_RM0385.yaml
+++ b/devices/common_patches/cec/cec_RM0385.yaml
@@ -1,5 +1,6 @@
 _delete:
   - CEC
+  - HDMI_CEC
 
 _add:
   CEC:

--- a/devices/common_patches/cec/cec_RM0385.yaml
+++ b/devices/common_patches/cec/cec_RM0385.yaml
@@ -1,7 +1,3 @@
-_delete:
-  - CEC
-  - HDMI_CEC
-
 _add:
   CEC:
     description: "HDMI-CEC controller"

--- a/devices/common_patches/cec/cec_RM0390.yaml
+++ b/devices/common_patches/cec/cec_RM0390.yaml
@@ -1,5 +1,6 @@
 _delete:
   - CEC
+  - HDMI_CEC
 
 _add:
   CEC:

--- a/devices/common_patches/cec/cec_RM0390.yaml
+++ b/devices/common_patches/cec/cec_RM0390.yaml
@@ -1,0 +1,20 @@
+_delete:
+  - CEC
+
+_add:
+  CEC:
+    description: "HDMI-CEC controller"
+    baseAddress: 0x40006C00
+    addressBlock:
+      offset: 0x0
+      size: 0x400
+      usage: "registers"
+    interrupts:
+      CEC:
+        description: "HDMI-CEC global interrupt"
+        value: 93
+    registers: {}
+
+CEC:
+  _include:
+    - registers/cec_v2_registers_common.yaml

--- a/devices/common_patches/cec/cec_RM0390.yaml
+++ b/devices/common_patches/cec/cec_RM0390.yaml
@@ -1,7 +1,3 @@
-_delete:
-  - CEC
-  - HDMI_CEC
-
 _add:
   CEC:
     description: "HDMI-CEC controller"

--- a/devices/common_patches/cec/cec_RM0399.yaml
+++ b/devices/common_patches/cec/cec_RM0399.yaml
@@ -1,0 +1,20 @@
+_delete:
+  - CEC
+
+_add:
+  CEC:
+    description: "HDMI-CEC controller"
+    baseAddress: 0x40006C00
+    addressBlock:
+      offset: 0x0
+      size: 0x400
+      usage: "registers"
+    interrupts:
+      CEC:
+        description: "HDMI-CEC global interrupt"
+        value: 94
+    registers: {}
+
+CEC:
+  _include:
+    - registers/cec_v2_registers_common.yaml

--- a/devices/common_patches/cec/cec_RM0399.yaml
+++ b/devices/common_patches/cec/cec_RM0399.yaml
@@ -1,5 +1,6 @@
 _delete:
   - CEC
+  - HDMI_CEC
 
 _add:
   CEC:

--- a/devices/common_patches/cec/cec_RM0399.yaml
+++ b/devices/common_patches/cec/cec_RM0399.yaml
@@ -1,7 +1,3 @@
-_delete:
-  - CEC
-  - HDMI_CEC
-
 _add:
   CEC:
     description: "HDMI-CEC controller"

--- a/devices/common_patches/cec/cec_RM0410.yaml
+++ b/devices/common_patches/cec/cec_RM0410.yaml
@@ -1,0 +1,20 @@
+_delete:
+  - CEC
+
+_add:
+  CEC:
+    description: "HDMI-CEC controller"
+    baseAddress: 0x40006C00
+    addressBlock:
+      offset: 0x0
+      size: 0x400
+      usage: "registers"
+    interrupts:
+      CEC:
+        description: "HDMI-CEC global interrupt"
+        value: 94
+    registers: {}
+
+CEC:
+  _include:
+    - registers/cec_v2_registers_common.yaml

--- a/devices/common_patches/cec/cec_RM0410.yaml
+++ b/devices/common_patches/cec/cec_RM0410.yaml
@@ -1,5 +1,6 @@
 _delete:
   - CEC
+  - HDMI_CEC
 
 _add:
   CEC:

--- a/devices/common_patches/cec/cec_RM0410.yaml
+++ b/devices/common_patches/cec/cec_RM0410.yaml
@@ -1,7 +1,3 @@
-_delete:
-  - CEC
-  - HDMI_CEC
-
 _add:
   CEC:
     description: "HDMI-CEC controller"

--- a/devices/common_patches/cec/cec_RM0433.yaml
+++ b/devices/common_patches/cec/cec_RM0433.yaml
@@ -1,0 +1,20 @@
+_delete:
+  - CEC
+
+_add:
+  CEC:
+    description: "HDMI-CEC controller"
+    baseAddress: 0x40006C00
+    addressBlock:
+      offset: 0x0
+      size: 0x400
+      usage: "registers"
+    interrupts:
+      CEC:
+        description: "HDMI-CEC global interrupt"
+        value: 94
+    registers: {}
+
+CEC:
+  _include:
+    - registers/cec_v2_registers_common.yaml

--- a/devices/common_patches/cec/cec_RM0433.yaml
+++ b/devices/common_patches/cec/cec_RM0433.yaml
@@ -1,5 +1,6 @@
 _delete:
   - CEC
+  - HDMI_CEC
 
 _add:
   CEC:

--- a/devices/common_patches/cec/cec_RM0433.yaml
+++ b/devices/common_patches/cec/cec_RM0433.yaml
@@ -1,7 +1,3 @@
-_delete:
-  - CEC
-  - HDMI_CEC
-
 _add:
   CEC:
     description: "HDMI-CEC controller"

--- a/devices/common_patches/cec/cec_RM0436.yaml
+++ b/devices/common_patches/cec/cec_RM0436.yaml
@@ -1,0 +1,20 @@
+_delete:
+  - CEC
+
+_add:
+  CEC:
+    description: "HDMI-CEC controller"
+    baseAddress: 0x40016000
+    addressBlock:
+      offset: 0x0
+      size: 0x400
+      usage: "registers"
+    interrupts:
+      CEC:
+        description: "HDMI-CEC global interrupt"
+        value: 94
+    registers: {}
+
+CEC:
+  _include:
+    - registers/cec_v2_registers_common.yaml

--- a/devices/common_patches/cec/cec_RM0436.yaml
+++ b/devices/common_patches/cec/cec_RM0436.yaml
@@ -1,5 +1,6 @@
 _delete:
   - CEC
+  - HDMI_CEC
 
 _add:
   CEC:

--- a/devices/common_patches/cec/cec_RM0436.yaml
+++ b/devices/common_patches/cec/cec_RM0436.yaml
@@ -1,7 +1,3 @@
-_delete:
-  - CEC
-  - HDMI_CEC
-
 _add:
   CEC:
     description: "HDMI-CEC controller"

--- a/devices/common_patches/cec/cec_RM0441.yaml
+++ b/devices/common_patches/cec/cec_RM0441.yaml
@@ -1,0 +1,20 @@
+_delete:
+  - CEC
+
+_add:
+  CEC:
+    description: "HDMI-CEC controller"
+    baseAddress: 0x40016000
+    addressBlock:
+      offset: 0x0
+      size: 0x400
+      usage: "registers"
+    interrupts:
+      CEC:
+        description: "HDMI-CEC global interrupt"
+        value: 94
+    registers: {}
+
+CEC:
+  _include:
+    - registers/cec_v2_registers_common.yaml

--- a/devices/common_patches/cec/cec_RM0441.yaml
+++ b/devices/common_patches/cec/cec_RM0441.yaml
@@ -1,5 +1,6 @@
 _delete:
   - CEC
+  - HDMI_CEC
 
 _add:
   CEC:

--- a/devices/common_patches/cec/cec_RM0441.yaml
+++ b/devices/common_patches/cec/cec_RM0441.yaml
@@ -1,7 +1,3 @@
-_delete:
-  - CEC
-  - HDMI_CEC
-
 _add:
   CEC:
     description: "HDMI-CEC controller"

--- a/devices/common_patches/cec/cec_RM0442.yaml
+++ b/devices/common_patches/cec/cec_RM0442.yaml
@@ -1,0 +1,20 @@
+_delete:
+  - CEC
+
+_add:
+  CEC:
+    description: "HDMI-CEC controller"
+    baseAddress: 0x40016000
+    addressBlock:
+      offset: 0x0
+      size: 0x400
+      usage: "registers"
+    interrupts:
+      CEC:
+        description: "HDMI-CEC global interrupt"
+        value: 94
+    registers: {}
+
+CEC:
+  _include:
+    - registers/cec_v2_registers_common.yaml

--- a/devices/common_patches/cec/cec_RM0442.yaml
+++ b/devices/common_patches/cec/cec_RM0442.yaml
@@ -1,5 +1,6 @@
 _delete:
   - CEC
+  - HDMI_CEC
 
 _add:
   CEC:

--- a/devices/common_patches/cec/cec_RM0442.yaml
+++ b/devices/common_patches/cec/cec_RM0442.yaml
@@ -1,7 +1,3 @@
-_delete:
-  - CEC
-  - HDMI_CEC
-
 _add:
   CEC:
     description: "HDMI-CEC controller"

--- a/devices/common_patches/cec/cec_RM0444.yaml
+++ b/devices/common_patches/cec/cec_RM0444.yaml
@@ -1,5 +1,6 @@
 _delete:
   - CEC
+  - HDMI_CEC
 
 _add:
   CEC:

--- a/devices/common_patches/cec/cec_RM0444.yaml
+++ b/devices/common_patches/cec/cec_RM0444.yaml
@@ -1,0 +1,20 @@
+_delete:
+  - CEC
+
+_add:
+  CEC:
+    description: "HDMI-CEC controller"
+    baseAddress: 0x40007800
+    addressBlock:
+      offset: 0x0
+      size: 0x400
+      usage: "registers"
+    interrupts:
+      CEC:
+        description: "HDMI-CEC global interrupt"
+        value: 30
+    registers: {}
+
+CEC:
+  _include:
+    - registers/cec_v2_registers_common.yaml

--- a/devices/common_patches/cec/cec_RM0444.yaml
+++ b/devices/common_patches/cec/cec_RM0444.yaml
@@ -1,7 +1,3 @@
-_delete:
-  - CEC
-  - HDMI_CEC
-
 _add:
   CEC:
     description: "HDMI-CEC controller"

--- a/devices/common_patches/cec/cec_RM0455.yaml
+++ b/devices/common_patches/cec/cec_RM0455.yaml
@@ -1,0 +1,20 @@
+_delete:
+  - CEC
+
+_add:
+  CEC:
+    description: "HDMI-CEC controller"
+    baseAddress: 0x40006C00
+    addressBlock:
+      offset: 0x0
+      size: 0x400
+      usage: "registers"
+    interrupts:
+      CEC:
+        description: "HDMI-CEC global interrupt"
+        value: 94
+    registers: {}
+
+CEC:
+  _include:
+    - registers/cec_v2_registers_common.yaml

--- a/devices/common_patches/cec/cec_RM0455.yaml
+++ b/devices/common_patches/cec/cec_RM0455.yaml
@@ -1,5 +1,6 @@
 _delete:
   - CEC
+  - HDMI_CEC
 
 _add:
   CEC:

--- a/devices/common_patches/cec/cec_RM0455.yaml
+++ b/devices/common_patches/cec/cec_RM0455.yaml
@@ -1,7 +1,3 @@
-_delete:
-  - CEC
-  - HDMI_CEC
-
 _add:
   CEC:
     description: "HDMI-CEC controller"

--- a/devices/common_patches/cec/cec_RM0468.yaml
+++ b/devices/common_patches/cec/cec_RM0468.yaml
@@ -1,0 +1,20 @@
+_delete:
+  - CEC
+
+_add:
+  CEC:
+    description: "HDMI-CEC controller"
+    baseAddress: 0x40006C00
+    addressBlock:
+      offset: 0x0
+      size: 0x400
+      usage: "registers"
+    interrupts:
+      CEC:
+        description: "HDMI-CEC global interrupt"
+        value: 94
+    registers: {}
+
+CEC:
+  _include:
+    - registers/cec_v2_registers_common.yaml

--- a/devices/common_patches/cec/cec_RM0468.yaml
+++ b/devices/common_patches/cec/cec_RM0468.yaml
@@ -1,5 +1,6 @@
 _delete:
   - CEC
+  - HDMI_CEC
 
 _add:
   CEC:

--- a/devices/common_patches/cec/cec_RM0468.yaml
+++ b/devices/common_patches/cec/cec_RM0468.yaml
@@ -1,7 +1,3 @@
-_delete:
-  - CEC
-  - HDMI_CEC
-
 _add:
   CEC:
     description: "HDMI-CEC controller"

--- a/devices/common_patches/cec/cec_delete.yaml
+++ b/devices/common_patches/cec/cec_delete.yaml
@@ -1,0 +1,4 @@
+_delete:
+  - CEC
+  - HDMI_CEC
+  - HDMI-CEC

--- a/devices/common_patches/cec/registers/cec_v1_registers_common.yaml
+++ b/devices/common_patches/cec/registers/cec_v1_registers_common.yaml
@@ -1,0 +1,145 @@
+_add:
+  CFGR:
+    description: "CEC configuration register"
+    addressOffset: 0x00
+    access: read-write
+    resetValue: 0x00000000
+    fields:
+      BPEM:
+        description: "Bit period error mode"
+        bitOffset: 3
+        bitWidth: 1
+      BTEM:
+        description: "Bit timing error mode"
+        bitOffset: 2
+        bitWidth: 1
+      IE:
+        description: "CEC interrupt enable"
+        bitOffset: 1
+        bitWidth: 1
+      PE:
+        description: "Peripheral enable"
+        bitOffset: 0
+        bitWidth: 1
+
+  OAR:
+    description: "CEC own address register"
+    addressOffset: 0x04
+    access: read-write
+    resetValue: 0x00000000
+    fields:
+      OA:
+        description: "Own address"
+        bitOffset: 0
+        bitWidth: 4
+
+  PRES:
+    description: "CEC prescalar register"
+    addressOffset: 0x08
+    access: read-write
+    resetValue: 0x00000000
+    fields:
+      PRESC:
+        description: "Prescalar counter value"
+        bitOffset: 0
+        bitWidth: 14
+
+  ESR:
+    description: "CEC error status register"
+    addressOffset: 0x0C
+    access: read-only
+    resetValue: 0x00000000
+    fields:
+      TBTFE:
+        description: "Tx block transfer finished error"
+        bitOffset: 6
+        bitWidth: 1
+      LINE:
+        description: "Line error"
+        bitOffset: 5
+        bitWidth: 1
+      ACKE:
+        description: "Block acknowledge error"
+        bitOffset: 4
+        bitWidth: 1
+      SBE:
+        description: "Start bit error"
+        bitOffset: 3
+        bitWidth: 1
+      RBTFE:
+        description: "Rx block transfer finished error"
+        bitOffset: 2
+        bitWidth: 1
+      BPE:
+        description: "Bit period error"
+        bitOffset: 1
+        bitWidth: 1
+      BTE:
+        description: "Bit timing error"
+        bitOffset: 0
+        bitWidth: 1
+
+  CSR:
+    description: "CEC control and status register"
+    addressOffset: 0x10
+    access: read-write
+    resetValue: 0x00000000
+    fields:
+      RBTF:
+        description: "Rx byte/block transfer finished flag"
+        bitOffset: 7
+        bitWidth: 1
+      RERR:
+        description: "Rx error"
+        bitOffset: 6
+        bitWidth: 1
+      REOM:
+        description: "Rx end of message flag"
+        bitOffset: 5
+        bitWidth: 1
+      RSOM:
+        description: "Rx start of message flag"
+        bitOffset: 4
+        bitWidth: 1
+      TBTRF:
+        description: "Tx byte transfer request or block transfer finished flag"
+        bitOffset: 3
+        bitWidth: 1
+      TERR:
+        description: "Tx error"
+        bitOffset: 2
+        bitWidth: 1
+      TEOM:
+        description: "Tx end of message"
+        bitOffset: 1
+        bitWidth: 1
+      TSOM:
+        description: "Tx start of message"
+        bitOffset: 0
+        bitWidth: 1
+
+  TXD:
+    description: "CEC Tx data register"
+    addressOffset: 0x14
+    access: read-write
+    resetValue: 0x00000000
+    fields:
+      TXD:
+        description: "Tx data"
+        bitOffset: 0
+        bitWidth: 8
+
+  RXD:
+    description: "CEC Rx data register"
+    addressOffset: 0x18
+    access: read-only
+    resetValue: 0x00000000
+    fields:
+      RXD:
+        description: "Rx data"
+        bitOffset: 0
+        bitWidth: 8
+
+_include:
+  - ../../../../peripherals/cec/cec_v1_fields_common.yaml
+        

--- a/devices/common_patches/cec/registers/cec_v2_registers_common.yaml
+++ b/devices/common_patches/cec/registers/cec_v2_registers_common.yaml
@@ -2,6 +2,7 @@ _add:
   CR:
     description: "CEC control register"
     addressOffset: 0x00
+    access: read-write
     resetValue: 0x00000000
     fields:
       TXEOM:
@@ -20,6 +21,7 @@ _add:
   CFGR:
     description: "CEC configuration register"
     addressOffset: 0x04
+    access: read-write
     resetValue: 0x00000000
     fields:
       LSTN:
@@ -198,3 +200,6 @@ _add:
         description: "Rx byte received interrupt enable"
         bitOffset: 0
         bitWidth: 1
+
+_include:
+  - ../../../../peripherals/cec/cec_v2_fields_common.yaml

--- a/devices/common_patches/cec/registers/cec_v2_registers_common.yaml
+++ b/devices/common_patches/cec/registers/cec_v2_registers_common.yaml
@@ -1,0 +1,200 @@
+_add:
+  CR:
+    description: "CEC control register"
+    addressOffset: 0x00
+    resetValue: 0x00000000
+    fields:
+      TXEOM:
+        description: "Tx end of message"
+        bitOffset: 2
+        bitWidth: 1
+      TXSOM:
+        description: "Tx start of message"
+        bitOffset: 1
+        bitWidth: 1
+      CECEN:
+        description: "CEC enable"
+        bitOffset: 0
+        bitWidth: 1
+
+  CFGR:
+    description: "CEC configuration register"
+    addressOffset: 0x04
+    resetValue: 0x00000000
+    fields:
+      LSTN:
+        description: "Listen mode"
+        bitOffset: 31
+        bitWidth: 1
+      OAR:
+        description: "Own address configuration"
+        bitOffset: 16
+        bitWidth: 15
+      SFTOP:
+        description: "SFT option bit"
+        bitOffset: 8
+        bitWidth: 1
+      BRDNOGEN:
+        description: "Avoid error bit generation in broadcast"
+        bitOffset: 7
+        bitWidth: 1
+      LBPEGEN:
+        description: "Generate error bit on long bit period error"
+        bitOffset: 6
+        bitWidth: 1
+      BREGEN:
+        description: "Generate error bit on bit rising error"
+        bitOffset: 5
+        bitWidth: 1
+      BRESTP:
+        description: "Rx stop on bit rising error"
+        bitOffset: 4
+        bitWidth: 1
+      RXTOL:
+        description: "Rx tolerance"
+        bitOffset: 3
+        bitWidth: 1
+      SFT:
+        description: "Signal free time"
+        bitOffset: 0
+        bitWidth: 3
+
+  TXDR:
+    description: "CEC Tx data register"
+    addressOffset: 0x08
+    access: write-only
+    resetValue: 0x00000000
+    fields:
+      TXD:
+        description: "Tx data"
+        bitOffset: 0
+        bitWidth: 8
+
+  RXDR:
+    description: "CEC Rx data register"
+    addressOffset: 0x0C
+    access: read-only
+    resetValue: 0x00000000
+    fields:
+      RXD:
+        description: "Rx data"
+        bitOffset: 0
+        bitWidth: 8
+
+  ISR:
+    description: "CEC interrupt and status register"
+    addressOffset: 0x10
+    access: read-write
+    resetValue: 0x00000000
+    fields:
+      TXACKE:
+        description: "Tx missing acknowledge error"
+        bitOffset: 12
+        bitWidth: 1
+      TXERR:
+        description: "Tx error"
+        bitOffset: 11
+        bitWidth: 1
+      TXUDR:
+        description: "Tx buffer underrun flag"
+        bitOffset: 10
+        bitWidth: 1
+      TXEND:
+        description: "End of transmission flag"
+        bitOffset: 9
+        bitWidth: 1
+      TXBR:
+        description: "Tx byte request flag"
+        bitOffset: 8
+        bitWidth: 1
+      ARBLST:
+        description: "Arbitration lost flag"
+        bitOffset: 7
+        bitWidth: 1
+      RXACKE:
+        description: "Rx missing acknowledge error"
+        bitOffset: 6
+        bitWidth: 1
+      LBPE:
+        description: "Rx long bit period error"
+        bitOffset: 5
+        bitWidth: 1
+      SBPE:
+        description: "Rx short bit period error"
+        bitOffset: 4
+        bitWidth: 1
+      BRE:
+        description: "Rx bit rising error"
+        bitOffset: 3
+        bitWidth: 1
+      RXOVR:
+        description: "Rx overrun flag"
+        bitOffset: 2
+        bitWidth: 1
+      RXEND:
+        description: "Rx end of reception flag"
+        bitOffset: 1
+        bitWidth: 1
+      RXBR:
+        description: "Rx byte received flag"
+        bitOffset: 0
+        bitWidth: 1
+
+  IER:
+    description: "CEC interrupt enable register"
+    addressOffset: 0x14
+    access: read-write
+    resetValue: 0x00000000
+    fields:
+      TXACKIE:
+        description: "Tx missing acknowledge error interrupt enable"
+        bitOffset: 12
+        bitWidth: 1
+      TXERRIE:
+        description: "Tx error interrupt enable"
+        bitOffset: 11
+        bitWidth: 1
+      TXUDRIE:
+        description: "Tx underrun interrupt enable"
+        bitOffset: 10
+        bitWidth: 1
+      TXENDIE:
+        description: "Tx end of message interrupt enable"
+        bitOffset: 9
+        bitWidth: 1
+      TXBRIE:
+        description: "Tx byte request interrupt enable"
+        bitOffset: 8
+        bitWidth: 1
+      ARBLSTIE:
+        description: "Arbitration lost interrupt enable"
+        bitOffset: 7
+        bitWidth: 1
+      RXACKIE:
+        description: "Rx missing acknowledge error interrupt enable"
+        bitOffset: 6
+        bitWidth: 1
+      LBPEIE:
+        description: "Long bit period error interrupt enable"
+        bitOffset: 5
+        bitWidth: 1
+      SBPEIE:
+        description: "Short bit period error interrupt enable"
+        bitOffset: 4
+        bitWidth: 1
+      BREIE:
+        description: "Bit rising error interrupt enable"
+        bitOffset: 3
+        bitWidth: 1
+      RXOVRIE:
+        description: "Rx buffer overrun interrupt enable"
+        bitOffset: 2
+        bitWidth: 1
+      RXENDIE:
+        description: "Rx end of reception interrupt enable"
+        bitOffset: 1
+        bitWidth: 1
+      RXBRIE:
+        description: "Rx byte received interrupt enable"
+        bitOffset: 0
+        bitWidth: 1

--- a/devices/stm32f0x1.yaml
+++ b/devices/stm32f0x1.yaml
@@ -71,3 +71,4 @@ _include:
  - ../peripherals/tim/tim_ccm_v1.yaml
  - ./common_patches/2_nvic_prio_bits.yaml
  - ./common_patches/f0_crc_init_addr_fix.yaml
+ - common_patches/cec/cec_RM0091.yaml

--- a/devices/stm32f0x1.yaml
+++ b/devices/stm32f0x1.yaml
@@ -71,4 +71,5 @@ _include:
  - ../peripherals/tim/tim_ccm_v1.yaml
  - ./common_patches/2_nvic_prio_bits.yaml
  - ./common_patches/f0_crc_init_addr_fix.yaml
+ - common_patches/cec/cec_delete.yaml
  - common_patches/cec/cec_RM0091.yaml

--- a/devices/stm32f0x2.yaml
+++ b/devices/stm32f0x2.yaml
@@ -89,4 +89,5 @@ _include:
  - ../peripherals/tim/tim_ccm_v1.yaml
  - ./common_patches/2_nvic_prio_bits.yaml
  - ./common_patches/f0_crc_init_addr_fix.yaml
+ - common_patches/cec/cec_delete.yaml
  - common_patches/cec/cec_RM0091.yaml

--- a/devices/stm32f0x2.yaml
+++ b/devices/stm32f0x2.yaml
@@ -89,3 +89,4 @@ _include:
  - ../peripherals/tim/tim_ccm_v1.yaml
  - ./common_patches/2_nvic_prio_bits.yaml
  - ./common_patches/f0_crc_init_addr_fix.yaml
+ - common_patches/cec/cec_RM0091.yaml

--- a/devices/stm32f0x8.yaml
+++ b/devices/stm32f0x8.yaml
@@ -64,4 +64,5 @@ _include:
  - ../peripherals/tim/tim_ccm_v1.yaml
  - ./common_patches/2_nvic_prio_bits.yaml
  - ./common_patches/f0_crc_init_addr_fix.yaml
+ - common_patches/cec/cec_delete.yaml
  - common_patches/cec/cec_RM0091.yaml

--- a/devices/stm32f0x8.yaml
+++ b/devices/stm32f0x8.yaml
@@ -64,3 +64,4 @@ _include:
  - ../peripherals/tim/tim_ccm_v1.yaml
  - ./common_patches/2_nvic_prio_bits.yaml
  - ./common_patches/f0_crc_init_addr_fix.yaml
+ - common_patches/cec/cec_RM0091.yaml

--- a/devices/stm32f100.yaml
+++ b/devices/stm32f100.yaml
@@ -46,3 +46,4 @@ _include:
  - common_patches/dbgmcu_rename.yaml
  - ../peripherals/tim/tim_ccm_v1.yaml
  - ../peripherals/adc/adc_f1_common.yaml
+ - common_patches/cec/cec_RM0041.yaml

--- a/devices/stm32f100.yaml
+++ b/devices/stm32f100.yaml
@@ -46,4 +46,5 @@ _include:
  - common_patches/dbgmcu_rename.yaml
  - ../peripherals/tim/tim_ccm_v1.yaml
  - ../peripherals/adc/adc_f1_common.yaml
+ - common_patches/cec/cec_delete.yaml
  - common_patches/cec/cec_RM0041.yaml

--- a/devices/stm32f301.yaml
+++ b/devices/stm32f301.yaml
@@ -176,3 +176,4 @@ _include:
  - common_patches/rtc/rtc_cr.yaml
  - ../peripherals/rtc/rtc_common.yaml
  - ../peripherals/rtc/rtc_f3.yaml
+ - common_patches/cec/cec_delete.yaml

--- a/devices/stm32f373.yaml
+++ b/devices/stm32f373.yaml
@@ -186,4 +186,5 @@ _include:
  - common_patches/rtc/rtc_cr.yaml
  - ../peripherals/rtc/rtc_common.yaml
  - ../peripherals/rtc/rtc_f3.yaml
+ - common_patches/cec/cec_delete.yaml
  - common_patches/cec/cec_RM0313.yaml

--- a/devices/stm32f373.yaml
+++ b/devices/stm32f373.yaml
@@ -186,3 +186,4 @@ _include:
  - common_patches/rtc/rtc_cr.yaml
  - ../peripherals/rtc/rtc_common.yaml
  - ../peripherals/rtc/rtc_f3.yaml
+ - common_patches/cec/cec_RM0313.yaml

--- a/devices/stm32f446.yaml
+++ b/devices/stm32f446.yaml
@@ -573,3 +573,4 @@ _include:
  - common_patches/sdio_f446.yaml
  - ../peripherals/sdio/sdio.yaml
  - ../peripherals/sdio/sdio_f4_common.yaml
+ - common_patches/cec/cec_RM0390.yaml

--- a/devices/stm32f446.yaml
+++ b/devices/stm32f446.yaml
@@ -54,6 +54,12 @@ RCC:
         bitOffset: 28
         bitWidth: 1
         access: read-write
+  APB1RSTR:
+    _add:
+      CECRST:
+        description: CEC reset
+        bitOffset: 27
+        bitWidth: 1
   APB1ENR:
     _modify:
       CEC:

--- a/devices/stm32f446.yaml
+++ b/devices/stm32f446.yaml
@@ -573,4 +573,5 @@ _include:
  - common_patches/sdio_f446.yaml
  - ../peripherals/sdio/sdio.yaml
  - ../peripherals/sdio/sdio_f4_common.yaml
+ - common_patches/cec/cec_delete.yaml
  - common_patches/cec/cec_RM0390.yaml

--- a/devices/stm32f730.yaml
+++ b/devices/stm32f730.yaml
@@ -12,6 +12,11 @@ _modify:
   C_ADC:
     name: ADC_Common
 
+RCC:
+  APB1RSTR:
+    _delete:
+      - CECRST
+
 _include:
  - common_patches/f7x23_pllsai.yaml
  - common_patches/dma_fcr_wo.yaml

--- a/devices/stm32f745.yaml
+++ b/devices/stm32f745.yaml
@@ -174,4 +174,5 @@ _include:
  - ../peripherals/dma/dma2d_v1.yaml
  - common_patches/rtc/rtc_cr.yaml
  - ../peripherals/rtc/rtc_common.yaml
+ - common_patches/cec/cec_delete.yaml
  - common_patches/cec/cec_RM0385.yaml

--- a/devices/stm32f745.yaml
+++ b/devices/stm32f745.yaml
@@ -174,3 +174,4 @@ _include:
  - ../peripherals/dma/dma2d_v1.yaml
  - common_patches/rtc/rtc_cr.yaml
  - ../peripherals/rtc/rtc_common.yaml
+ - common_patches/cec/cec_RM0385.yaml

--- a/devices/stm32f750.yaml
+++ b/devices/stm32f750.yaml
@@ -104,4 +104,5 @@ _include:
  - common_patches/ltdc/ltdc.yaml
  - common_patches/ltdc/f4_f7_ltdc_bccr.yaml
  - ../peripherals/ltdc/ltdc.yaml
+ - common_patches/cec/cec_delete.yaml
  - common_patches/cec/cec_RM0385.yaml

--- a/devices/stm32f750.yaml
+++ b/devices/stm32f750.yaml
@@ -104,3 +104,4 @@ _include:
  - common_patches/ltdc/ltdc.yaml
  - common_patches/ltdc/f4_f7_ltdc_bccr.yaml
  - ../peripherals/ltdc/ltdc.yaml
+ - common_patches/cec/cec_RM0385.yaml

--- a/devices/stm32f765.yaml
+++ b/devices/stm32f765.yaml
@@ -184,4 +184,5 @@ _include:
  - ../peripherals/dma/dma2d_v1.yaml
  - common_patches/rtc/rtc_cr.yaml
  - ../peripherals/rtc/rtc_common.yaml
+ - common_patches/cec/cec_delete.yaml
  - common_patches/cec/cec_RM0410.yaml

--- a/devices/stm32f765.yaml
+++ b/devices/stm32f765.yaml
@@ -184,3 +184,4 @@ _include:
  - ../peripherals/dma/dma2d_v1.yaml
  - common_patches/rtc/rtc_cr.yaml
  - ../peripherals/rtc/rtc_common.yaml
+ - common_patches/cec/cec_RM0410.yaml

--- a/devices/stm32f7x2.yaml
+++ b/devices/stm32f7x2.yaml
@@ -12,6 +12,11 @@ _modify:
   C_ADC:
     name: ADC_Common
 
+RCC:
+  APB1RSTR:
+    _delete:
+      - CECRST
+
 _include:
  - common_patches/f7x23_pllsai.yaml
  - common_patches/dma_fcr_wo.yaml

--- a/devices/stm32f7x3.yaml
+++ b/devices/stm32f7x3.yaml
@@ -12,6 +12,11 @@ _modify:
   C_ADC:
     name: ADC_Common
 
+RCC:
+  APB1RSTR:
+    _delete:
+      - CECRST
+
 # Registers name are prefixed with WWDG_. Use common names.
 WWDG:
   _modify:

--- a/devices/stm32f7x6.yaml
+++ b/devices/stm32f7x6.yaml
@@ -162,3 +162,4 @@ _include:
  - ../peripherals/dma/dma2d_v1.yaml
  - common_patches/rtc/rtc_cr.yaml
  - ../peripherals/rtc/rtc_common.yaml
+ - common_patches/cec/cec_RM0385.yaml

--- a/devices/stm32f7x6.yaml
+++ b/devices/stm32f7x6.yaml
@@ -162,4 +162,5 @@ _include:
  - ../peripherals/dma/dma2d_v1.yaml
  - common_patches/rtc/rtc_cr.yaml
  - ../peripherals/rtc/rtc_common.yaml
+ - common_patches/cec/cec_delete.yaml
  - common_patches/cec/cec_RM0385.yaml

--- a/devices/stm32f7x7.yaml
+++ b/devices/stm32f7x7.yaml
@@ -332,3 +332,4 @@ _include:
  - ../peripherals/dma/dma2d_v1.yaml
  - common_patches/rtc/rtc_cr.yaml
  - ../peripherals/rtc/rtc_common.yaml
+ - common_patches/cec/cec_RM0410.yaml

--- a/devices/stm32f7x7.yaml
+++ b/devices/stm32f7x7.yaml
@@ -332,4 +332,5 @@ _include:
  - ../peripherals/dma/dma2d_v1.yaml
  - common_patches/rtc/rtc_cr.yaml
  - ../peripherals/rtc/rtc_common.yaml
+ - common_patches/cec/cec_delete.yaml
  - common_patches/cec/cec_RM0410.yaml

--- a/devices/stm32f7x9.yaml
+++ b/devices/stm32f7x9.yaml
@@ -327,3 +327,4 @@ _include:
  - ../peripherals/dma/dma2d_v1.yaml
  - common_patches/rtc/rtc_cr.yaml
  - ../peripherals/rtc/rtc_common.yaml
+ - common_patches/cec/cec_RM0410.yaml

--- a/devices/stm32f7x9.yaml
+++ b/devices/stm32f7x9.yaml
@@ -327,4 +327,5 @@ _include:
  - ../peripherals/dma/dma2d_v1.yaml
  - common_patches/rtc/rtc_cr.yaml
  - ../peripherals/rtc/rtc_common.yaml
+ - common_patches/cec/cec_delete.yaml
  - common_patches/cec/cec_RM0410.yaml

--- a/devices/stm32g071.yaml
+++ b/devices/stm32g071.yaml
@@ -42,4 +42,5 @@ _include:
  - ../peripherals/exti/exti_g0.yaml
  - ./common_patches/g0_adc_typo.yaml
  - ./common_patches/g0_dma_7ch.yaml
+ - common_patches/cec/cec_delete.yaml
  - common_patches/cec/cec_RM0444.yaml

--- a/devices/stm32g071.yaml
+++ b/devices/stm32g071.yaml
@@ -42,3 +42,4 @@ _include:
  - ../peripherals/exti/exti_g0.yaml
  - ./common_patches/g0_adc_typo.yaml
  - ./common_patches/g0_dma_7ch.yaml
+ - common_patches/cec/cec_RM0444.yaml

--- a/devices/stm32g081.yaml
+++ b/devices/stm32g081.yaml
@@ -15,3 +15,4 @@ _include:
  - ../peripherals/exti/exti_g0.yaml
  - ./common_patches/g0_adc_typo.yaml
  - ./common_patches/g0_dma_7ch.yaml
+ - common_patches/cec/cec_RM0444.yaml

--- a/devices/stm32g081.yaml
+++ b/devices/stm32g081.yaml
@@ -15,4 +15,5 @@ _include:
  - ../peripherals/exti/exti_g0.yaml
  - ./common_patches/g0_adc_typo.yaml
  - ./common_patches/g0_dma_7ch.yaml
+ - common_patches/cec/cec_delete.yaml
  - common_patches/cec/cec_RM0444.yaml

--- a/devices/stm32h743.yaml
+++ b/devices/stm32h743.yaml
@@ -76,3 +76,4 @@ _include:
  - ../peripherals/rtc/rtc_h7.yaml
  - common_patches/h7_crc_addr_fix.yaml
  - common_patches/h7_wwdg.yaml
+ - common_patches/cec/cec_RM0433.yaml

--- a/devices/stm32h743.yaml
+++ b/devices/stm32h743.yaml
@@ -76,4 +76,5 @@ _include:
  - ../peripherals/rtc/rtc_h7.yaml
  - common_patches/h7_crc_addr_fix.yaml
  - common_patches/h7_wwdg.yaml
+ - common_patches/cec/cec_delete.yaml
  - common_patches/cec/cec_RM0433.yaml

--- a/devices/stm32h743v.yaml
+++ b/devices/stm32h743v.yaml
@@ -78,3 +78,4 @@ _include:
  - ../peripherals/rtc/rtc_h7.yaml
  - common_patches/h7_crc_addr_fix.yaml
  - common_patches/h7_wwdg.yaml
+ - common_patches/cec/cec_RM0433.yaml

--- a/devices/stm32h743v.yaml
+++ b/devices/stm32h743v.yaml
@@ -78,4 +78,5 @@ _include:
  - ../peripherals/rtc/rtc_h7.yaml
  - common_patches/h7_crc_addr_fix.yaml
  - common_patches/h7_wwdg.yaml
+ - common_patches/cec/cec_delete.yaml
  - common_patches/cec/cec_RM0433.yaml

--- a/devices/stm32h747cm4.yaml
+++ b/devices/stm32h747cm4.yaml
@@ -90,3 +90,4 @@ _include:
  - ../peripherals/sai/sai.yaml
  - common_patches/h7_crc_addr_fix.yaml
  - common_patches/h7_wwdg.yaml
+ - common_patches/cec/cec_RM0399.yaml

--- a/devices/stm32h747cm4.yaml
+++ b/devices/stm32h747cm4.yaml
@@ -90,4 +90,5 @@ _include:
  - ../peripherals/sai/sai.yaml
  - common_patches/h7_crc_addr_fix.yaml
  - common_patches/h7_wwdg.yaml
+ - common_patches/cec/cec_delete.yaml
  - common_patches/cec/cec_RM0399.yaml

--- a/devices/stm32h747cm7.yaml
+++ b/devices/stm32h747cm7.yaml
@@ -94,4 +94,5 @@ _include:
  - ../peripherals/rtc/rtc_h7.yaml
  - common_patches/h7_crc_addr_fix.yaml
  - common_patches/h7_wwdg.yaml
+ - common_patches/cec/cec_delete.yaml
  - common_patches/cec/cec_RM0399.yaml

--- a/devices/stm32h747cm7.yaml
+++ b/devices/stm32h747cm7.yaml
@@ -94,3 +94,4 @@ _include:
  - ../peripherals/rtc/rtc_h7.yaml
  - common_patches/h7_crc_addr_fix.yaml
  - common_patches/h7_wwdg.yaml
+ - common_patches/cec/cec_RM0399.yaml

--- a/devices/stm32h753.yaml
+++ b/devices/stm32h753.yaml
@@ -85,4 +85,5 @@ _include:
  - ../peripherals/rtc/rtc_h7.yaml
  - common_patches/h7_crc_addr_fix.yaml
  - common_patches/h7_wwdg.yaml
+ - common_patches/cec/cec_delete.yaml
  - common_patches/cec/cec_RM0433.yaml

--- a/devices/stm32h753.yaml
+++ b/devices/stm32h753.yaml
@@ -85,3 +85,4 @@ _include:
  - ../peripherals/rtc/rtc_h7.yaml
  - common_patches/h7_crc_addr_fix.yaml
  - common_patches/h7_wwdg.yaml
+ - common_patches/cec/cec_RM0433.yaml

--- a/devices/stm32h753v.yaml
+++ b/devices/stm32h753v.yaml
@@ -88,3 +88,4 @@ _include:
  - ../peripherals/rtc/rtc_h7.yaml
  - common_patches/h7_crc_addr_fix.yaml
  - common_patches/h7_wwdg.yaml
+ - common_patches/cec/cec_RM0433.yaml

--- a/devices/stm32h753v.yaml
+++ b/devices/stm32h753v.yaml
@@ -88,4 +88,5 @@ _include:
  - ../peripherals/rtc/rtc_h7.yaml
  - common_patches/h7_crc_addr_fix.yaml
  - common_patches/h7_wwdg.yaml
+ - common_patches/cec/cec_delete.yaml
  - common_patches/cec/cec_RM0433.yaml

--- a/devices/stm32h7b3.yaml
+++ b/devices/stm32h7b3.yaml
@@ -170,4 +170,5 @@ _include:
  - ../peripherals/rtc/rtc_h7.yaml
  - common_patches/h7_crc_addr_fix.yaml
  - common_patches/h7_wwdg.yaml
+ - common_patches/cec/cec_delete.yaml
  - common_patches/cec/cec_RM0455.yaml

--- a/devices/stm32h7b3.yaml
+++ b/devices/stm32h7b3.yaml
@@ -170,3 +170,4 @@ _include:
  - ../peripherals/rtc/rtc_h7.yaml
  - common_patches/h7_crc_addr_fix.yaml
  - common_patches/h7_wwdg.yaml
+ - common_patches/cec/cec_RM0455.yaml

--- a/devices/stm32mp157.yaml
+++ b/devices/stm32mp157.yaml
@@ -12,3 +12,6 @@ _modify:
     fpuPresent: "true"
     nvicPrioBits: 4
     vendorSystickConfig: "false"
+
+_include:
+ - common_patches/cec/cec_RM0436.yaml

--- a/devices/stm32mp157.yaml
+++ b/devices/stm32mp157.yaml
@@ -14,4 +14,5 @@ _modify:
     vendorSystickConfig: "false"
 
 _include:
+ - common_patches/cec/cec_delete.yaml
  - common_patches/cec/cec_RM0436.yaml

--- a/peripherals/cec/cec_v1_fields_common.yaml
+++ b/peripherals/cec/cec_v1_fields_common.yaml
@@ -1,0 +1,51 @@
+CFGR:
+  BPEM:
+    Standard: [0, "Standard mode"]
+    Flexible: [1, "Flexible bit period mode"]
+  BTEM:
+    Standard: [0, "Standard mode"]
+    ErrorFree: [1, "Bit timing error-free mode"]
+  IE:
+    Disabled: [0, "CEC interrupt is disabled"]
+    Enabled: [1, "CEC interrupt is enabled"]
+  PE:
+    Disabled: [0, "CEC is disabled"]
+    Enabled: [1, "CEC is enabled"]
+
+OAR:
+  OA: [0, 15]
+
+PRES:
+  PRESC: [0, 16383]
+
+CSR:
+  RBTF:
+    _write:
+      Clear: [0, "Clear Rx byte/block transfer finished flag"]
+  RERR:
+    _write:
+      Clear: [0, "Clear Rx error"]
+  REOM:
+    _write:
+      Clear: [0, "Clear Rx end of message flag"]
+  RSOM:
+    _write:
+      Clear: [0, "Clear Rx start of message flag"]
+  TBTRF:
+    _write:
+      Clear: [0, "Clear Tx byte transfer request or block transfer finished flag"]
+  TERR:
+    _write:
+      Clear: [0, "Clear Tx error"]
+  TEOM:
+    NoEOM: [0, "Tx data byte is transmitted without EOM bit"]
+    EOM: [1, "Tx data byte is transmitted with EOM bit"]
+  TSOM:
+    _read:
+      NoTx: [0, "No CEC transmission is ongoing"]
+      Tx: [1, "CEC transmission requested"]
+    _write:
+      Tx: [1, "Request CEC transmission"]
+
+TXD:
+  TXD: [0, 255]

--- a/peripherals/cec/cec_v2_fields_common.yaml
+++ b/peripherals/cec/cec_v2_fields_common.yaml
@@ -1,0 +1,134 @@
+CR:
+  TXEOM:
+    _read:
+      EOM0: [0, "TXDR data byte is transmitted with EOM=0"]
+      EOM1: [1, "TXDR data byte is transmitted with EOM=1"]
+    _write:
+      EOM1: [1, "Transmit TXDR data byte with EOM=1"]
+  TXSOM:
+    _read:
+      NoTx: [0, "No CEC transmission is ongoing"]
+      Tx: [1, "CEC transmission commanded"]
+    _write:
+      Tx: [1, "Set CEC transmission command"]
+  CECEN:
+    Disabled: [0, "CEC is disabled"]
+    Enabled: [1, "CEC is enabled"]
+
+CFGR:
+  LSTN:
+    Ignore: [0, "CEC peripheral only receives messages addressed to its own address and ignores others"]
+    Listen: [1, "CEC peripheral receives all messages and acknowledges messages addressed to its own address"]
+  OAR: [0, 32767]
+  SFTOP:
+    Manual: [0, "SFT timer starts when TXSOM is set by software"]
+    Auto: [1, "SFT timer starts automatically at the end of message transmission/reception"]
+  BRDNOGEN:
+    GenErr: [0, "BRE detection or LBPE detection on a broadcast message generates an error bit on the CEC line"]
+    NoErr: [1, "Error detection on a broadcast message does not generate an error bit on the CEC line"]
+  LBPEGEN:
+    NoErr: [0, "LBPE detection does not generate an error bit on the CEC line"]
+    GenErr: [1, "LBPE detection generates an error bit on the CEC line"]
+  BREGEN:
+    NoErr: [0, "BRE detection does not generate an error bit on the CEC line"]
+    GenErr: [1, "BRE detection generates an error bit on the CEC line if BRESTP is set"]
+  BRESTP:
+    NoStop: [0, "BRE detection does not stop reception of the CEC message"]
+    ErrStop: [1, "BRE detection stops message reception"]
+  RXTOL:
+    Standard: [0, "Standard Rx tolerance margin"]
+    Extended: [1, "Extended Rx tolerance margin"]
+  SFT:
+    WaitHist: [0, "Number of nominal data bit periods waited is determined by the transmission history"]
+    Wait05: [1, "Wait 0.5 nominal data bit periods"]
+    Wait15: [1, "Wait 1.5 nominal data bit periods"]
+    Wait25: [1, "Wait 2.5 nominal data bit periods"]
+    Wait35: [1, "Wait 3.5 nominal data bit periods"]
+    Wait45: [1, "Wait 4.5 nominal data bit periods"]
+    Wait55: [1, "Wait 5.5 nominal data bit periods"]
+    Wait65: [1, "Wait 6.5 nominal data bit periods"]
+
+TXDR:
+  TXD: [0, 255]
+
+ISR:
+  TXACKE:
+    _write:
+      Clear: [1, "Clear Tx missing acknowledge error"]
+  TXERR:
+    _write:
+      Clear: [1, "Clear Tx error"]
+  TXUDR:
+    _write:
+      Clear: [1, "Clear Tx buffer underrun flag"]
+  TXEND:
+    _write:
+      Clear: [1, "Clear Tx end of transmission flag"]
+  TXBR:
+    _write:
+      Clear: [1, "Clear Tx byte request flag"]
+  ARBLST:
+    _write:
+      Clear: [1, "Clear arbitration lost flag"]
+  RXACKE:
+    _write:
+      Clear: [1, "Clear Rx missing acknowledge error"]
+  LBPE:
+    _write:
+      Clear: [1, "Clear Rx long bit period error"]
+  SBPE:
+    _write:
+      Clear: [1, "Clear Rx short bit period error"]
+  BRE:
+    _write:
+      Clear: [1, "Clear Rx bit rising error"]
+  RXOVR:
+    _write:
+      Clear: [1, "Clear Rx overrun flag"]
+  RXEND:
+    _write:
+      Clear: [1, "Clear Rx end of reception flag"]
+  RXBR:
+    _write:
+      Clear: [1, "Clear Rx byte received flag"]
+
+IER:
+  TXACKIE:
+    Disabled: [0, "Tx missing acknowledge error interrupt is disabled"]
+    Enabled: [1, "Tx missing acknowledge error interrupt is enabled"]
+  TXERRIE:
+    Disabled: [0, "Tx error interrupt is disabled"]
+    Enabled: [1, "Tx error interrupt is enabled"]
+  TXUDRIE:
+    Disabled: [0, "Tx underrun interrupt is disabled"]
+    Enabled: [1, "Tx underrun interrupt is enabled"]
+  TXENDIE:
+    Disabled: [0, "Tx end of message interrupt is disabled"]
+    Enabled: [1, "Tx end of message interrupt is enabled"]
+  TXBRIE:
+    Disabled: [0, "Tx byte request interrupt is disabled"]
+    Enabled: [1, "Tx byte request interrupt is enabled"]
+  ARBLSTIE:
+    Disabled: [0, "Arbitration lost interrupt is disabled"]
+    Enabled: [1, "Arbitration lost interrupt is enabled"]
+  RXACKIE:
+    Disabled: [0, "Rx missing acknowledge error interrupt is disabled"]
+    Enabled: [1, "Rx missing acknowledge error interrupt is enabled"]
+  LBPEIE:
+    Disabled: [0, "Long bit period error interrupt is disabled"]
+    Enabled: [1, "Long bit period error interrupt is enabled"]
+  SBPEIE:
+    Disabled: [0, "Short period error interrupt is disabled"]
+    Enabled: [1, "Short period error interrupt is enabled"]
+  BREIE:
+    Disabled: [0, "Bit rising error interrupt is disabled"]
+    Enabled: [1, "Bit rising error interrupt is enabled"]
+  RXOVRIE:
+    Disabled: [0, "Rx buffer overrun interrupt is disabled"]
+    Enabled: [1, "Rx buffer overrun interrupt is enabled"]
+  RXENDIE:
+    Disabled: [0, "Rx end of reception interrupt is disabled"]
+    Enabled: [1, "Rx end of reception interrupt is enabled"]
+  RXBRIE:
+    Disabled: [0, "Rx byte received interrupt is disabled"]
+    Enabled: [1, "Rx byte received interrupt is enabled"]

--- a/peripherals/cec/cec_v2_fields_common.yaml
+++ b/peripherals/cec/cec_v2_fields_common.yaml
@@ -8,9 +8,9 @@ CR:
   TXSOM:
     _read:
       NoTx: [0, "No CEC transmission is ongoing"]
-      Tx: [1, "CEC transmission commanded"]
+      Tx: [1, "CEC transmission requested"]
     _write:
-      Tx: [1, "Set CEC transmission command"]
+      Tx: [1, "Request CEC transmission"]
   CECEN:
     Disabled: [0, "CEC is disabled"]
     Enabled: [1, "CEC is enabled"]

--- a/peripherals/cec/cec_v2_fields_common.yaml
+++ b/peripherals/cec/cec_v2_fields_common.yaml
@@ -41,12 +41,12 @@ CFGR:
   SFT:
     WaitHist: [0, "Number of nominal data bit periods waited is determined by the transmission history"]
     Wait05: [1, "Wait 0.5 nominal data bit periods"]
-    Wait15: [1, "Wait 1.5 nominal data bit periods"]
-    Wait25: [1, "Wait 2.5 nominal data bit periods"]
-    Wait35: [1, "Wait 3.5 nominal data bit periods"]
-    Wait45: [1, "Wait 4.5 nominal data bit periods"]
-    Wait55: [1, "Wait 5.5 nominal data bit periods"]
-    Wait65: [1, "Wait 6.5 nominal data bit periods"]
+    Wait15: [2, "Wait 1.5 nominal data bit periods"]
+    Wait25: [3, "Wait 2.5 nominal data bit periods"]
+    Wait35: [4, "Wait 3.5 nominal data bit periods"]
+    Wait45: [5, "Wait 4.5 nominal data bit periods"]
+    Wait55: [6, "Wait 5.5 nominal data bit periods"]
+    Wait65: [7, "Wait 6.5 nominal data bit periods"]
 
 TXDR:
   TXD: [0, 255]


### PR DESCRIPTION
This PR adds comprehensive CEC support for all devices with CEC IP and serves as a proposal for an RM-based/peripheral-based patch approach that can coexist with the current patching methodologies. This method is conducive to decreased dependence on SVD files (like stm32-rs/meta#4 proposes) and faster support for new devices in the future (#477 and #504). CEC support is added for the following RMs/devices (including devices that do not yet have a patch file and/or SVD file):

- RM0041: F100
- RM0091: F042, F048, F051, F058, F071, F072, F078, F091, F098
- RM0313: F373, F378
- RM0385: F745, F746, F750, F756
- RM0390: F446
- RM0399: H745, H747, H755, H757
- RM0410: F765, F767, F769, F777, F778, F779
- RM0433: H742, H743, H750, H753
- RM0436: MP157
- RM0441: MP151
- RM0442: MP153
- RM0444: G071, G081
- RM0455: H7A3, H7B0, H7B3
- RM0468: H723, H725, H730, H733, H735

The goal of this approach is to create a self-contained definition of the CEC peripheral that can replace the sometimes-erroneous SVD definition and unify the register/field descriptions for all SVDs. The basic idea is that there is a unique YAML file in common_patches/cec for each reference manual that creates a new CEC peripheral to match that RM's description. The register and field definitions are imported from other YAML files that define the IP common to different RMs. A separate cec_delete.yaml file removes the original SVD's CEC definition. Some SVDs have a CEC definition when the device itself doesn't actually have CEC IP, so the separate delete file allows easy removal. If stm32-rs is no longer dependent on SVD files at some point in the future, then the delete file can just go away. Some code duplication could be reduced with new features in svdtools, but I haven't looked at this in-depth yet.

One aspect that doesn't really fit into this peripheral-based approach is the peripheral reset and enable fields in the RCC registers. Most SVDs already had them, but F446 needed CECRST added. F730, F7x2, and F7x3 needed CECRST removed. These were just done in the top device YAML file in the absence of a better idea.

The CEC peripheral is pretty straightforward with only two IP versions (v1 for F100 and v2 for all others), so some of the design decisions aren't applicable here but make more sense for more complicated peripherals (like the DFSDM, which I'm also working on).

I don't have a use case for the CEC or an easy way to test it, so I can't speak for the accuracy of this patch with respect to the actual silicon. However, I've reviewed the RMs and mmap diffs very thoroughly and am pretty confident in the accuracy of this patch. There are some notable differences that show up in the mmap diffs besides basic name and description changes:

- stm32f0x1: The original SVD's CFGR register is messed up
- stm32f0x2: Same
- stm32f0x8: Same
- stm32f301: Completely removed the CEC peripheral
- stm32f373: Same as f0xx above
- stm32f446: The original SVD is missing the CEC interrupt and CECRST
- stm32f730: Removed CECRST
- stm32f7x2: Same
- stm32f7x3: Same

I'd appreciate any feedback or suggestions for improvement on this approach, as well as any errors that I missed (or added). Absent any problems, this should be ready to merge.
