### PR TITLE
l0: fix CNT, ARR, CCRx register sizes

### DIFF
--- a/devices/common_patches/l0_tim.yaml
+++ b/devices/common_patches/l0_tim.yaml
@@ -1,3 +1,14 @@
+# Per RM0367,RM0376, RM0377 all timers have 16 bit registers for CNT,ARR,CCRx
+TIM*:
+  _modify:
+    CNT:
+      size: 16
+    ARR:
+      size: 16
+    CCR*:
+      size: 16
+
+
 # Fix Timers for L0 Flash
 "TIM[23]":
   _delete:


### PR DESCRIPTION
The existing patch for l0 timers was setting these registers to 16-bit as a side-effect of redefining TIM2/TIM3 - but for all TIM objects, the corresponding reference manuals indicate CNT, ARR and CCRx values should be 16-bit registers.

Relevant ref manuals: RM0367, RM0376, RM0377