### PR TITLE
Set STM32F3x4 HRTIM ISR FLT* fields read-write

### DIFF
--- a/devices/stm32f3x4.yaml
+++ b/devices/stm32f3x4.yaml
@@ -126,6 +126,8 @@ HRTIM_Common:
     _modify:
       FLT[12345]:
         access: read-write
+      BMPER,DLLRDY:
+        access: read-write
 
 HRTIM_Master:
   _modify:

--- a/devices/stm32f3x4.yaml
+++ b/devices/stm32f3x4.yaml
@@ -122,6 +122,10 @@ HRTIM_Common:
     _modify:
       SYSFLTC:
         access: write-only
+  ISR:
+    _modify:
+      FLT[12345]:
+        access: read-write
 
 HRTIM_Master:
   _modify:


### PR DESCRIPTION
Fixes an issue caused by svdtools 0.1.16.