### PR TITLE
Add stm32wb to nightly releases

### DIFF
--- a/.github/workflows/nightlies.yaml
+++ b/.github/workflows/nightlies.yaml
@@ -64,7 +64,7 @@ jobs:
           cd stm32-rs
           COMMIT=$(git rev-parse HEAD)
           make -j2 form
-          mv stm32{f,g,h,l,mp,wl}* ../nightly
+          mv stm32{f,g,h,l,mp,wl,wb}* ../nightly
           cp .github/workflows/README-nightlies.md ../nightly/README.md
           cd ../nightly
           git init


### PR DESCRIPTION
Seems to have been left out of #467, this adds the stm32wb crate to the nightlies repo.