### PR TITLE
STM32F401: Add FLTR register to all I2C peripherals

### DIFF
--- a/devices/common_patches/i2c_v1_fltr.yaml
+++ b/devices/common_patches/i2c_v1_fltr.yaml
@@ -1,0 +1,17 @@
+"I2C*":
+  _add:
+    # FLTR register (defined in RM0368 for example)
+    FLTR:
+      description: FLTR register
+      addressOffset: 0x24
+      access: read-write
+      resetValue: 0x0000
+      fields:
+        ANOFF:
+          description: Analog noise filter
+          bitOffset: 4
+          bitWidth: 1
+        DNF:
+          description: Digital noise filter
+          bitOffset: 0
+          bitWidth: 4

--- a/devices/stm32f401.yaml
+++ b/devices/stm32f401.yaml
@@ -12,46 +12,6 @@ _rebase:
       TIFRFE:
         name: "FRE"
 
-"I2C*":
-  _add:
-    # FLTR register defined RM0368
-    FLTR:
-      description: FLTR register
-      addressOffset: 0x24
-      access: read-write
-      resetValue: 0x0000
-      fields:
-        ANFOFF:
-          description: Analog noise filter
-          bitOffset: 4
-          bitWidth: 1
-        DNF:
-          description: Digital noise filter
-          bitOffset: 4
-          bitWidth: 4
-
-  FLTR:
-    ANFOFF:
-        Enabled: [0, "Analog noise filter enabled"]
-        Disabled: [1, "Analog noise filter disabled"]
-    DNF:
-        NoFilter: [0, "Digital filter disabled"]
-        Filter1: [1, "Digital filter enabled and filtering capability up to 1 tI2CCLK"]
-        Filter2: [2, "Digital filter enabled and filtering capability up to 2 tI2CCLK"]
-        Filter3: [3, "Digital filter enabled and filtering capability up to 3 tI2CCLK"]
-        Filter4: [4, "Digital filter enabled and filtering capability up to 4 tI2CCLK"]
-        Filter5: [5, "Digital filter enabled and filtering capability up to 5 tI2CCLK"]
-        Filter6: [6, "Digital filter enabled and filtering capability up to 6 tI2CCLK"]
-        Filter7: [7, "Digital filter enabled and filtering capability up to 7 tI2CCLK"]
-        Filter8: [8, "Digital filter enabled and filtering capability up to 8 tI2CCLK"]
-        Filter9: [9, "Digital filter enabled and filtering capability up to 9 tI2CCLK"]
-        Filter10: [10, "Digital filter enabled and filtering capability up to 10 tI2CCLK"]
-        Filter11: [11, "Digital filter enabled and filtering capability up to 11 tI2CCLK"]
-        Filter12: [12, "Digital filter enabled and filtering capability up to 12 tI2CCLK"]
-        Filter13: [13, "Digital filter enabled and filtering capability up to 13 tI2CCLK"]
-        Filter14: [14, "Digital filter enabled and filtering capability up to 14 tI2CCLK"]
-        Filter15: [15, "Digital filter enabled and filtering capability up to 15 tI2CCLK"]
-
 CRC:
   # The SVD calls the RESET field "CR", fix per RM0368
   CR:
@@ -183,3 +143,5 @@ _include:
  - common_patches/rtc/rtc_cr.yaml
  - ../peripherals/rtc/rtc_common.yaml
  - ../peripherals/sdio/sdio_f4.yaml
+ - common_patches/i2c_v1_fltr.yaml
+ - ../peripherals/i2c/i2c_v1_fltr.yaml

--- a/devices/stm32f401.yaml
+++ b/devices/stm32f401.yaml
@@ -12,6 +12,46 @@ _rebase:
       TIFRFE:
         name: "FRE"
 
+"I2C*":
+  _add:
+    # FLTR register defined RM0368
+    FLTR:
+      description: FLTR register
+      addressOffset: 0x24
+      access: read-write
+      resetValue: 0x0000
+      fields:
+        ANFOFF:
+          description: Analog noise filter
+          bitOffset: 4
+          bitWidth: 1
+        DNF:
+          description: Digital noise filter
+          bitOffset: 4
+          bitWidth: 4
+
+  FLTR:
+    ANFOFF:
+        Enabled: [0, "Analog noise filter enabled"]
+        Disabled: [1, "Analog noise filter disabled"]
+    DNF:
+        NoFilter: [0, "Digital filter disabled"]
+        Filter1: [1, "Digital filter enabled and filtering capability up to 1 tI2CCLK"]
+        Filter2: [2, "Digital filter enabled and filtering capability up to 2 tI2CCLK"]
+        Filter3: [3, "Digital filter enabled and filtering capability up to 3 tI2CCLK"]
+        Filter4: [4, "Digital filter enabled and filtering capability up to 4 tI2CCLK"]
+        Filter5: [5, "Digital filter enabled and filtering capability up to 5 tI2CCLK"]
+        Filter6: [6, "Digital filter enabled and filtering capability up to 6 tI2CCLK"]
+        Filter7: [7, "Digital filter enabled and filtering capability up to 7 tI2CCLK"]
+        Filter8: [8, "Digital filter enabled and filtering capability up to 8 tI2CCLK"]
+        Filter9: [9, "Digital filter enabled and filtering capability up to 9 tI2CCLK"]
+        Filter10: [10, "Digital filter enabled and filtering capability up to 10 tI2CCLK"]
+        Filter11: [11, "Digital filter enabled and filtering capability up to 11 tI2CCLK"]
+        Filter12: [12, "Digital filter enabled and filtering capability up to 12 tI2CCLK"]
+        Filter13: [13, "Digital filter enabled and filtering capability up to 13 tI2CCLK"]
+        Filter14: [14, "Digital filter enabled and filtering capability up to 14 tI2CCLK"]
+        Filter15: [15, "Digital filter enabled and filtering capability up to 15 tI2CCLK"]
+
 CRC:
   # The SVD calls the RESET field "CR", fix per RM0368
   CR:

--- a/devices/stm32f410.yaml
+++ b/devices/stm32f410.yaml
@@ -191,3 +191,5 @@ _include:
  - ../peripherals/tim/tim_ccm_v1.yaml
  - common_patches/rtc/rtc_cr.yaml
  - ../peripherals/rtc/rtc_common.yaml
+ - common_patches/i2c_v1_fltr.yaml
+ - ../peripherals/i2c/i2c_v1_fltr.yaml

--- a/devices/stm32f411.yaml
+++ b/devices/stm32f411.yaml
@@ -165,3 +165,5 @@ _include:
  - common_patches/rtc/rtc_cr.yaml
  - ../peripherals/rtc/rtc_common.yaml
  - ../peripherals/sdio/sdio_f4.yaml
+ - common_patches/i2c_v1_fltr.yaml
+ - ../peripherals/i2c/i2c_v1_fltr.yaml

--- a/devices/stm32f412.yaml
+++ b/devices/stm32f412.yaml
@@ -436,3 +436,5 @@ _include:
  - common_patches/rtc/rtc_cr.yaml
  - ../peripherals/rtc/rtc_common.yaml
  - ../peripherals/sdio/sdio_f4.yaml
+ - common_patches/i2c_v1_fltr.yaml
+ - ../peripherals/i2c/i2c_v1_fltr.yaml

--- a/devices/stm32f413.yaml
+++ b/devices/stm32f413.yaml
@@ -201,3 +201,4 @@ _include:
  - common_patches/rtc/rtc_cr.yaml
  - ../peripherals/rtc/rtc_common.yaml
  - ../peripherals/sdio/sdio_f4.yaml
+ - ../peripherals/i2c/i2c_v1_fltr.yaml

--- a/devices/stm32f427.yaml
+++ b/devices/stm32f427.yaml
@@ -237,3 +237,4 @@ _include:
  - common_patches/rtc/rtc_cr.yaml
  - ../peripherals/rtc/rtc_common.yaml
  - ../peripherals/sdio/sdio_f4.yaml
+ - ../peripherals/i2c/i2c_v1_fltr.yaml

--- a/devices/stm32f429.yaml
+++ b/devices/stm32f429.yaml
@@ -197,3 +197,4 @@ _include:
  - common_patches/rtc/rtc_cr.yaml
  - ../peripherals/rtc/rtc_common.yaml
  - ../peripherals/sdio/sdio_f4.yaml
+ - ../peripherals/i2c/i2c_v1_fltr.yaml

--- a/devices/stm32f446.yaml
+++ b/devices/stm32f446.yaml
@@ -582,3 +582,4 @@ _include:
  - ../peripherals/sdio/sdio_f4_common.yaml
  - ../peripherals/flash/flash_v1.yaml
  - ../peripherals/rcc/rcc_v2_pllcfgr_pllr.yaml
+ - ../peripherals/i2c/i2c_v1_fltr.yaml

--- a/devices/stm32f469.yaml
+++ b/devices/stm32f469.yaml
@@ -160,3 +160,4 @@ _include:
  - common_patches/rtc/rtc_cr.yaml
  - ../peripherals/rtc/rtc_common.yaml
  - ../peripherals/sdio/sdio_f4.yaml
+ - ../peripherals/i2c/i2c_v1_fltr.yaml

--- a/peripherals/i2c/i2c_v1_fltr.yaml
+++ b/peripherals/i2c/i2c_v1_fltr.yaml
@@ -1,0 +1,22 @@
+"I2C*":
+  FLTR:
+    ANOFF:
+        Enabled: [0, "Analog noise filter enabled"]
+        Disabled: [1, "Analog noise filter disabled"]
+    DNF:
+        NoFilter: [0, "Digital filter disabled"]
+        Filter1: [1, "Digital filter enabled and filtering capability up to 1 tI2CCLK"]
+        Filter2: [2, "Digital filter enabled and filtering capability up to 2 tI2CCLK"]
+        Filter3: [3, "Digital filter enabled and filtering capability up to 3 tI2CCLK"]
+        Filter4: [4, "Digital filter enabled and filtering capability up to 4 tI2CCLK"]
+        Filter5: [5, "Digital filter enabled and filtering capability up to 5 tI2CCLK"]
+        Filter6: [6, "Digital filter enabled and filtering capability up to 6 tI2CCLK"]
+        Filter7: [7, "Digital filter enabled and filtering capability up to 7 tI2CCLK"]
+        Filter8: [8, "Digital filter enabled and filtering capability up to 8 tI2CCLK"]
+        Filter9: [9, "Digital filter enabled and filtering capability up to 9 tI2CCLK"]
+        Filter10: [10, "Digital filter enabled and filtering capability up to 10 tI2CCLK"]
+        Filter11: [11, "Digital filter enabled and filtering capability up to 11 tI2CCLK"]
+        Filter12: [12, "Digital filter enabled and filtering capability up to 12 tI2CCLK"]
+        Filter13: [13, "Digital filter enabled and filtering capability up to 13 tI2CCLK"]
+        Filter14: [14, "Digital filter enabled and filtering capability up to 14 tI2CCLK"]
+        Filter15: [15, "Digital filter enabled and filtering capability up to 15 tI2CCLK"]


### PR DESCRIPTION
This adds the I2C FLTR register defined in RM0368. I have tested this result in code that compiles and looks correct to me (see below). However, I have not tested that this indeed does the right thing in hardware. Not even sure how I would do that :).

```rust
i2c1.fltr.write(|w| w.anfoff().enabled().dnf().no_filter());
```

I only made changes in `devices/stm32f401.yaml` as I personally don't know whether other similar devices have this. For example, STM32L4 does not follow this structure, but maybe other STM32F4's do? Don't know.