### PR TITLE
Added peripherals/gpio/gpio_v2.yaml to stm32g4 series

### DIFF
--- a/devices/stm32g431.yaml
+++ b/devices/stm32g431.yaml
@@ -17,3 +17,4 @@ _include:
  - ./common_patches/rtc/rtc_cr.yaml
  - ../peripherals/opamp/opamp_g4_common.yaml
  - ../peripherals/i2c/i2c_v2.yaml
+ - ../peripherals/gpio/gpio_v2.yaml

--- a/devices/stm32g441.yaml
+++ b/devices/stm32g441.yaml
@@ -17,3 +17,4 @@ _include:
  - ./common_patches/rtc/rtc_cr.yaml
  - ../peripherals/opamp/opamp_g4_common.yaml 
  - ../peripherals/i2c/i2c_v2.yaml
+ - ../peripherals/gpio/gpio_v2.yaml

--- a/devices/stm32g471.yaml
+++ b/devices/stm32g471.yaml
@@ -17,3 +17,4 @@ _include:
  - ./common_patches/rtc/rtc_cr.yaml
  - ../peripherals/opamp/opamp_g4_common.yaml 
  - ../peripherals/i2c/i2c_v2.yaml
+ - ../peripherals/gpio/gpio_v2.yaml

--- a/devices/stm32g473.yaml
+++ b/devices/stm32g473.yaml
@@ -19,3 +19,4 @@ _include:
  - ../peripherals/opamp/opamp_g4_opamp4_5.yaml 
  - ../peripherals/opamp/opamp_g4_opamp6.yaml 
  - ../peripherals/i2c/i2c_v2.yaml
+ - ../peripherals/gpio/gpio_v2.yaml

--- a/devices/stm32g474.yaml
+++ b/devices/stm32g474.yaml
@@ -19,3 +19,4 @@ _include:
  - ../peripherals/opamp/opamp_g4_opamp4_5.yaml 
  - ../peripherals/opamp/opamp_g4_opamp6.yaml 
  - ../peripherals/i2c/i2c_v2.yaml
+ - ../peripherals/gpio/gpio_v2.yaml

--- a/devices/stm32g483.yaml
+++ b/devices/stm32g483.yaml
@@ -20,3 +20,4 @@ _include:
  - ../peripherals/opamp/opamp_g4_opamp4_5.yaml 
  - ../peripherals/opamp/opamp_g4_opamp6.yaml 
  - ../peripherals/i2c/i2c_v2.yaml
+ - ../peripherals/gpio/gpio_v2.yaml

--- a/devices/stm32g484.yaml
+++ b/devices/stm32g484.yaml
@@ -19,3 +19,4 @@ _include:
  - ../peripherals/opamp/opamp_g4_opamp4_5.yaml 
  - ../peripherals/opamp/opamp_g4_opamp6.yaml
  - ../peripherals/i2c/i2c_v2.yaml
+ - ../peripherals/gpio/gpio_v2.yaml

--- a/devices/stm32g491.yaml
+++ b/devices/stm32g491.yaml
@@ -28,3 +28,4 @@ _include:
  - ../peripherals/opamp/opamp_g4_common.yaml 
  - ../peripherals/opamp/opamp_g4_opamp6.yaml 
  - ../peripherals/i2c/i2c_v2.yaml
+ - ../peripherals/gpio/gpio_v2.yaml

--- a/devices/stm32g4a1.yaml
+++ b/devices/stm32g4a1.yaml
@@ -28,3 +28,4 @@ _include:
  - ../peripherals/opamp/opamp_g4_common.yaml
  - ../peripherals/opamp/opamp_g4_opamp6.yaml
  - ../peripherals/i2c/i2c_v2.yaml
+ - ../peripherals/gpio/gpio_v2.yaml


### PR DESCRIPTION
I think the register definitions in gpio_v2.yaml match those of the stm32g4 series so I added them to the device files.