### PR TITLE
Fix ADC SQR1.L name and description for L4xx and WB55

### DIFF
--- a/devices/common_patches/l4_adc_sqr1.yaml
+++ b/devices/common_patches/l4_adc_sqr1.yaml
@@ -1,0 +1,8 @@
+# Rename the L3 field to L to match RM0394
+
+"ADC?":
+  SQR1:
+    _modify:
+      L3:
+        name: L
+        description: Regular channel sequence length

--- a/devices/stm32l4x1.yaml
+++ b/devices/stm32l4x1.yaml
@@ -97,3 +97,4 @@ _include:
  - ../peripherals/sai/sai.yaml
  - ./common_patches/l4_adc_common.yaml
  - ./common_patches/l4_adc_smpr.yaml
+ - ./common_patches/l4_adc_sqr1.yaml

--- a/devices/stm32l4x2.yaml
+++ b/devices/stm32l4x2.yaml
@@ -129,3 +129,4 @@ _include:
  - ../peripherals/sai/sai.yaml
  - ./common_patches/l4_adc_common.yaml
  - ./common_patches/l4_adc_smpr.yaml
+ - ./common_patches/l4_adc_sqr1.yaml

--- a/devices/stm32l4x3.yaml
+++ b/devices/stm32l4x3.yaml
@@ -75,3 +75,4 @@ _include:
  - common_patches/dma_interrupt_names.yaml
  - ./common_patches/l4_adc_common.yaml
  - ./common_patches/l4_adc_smpr.yaml
+ - ./common_patches/l4_adc_sqr1.yaml

--- a/devices/stm32l4x5.yaml
+++ b/devices/stm32l4x5.yaml
@@ -158,3 +158,4 @@ _include:
  - ../peripherals/sai/sai.yaml
  - common_patches/dma_interrupt_names.yaml
  - ./common_patches/l4_adc_smpr.yaml
+ - ./common_patches/l4_adc_sqr1.yaml

--- a/devices/stm32wb55.yaml
+++ b/devices/stm32wb55.yaml
@@ -15,6 +15,15 @@ PWR:
       802EWKUP:
         name: _802EWKUP
 
+# Rename the L3 field to L to match RM0434
+ADC:
+  SQR1:
+    _modify:
+      L3:
+        name: L
+        description: Regular channel sequence length
+
+
 _include:
  - ./common_patches/sai/sai_v1.yaml
  - ./common_patches/rtc/rtc_cr.yaml


### PR DESCRIPTION
This PR closes #513. In addition to L4x1, L4x2, L4x3, and L4x5, this issue also affected WB55.