### PR TITLE
Fix TIM15 CCR2 address offset for STM32L5xx

### DIFF
--- a/devices/stm32l552.yaml
+++ b/devices/stm32l552.yaml
@@ -58,6 +58,11 @@ TIM7:
         description: TIM7 global interrupt
         value: 50
 
+TIM15:
+  _modify:
+    CCR2:
+      addressOffset: 0x38
+
 _include:
  - common_patches/dma_interrupt_names.yaml
  - ../peripherals/gpio/gpio_l5.yaml

--- a/devices/stm32l562.yaml
+++ b/devices/stm32l562.yaml
@@ -10,6 +10,11 @@ _modify:
     nvicPrioBits: 3
     vendorSystickConfig: "false"
 
+TIM15:
+  _modify:
+    CCR2:
+      addressOffset: 0x38
+
 _include:
  - common_patches/dma_interrupt_names.yaml
  - ../peripherals/gpio/gpio_l5.yaml


### PR DESCRIPTION
This PR closes #511. TIM15 on L552 and L562 are the only timers affected by this issue.