### PR TITLE
F0 patches that rename registers should modify the existing register

### DIFF
--- a/devices/common_patches/f0_adc_fixes.yaml
+++ b/devices/common_patches/f0_adc_fixes.yaml
@@ -1,4 +1,4 @@
-# Renames a few fields in the F0 ADC and adds the WAIT file which was missed
+# Renames a few fields in the F0 ADC and replaces AUTDLY with WAIT
 
 ADC:
   ISR:
@@ -10,10 +10,9 @@ ADC:
       EOSIE:
         name: "EOSEQIE"
   CFGR1:
-    _add:
-      WAIT:
-        bitOffset: 14
-        bitWidth: 1
+    _modify:
+      AUTDLY:
+        name: "WAIT"
         description: "Wait conversion mode"
   SMPR:
     _modify:

--- a/devices/common_patches/f0_dmaen.yaml
+++ b/devices/common_patches/f0_dmaen.yaml
@@ -1,7 +1,6 @@
 RCC:
   AHBENR:
-    _add:
-      DMAEN:
+    _modify:
+      DMA1EN:
+        name: DMAEN
         description: DMA clock enable
-        bitOffset: 0
-        bitWidth: 1


### PR DESCRIPTION
While consuming a patched F0 SVD from https://github.com/lynaghk/svd2zig/ I noticed that a few patches add registers which alias existing ones at the same `bitOffset`.
E.g., [AUTDLY](https://github.com/stm32-rs/stm32-rs-nightlies/blob/7f67ec12360dfdfa9ce08aa76bf088c17f21cdc9/stm32f0/src/stm32f0x0/adc/cfgr1.rs#L1180-L1184) and [WAIT](https://github.com/stm32-rs/stm32-rs-nightlies/blob/7f67ec12360dfdfa9ce08aa76bf088c17f21cdc9/stm32f0/src/stm32f0x0/adc/cfgr1.rs#L1230-L1234).

Based on the ST reference doc:

<img width="757" alt="Screen Shot 2021-04-13 at 7 54 06 PM" src="https://user-images.githubusercontent.com/147919/114548234-11a33900-9c92-11eb-8db1-2b7e12aa641f.png">

I suspect the patch intent was actually to replace the former with the latter.
Ditto with DMA, which should also (I suspect) modify rather than alias:

<img width="831" alt="Screen Shot 2021-04-13 at 7 55 49 PM" src="https://user-images.githubusercontent.com/147919/114548430-53cc7a80-9c92-11eb-893c-b190a1a920f3.png">

