### PR TITLE
Revert rebasing TIM5 for F7x2, since OR must be different.

### DIFF
--- a/devices/stm32f7x2.yaml
+++ b/devices/stm32f7x2.yaml
@@ -2,7 +2,6 @@ _svd: ../svd/stm32f7x2.svd
 
 _derive:
   USART3: USART1
-  TIM5: TIM2
 
 _rebase:
   SPI1: SPI5


### PR DESCRIPTION
In #540 TIM5 was updated to be rebased from TIM2, but as its option register OR is different, it can't be rebased.

@burrbull I thought I'd need to instead copy it from TIM2 and then change OR, like

```yaml
_copy:
  TIM5:
    from: TIM2

TIM5:
  _modify:
    OR:
      description: TIM5 option register 1
  OR:
    _delete:
      - ITR1_RMP
    _add:
      TI4_RMP:
        description: Timer Input 4 remap
        bitOffset: 6
        bitWidth: 2
```

but it looks like the plain SVD is already correct and we just don't need to do anything, can you remember why you rebased it originally?