### PR TITLE
Resolve small breakage in OCxM fields for stm32h735 in #546

### DIFF
--- a/devices/stm32h735.yaml
+++ b/devices/stm32h735.yaml
@@ -555,12 +555,12 @@ _include:
  - ../peripherals/tim/tim_advanced.yaml
  - ../peripherals/tim/tim_h7.yaml
  - common_patches/tim/tim_ccr.yaml
+ - ../peripherals/tim/v2/ccm.yaml
  - ../peripherals/iwdg/iwdg_with_WINR.yaml
  - ../peripherals/exti/exti_h7.yaml
  - ../peripherals/i2c/i2c_v2.yaml
  - ../peripherals/wwdg/wwdg_v2.yaml
  - ../peripherals/usart/usart_v2B1.yaml
- - common_patches/tim/tim_ccr.yaml
  - ../peripherals/sai/sai.yaml
  - common_patches/rtc/rtc_bkpr.yaml
  - common_patches/rtc/rtc_cr.yaml

--- a/devices/stm32h743.yaml
+++ b/devices/stm32h743.yaml
@@ -1,7 +1,6 @@
 _svd: ../svd/stm32h743.svd
 
 _derive:
-  TIM17: TIM16
   TIM4: TIM3
   TIM14: TIM13
 


### PR DESCRIPTION
After 0cb0f60346d21320bbfde60b37d2d14aa49439d2 the peripheral patches for the OCxM fields were no longer applied for these parts. This PR fixes that.

* Add `peripherals/tim/v2/ccm.yaml` that appeared during the refactor but wasn't added to this device
* Remove duplicate include of `common_patches/tim/tim_ccr.yaml`