### PR TITLE
Add missing APB1RSTR1.USBFSRST field for L4x3

### DIFF
--- a/devices/stm32l4x3.yaml
+++ b/devices/stm32l4x3.yaml
@@ -11,6 +11,12 @@ RCC:
       USBF:
         name: USBFSEN
         description: USB FS clock enable
+  APB1RSTR1:
+    _add:
+      USBFSRST:
+        description: USB FS reset
+        bitOffset: 26
+        bitWidth: 1
 
 _modify:
   # The SVD calls ADC1 ADC.


### PR DESCRIPTION
This PR closes #525. L4x3 is the only device in the L4 family affected by this issue.