### PR TITLE
STM32F446: FLASH description, RCC.PLLCFGR.PLLR

### DIFF
--- a/devices/stm32f446.yaml
+++ b/devices/stm32f446.yaml
@@ -66,6 +66,13 @@ RCC:
     _modify:
       SPDIFSEL:
         name: SPDIFRXSEL
+  PLLCFGR:
+    _add:
+      PLLR:
+        description: Main PLL division factor for I2Ss, SAIs, SYSTEM and SPDIF-Rx clocks
+        bitOffset: 28
+        bitWidth: 3
+
 
 SYSCFG:
   _add:
@@ -573,3 +580,5 @@ _include:
  - common_patches/sdio_f446.yaml
  - ../peripherals/sdio/sdio.yaml
  - ../peripherals/sdio/sdio_f4_common.yaml
+ - ../peripherals/flash/flash_v1.yaml
+ - ../peripherals/rcc/rcc_v2_pllcfgr_pllr.yaml


### PR DESCRIPTION
So I almost made the same mistake as #374, but actually managed to notice that before starting a pull request, so here I just included the [flash_v1.yaml](https://github.com/stm32-rs/stm32-rs/blob/master/peripherals/flash/flash_v1.yaml) to the f446 device file.
(Apparently, the decision was made not to fiddle with `_read/_write` for 'write 1 to reset' in the library, so I abstained from including that for the FLASH.SR bits)
Moreover, SVD apparently missed PLLR field for some reason, so I based that fix on the similar solution from the f412 patch.