### PR TITLE
Enable the `rt` feature by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+Common:
+
+* The `rt` feature is now enabled by default; use `default-features=false` to
+  disable.
+
 ## [v0.13.1] 2021-06-02
 
 This version has only been released as a patch release for the

--- a/scripts/makecrates.py
+++ b/scripts/makecrates.py
@@ -86,7 +86,7 @@ default-target = "{doc_target}"
 targets = []
 
 [features]
-default = []
+default = ["rt"]
 rt = ["cortex-m-rt/device"]
 {features}
 """


### PR DESCRIPTION
Requiring the `rt` feature seems to only catch people out, and as far as I can tell it's very rare to not want it. It's still possible to disable it if you don't want it, just now it will usually be enabled for you.