### PR TITLE
h7: LTDC field definitions apply for stm32h747cm7 too

### DIFF
--- a/devices/stm32h747cm7.yaml
+++ b/devices/stm32h747cm7.yaml
@@ -64,6 +64,7 @@ _include:
  - ../peripherals/dma/dma2d_v2.yaml
  - ../peripherals/gpio/gpio_v2.yaml
  - ../peripherals/lptim/lptim_v1.yaml
+ - ../peripherals/ltdc/ltdc.yaml
  - ../peripherals/rcc/rcc_h7.yaml
  - ../peripherals/rcc/rcc_h7_revision_v.yaml
  - ../peripherals/rng/rng_v1.yaml


### PR DESCRIPTION
Not sure why they were missing