### PR TITLE
Fix bit offset for RMVF in STM32l0x2 and STM32l0x3

### DIFF
--- a/devices/stm32l0x2.yaml
+++ b/devices/stm32l0x2.yaml
@@ -73,6 +73,15 @@ RCC:
     _modify:
       LPWRSTF:
         name: LPWRRSTF
+    _modify:
+      RMVF:
+        bitOffset: 23
+    _add:
+      FWRSTF:
+        description: Firewall reset flag
+        bitOffset: 24
+        bitWidth: 1
+
   APB2RSTR:
     _modify:
       TM12RST:

--- a/devices/stm32l0x2.yaml
+++ b/devices/stm32l0x2.yaml
@@ -73,7 +73,6 @@ RCC:
     _modify:
       LPWRSTF:
         name: LPWRRSTF
-    _modify:
       RMVF:
         bitOffset: 23
     _add:

--- a/devices/stm32l0x3.yaml
+++ b/devices/stm32l0x3.yaml
@@ -84,7 +84,6 @@ RCC:
     _modify:
       LPWRSTF:
         name: LPWRRSTF
-    _modify:
       RMVF:
         bitOffset: 23
     _add:

--- a/devices/stm32l0x3.yaml
+++ b/devices/stm32l0x3.yaml
@@ -84,6 +84,14 @@ RCC:
     _modify:
       LPWRSTF:
         name: LPWRRSTF
+    _modify:
+      RMVF:
+        bitOffset: 23
+    _add:
+      FWRSTF:
+        description: Firewall reset flag
+        bitOffset: 24
+        bitWidth: 1
   APB2RSTR:
     _modify:
       TM12RST:


### PR DESCRIPTION
According to the reference manuals for STM32L0x{2, 3}, the RCC_CSR
register RMVF has the offset 23 and not 24. Offset 24 is occupied by a
Firewall reset which is also added in this change

Page 219 in the STM32L0x2 release manual can be used to verify.