### PR TITLE
Make FDCAN_TEST register writeable for H7 family

### DIFF
--- a/devices/common_patches/fdcan/fdcan_h7.yaml
+++ b/devices/common_patches/fdcan/fdcan_h7.yaml
@@ -43,3 +43,7 @@ _include:
     _modify:
       CT:
         name: CCV
+
+  _modify:
+    TEST:
+      access: read-write


### PR DESCRIPTION
To make sure the Writable trait is also implemented for the TEST register