### PR TITLE
stm32wle5: normalize EXTI.IMRx to match dual-core variants

### DIFF
--- a/devices/stm32wle5.yaml
+++ b/devices/stm32wle5.yaml
@@ -35,7 +35,14 @@ DAC:
       - "TSEL1*"
 
 EXTI:
-  IMR2:
+  _modify:
+    IMR1:
+      name:
+        C1IMR1
+    IMR2:
+      name:
+        C1IMR2
+  C1IMR2:
     _modify:
       IM42:
         bitWidth: 1


### PR DESCRIPTION
The dual-core STM32WL5x variant use the `CxIMRy` naming convention on the EXTI IMR registers whereas the single-core STM32WLE5 variant uses `IMRy`.

This PR adds the `Cx` prefix to the single-core variant to reduce the occurrences of `#[cfg(feature = "stm32wle5")]`.  This matches what has already been done for other peripherals (HSEM).

cc @jorgeig-space