### PR TITLE
[scripts/makehtml] Fix displaying of registers with the same addressOffset and parsing of addressOffset

### DIFF
--- a/scripts/makehtml.py
+++ b/scripts/makehtml.py
@@ -69,7 +69,8 @@ def parse_device(svdfile):
             rdesc = rtag.findtext('description')
             rrstv = rtag.findtext('resetValue')
             raccs = rtag.findtext('access') or "Unspecified"
-            roffset = int(rtag.findtext('addressOffset'), 16)
+            addr_offset = rtag.findtext('addressOffset')
+            roffset = int(addr_offset, 16 if addr_offset.startswith('0x') else 10)
             for ftag in rtag.iter('field'):
                 register_fields_total += 1
                 fname = ftag.findtext('name')
@@ -146,7 +147,7 @@ def parse_device(svdfile):
             # Bodge to prevent /0 when there are no fields in a register
             if register_fields_total == 0:
                 register_fields_total = 1
-            registers[roffset] = {"name": rname,
+            registers[rname] = {"name": rname,
                                   "offset": "0x{:X}".format(roffset),
                                   "description": rdesc, "resetValue": rrstv,
                                   "access": raccs, "fields": fields,

--- a/scripts/makehtml.py
+++ b/scripts/makehtml.py
@@ -69,8 +69,7 @@ def parse_device(svdfile):
             rdesc = rtag.findtext('description')
             rrstv = rtag.findtext('resetValue')
             raccs = rtag.findtext('access') or "Unspecified"
-            addr_offset = rtag.findtext('addressOffset')
-            roffset = int(addr_offset, 16 if addr_offset.startswith('0x') else 10)
+            roffset = int(rtag.findtext('addressOffset'), 0)
             for ftag in rtag.iter('field'):
                 register_fields_total += 1
                 fname = ftag.findtext('name')

--- a/scripts/makehtml.py
+++ b/scripts/makehtml.py
@@ -146,14 +146,14 @@ def parse_device(svdfile):
             # Bodge to prevent /0 when there are no fields in a register
             if register_fields_total == 0:
                 register_fields_total = 1
-            registers[rname] = {"name": rname,
-                                  "offset": "0x{:X}".format(roffset),
-                                  "description": rdesc, "resetValue": rrstv,
-                                  "access": raccs, "fields": fields,
-                                  "table": table,
-                                  "fields_total": register_fields_total,
-                                  "fields_documented":
-                                      register_fields_documented}
+            registers[(roffset, rname)] = {"name": rname,
+                                           "offset": "0x{:X}".format(roffset),
+                                           "description": rdesc, "resetValue": rrstv,
+                                           "access": raccs, "fields": fields,
+                                           "table": table,
+                                           "fields_total": register_fields_total,
+                                           "fields_documented":
+                                               register_fields_documented}
             peripheral_fields_total += register_fields_total
             peripheral_fields_documented += register_fields_documented
         peripherals[pname] = {"name": pname, "base": pbase,

--- a/scripts/makehtml.template.html
+++ b/scripts/makehtml.template.html
@@ -118,7 +118,7 @@ nav.menu a {
         <a class=toggle-registers href=#>Toggle Registers</a>.
       </p>
       <div class="container registers" id="{{ pname }}-registers">
-        {% for roffset, register in peripheral.registers|dictsort %}
+        {% for _, register in peripheral.registers|dictsort %}
         <div class=row>
           <div class="col-sm-11 register">
             <h4>


### PR DESCRIPTION
This pull request fix two bugs in the `makehtml.py` script:

- When parsing the addressOffset value, the value is parsed as base16 even if it's in base10.
- When two registers have the same addressOffset, one of the two is suppressed

The first bug is fixed by checking if the addressOffset starts with `0x` to parse from base16, or parse from base10 by default (when a register is generated from a patch).

The second bug is fixed by changing the index used for the list of registers from the addressOffset to the register name.