### PR TITLE
Fix write constraints for USART RDR and TDR registers

### DIFF
--- a/peripherals/usart/_v2_ABC_common.yaml
+++ b/peripherals/usart/_v2_ABC_common.yaml
@@ -144,6 +144,6 @@ ICR:
   PECF:
     Clear: [1, "Clears the PE flag in the ISR register"]
 RDR:
-  RDR: [0, 0xFF]
+  RDR: [0, 0x1FF]
 TDR:
-  TDR: [0, 0xFF]
+  TDR: [0, 0x1FF]


### PR DESCRIPTION
The STM32F303 has 9 bit wide RDR and TDR registers and according to the SVDs this is the case for all other devices with this peripheral too. Make accessing TDR via tdr().bits() safe again by providing the appropriate constraints.

I stumbled upon this issue in https://github.com/rust-embedded/discovery/pull/267#issuecomment-822826949.

The currently exisiting bitWidths have been quick-and-dirty checked using:
```bash
svd $ xmllint --xpath ".//field[(name = 'RDR' or name = 'TDR') and bitWidth != 9]" --format *.svd *.svd.patched
```
This gave not output while searching for `bitWidth = 9` did.