### PR TITLE
Mention actually required version of svd2rust

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ contain the latest patches and updates.
 
 ## Generating Device Crates / Building Locally
 
-* Install `svd2rust`: `cargo install svd2rust`
+* Install `svd2rust`: `cargo install --version 0.17.0 svd2rust`
 * Install `form`: `cargo install form`
 * Install rustfmt: `rustup component add rustfmt`
 * Install svdtools: `pip install --user svdtools`


### PR DESCRIPTION
Issue #547 mentions this but it would be nice to have this information in this prominent place. Version 0.17.0 works for me.