### PR TITLE
Prepare for patch release of stm32f3 0.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [v0.13.1] 2021-06-02
+
+* F3:
+    * Backport #558 to allow use in Discovery book
+
 ## [v0.13.0] 2021-02-06
 
 Family-specific:

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ to drill down into each field on each register on each peripheral.
 In your own project's `Cargo.toml`:
 ```toml
 [dependencies.stm32f4]
-version = "0.13.0"
+version = "0.13.1"
 features = ["stm32f405", "rt"]
 ```
 

--- a/peripherals/usart/_v2_ABC_common.yaml
+++ b/peripherals/usart/_v2_ABC_common.yaml
@@ -144,6 +144,6 @@ ICR:
   PECF:
     Clear: [1, "Clears the PE flag in the ISR register"]
 RDR:
-  RDR: [0, 0xFF]
+  RDR: [0, 0x1FF]
 TDR:
-  TDR: [0, 0xFF]
+  TDR: [0, 0x1FF]

--- a/scripts/makecrates.py
+++ b/scripts/makecrates.py
@@ -16,7 +16,7 @@ import argparse
 import re
 import yaml
 
-VERSION = "0.13.0"
+VERSION = "0.13.1"
 SVD2RUST_VERSION = "0.17.0"
 
 CRATE_DOC_FEATURES = {


### PR DESCRIPTION
Contains backported #558 to allow use in Discovery book.