### PR TITLE
SPI for L4 series

### DIFF
--- a/devices/common_patches/l4_spi.yaml
+++ b/devices/common_patches/l4_spi.yaml
@@ -1,0 +1,14 @@
+# Rename SPI fields
+# CR1.CRCL field is documented, but in SVD as DFF.
+# SR.FRE field is documented, but in SVD as TIFRFE.
+"SPI*":
+  CR1:
+    _modify:
+      DFF:
+        name: CRCL
+        description: CRC length
+  SR:
+    _modify:
+      TIFRFE:
+        name: FRE
+        description: Frame format error

--- a/devices/stm32l4x1.yaml
+++ b/devices/stm32l4x1.yaml
@@ -98,3 +98,5 @@ _include:
  - ./common_patches/l4_adc_common.yaml
  - ./common_patches/l4_adc_smpr.yaml
  - ./common_patches/l4_adc_sqr1.yaml
+ - ./common_patches/l4_spi.yaml
+ - ../peripherals/spi/spi_l4.yaml

--- a/devices/stm32l4x2.yaml
+++ b/devices/stm32l4x2.yaml
@@ -130,3 +130,5 @@ _include:
  - ./common_patches/l4_adc_common.yaml
  - ./common_patches/l4_adc_smpr.yaml
  - ./common_patches/l4_adc_sqr1.yaml
+ - ./common_patches/l4_spi.yaml
+ - ../peripherals/spi/spi_l4.yaml

--- a/devices/stm32l4x3.yaml
+++ b/devices/stm32l4x3.yaml
@@ -99,3 +99,5 @@ _include:
  - ./common_patches/l4_adc_common.yaml
  - ./common_patches/l4_adc_smpr.yaml
  - ./common_patches/l4_adc_sqr1.yaml
+ - ./common_patches/l4_spi.yaml
+ - ../peripherals/spi/spi_l4.yaml

--- a/devices/stm32l4x5.yaml
+++ b/devices/stm32l4x5.yaml
@@ -159,3 +159,5 @@ _include:
  - common_patches/dma_interrupt_names.yaml
  - ./common_patches/l4_adc_smpr.yaml
  - ./common_patches/l4_adc_sqr1.yaml
+ - ./common_patches/l4_spi.yaml
+ - ../peripherals/spi/spi_l4.yaml

--- a/devices/stm32l4x6.yaml
+++ b/devices/stm32l4x6.yaml
@@ -72,3 +72,5 @@ _include:
  - ../peripherals/tim/tim_ccm_v2.yaml
  - ../peripherals/sai/sai.yaml
  - ../peripherals/dma/dma2d_v1.yaml
+ - ./common_patches/l4_spi.yaml
+ - ../peripherals/spi/spi_l4.yaml

--- a/peripherals/spi/spi_l4.yaml
+++ b/peripherals/spi/spi_l4.yaml
@@ -1,0 +1,4 @@
+# SPI for L4
+
+_include:
+  - "spi_common.yaml"


### PR DESCRIPTION
RM0394 documents the L4 series.

The common SPI mostly applies, but L4 series SPI differs from SPI_v1, v2 and v3 variants - so defining an 'spi_l4' variant.

Two SVD fields need renaming as part of this to be consistent with documented field names (and the ST-provided C HAL):

- CR1.CRCL
- SR.FRE
