### PR TITLE
Fix bit shift in AHB1 register for CRC enable/reset/sleep-mode bits, STM32L4x3.svd patch 

### DIFF
--- a/devices/stm32l4x3.yaml
+++ b/devices/stm32l4x3.yaml
@@ -12,19 +12,19 @@ RCC:
         name: USBFSEN
         description: USB FS clock enable
         
-    # SVD incorrectly shifts CRCEN/CRCRST/CRCSMEN  11 bits instead of 12
-    AHB1ENR:
-        _modify:
-            CRCEN:
-                bitOffset: 12
-    AHB1RSTR:
-        _modify:
-            CRCRST:
-                bitOffset: 12
-    AHB1SMENR:
-        _modify:
-            CRCSMEN:
-                bitOffset: 12
+  # SVD incorrectly shifts CRCEN/CRCRST/CRCSMEN  11 bits instead of 12
+  AHB1ENR:
+    _modify:
+      CRCEN:
+        bitOffset: 12
+  AHB1RSTR:
+    _modify:
+      CRCRST:
+        bitOffset: 12
+  AHB1SMENR:
+    _modify:
+      CRCSMEN:
+        bitOffset: 12
 
 _modify:
   # The SVD calls ADC1 ADC.

--- a/devices/stm32l4x3.yaml
+++ b/devices/stm32l4x3.yaml
@@ -12,8 +12,7 @@ RCC:
         name: USBFSEN
         description: USB FS clock enable
         
-# SVD incorrectly shifts CRCEN/CRCRST/CRCSMEN  11 bits instead of 12
-RCC:
+    # SVD incorrectly shifts CRCEN/CRCRST/CRCSMEN  11 bits instead of 12
     AHB1ENR:
         _modify:
             CRCEN:

--- a/devices/stm32l4x3.yaml
+++ b/devices/stm32l4x3.yaml
@@ -11,6 +11,21 @@ RCC:
       USBF:
         name: USBFSEN
         description: USB FS clock enable
+        
+# SVD incorrectly shifts CRCEN/CRCRST/CRCSMEN  11 bits instead of 12
+RCC:
+    AHB1ENR:
+        _modify:
+            CRCEN:
+                bitOffset: 12
+    AHB1RSTR:
+        _modify:
+            CRCRST:
+                bitOffset: 12
+    AHB1SMENR:
+        _modify:
+            CRCSMEN:
+                bitOffset: 12
 
 _modify:
   # The SVD calls ADC1 ADC.


### PR DESCRIPTION
Discovered when attempting to enable CRC hardware module.
```rust
    let crc_guy = dp.CRC.constrain(&mut rcc.ahb1);
```
CRC output would be 0. Found with debugger that the enable bit was not
being set in rcc.ahb1 power enable register. Other peripherals in the
register (DMA1/2) could be enabled and the remaining bits in the
register are not writable.

Tested against the following code provided by STM32CubeMX, in which the
CRC module is functional.

## Sources 
 - CMSIS/Device/ST/STM32L4xx/Include/stm32l433xx.h
 - STM32L43xxx... Reference Manual RM0394 Rev 4. Sections 6.4.9, 6.4.15, 6.4.21


 - Bug Verified/Fixed/Tested on STM32L433 (Nucleo-L433RC-P)