### PR TITLE
stm32f7x7: Fix missing fields for timers

### DIFF
--- a/devices/stm32f7x7.yaml
+++ b/devices/stm32f7x7.yaml
@@ -191,6 +191,164 @@ RCC:
         bitWidth: 3
         access: read-write
 
+TIM*:
+  CR1:
+    _add:
+      UIFREMAP:
+        description: UIF status bit remapping
+        bitOffset: 11
+        bitWidth: 1
+
+TIM[1-589],TIM1[0-4]:
+  SMCR:
+    _add:
+      SMS_3:
+        description: Slave mode selection - bit 3
+        bitOffset: 16
+        bitWidth: 1
+
+TIM[1-589],TIM1[04]:
+  CCMR1_Output:
+    _add:
+      OC1M_3:
+        description: Output Compare 1 mode - bit 3
+        bitOffset: 16
+        bitWidth: 1
+
+TIM[1-589]:
+  CCMR1_Output:
+    _add:
+      OC2M_3:
+        description: Output Compare 2 mode - bit 3
+        bitOffset: 24
+        bitWidth: 1
+
+TIM[1-58],TIM1[134]:
+  CCMR2_Output:
+    _add:
+      OC3M_3:
+        description: Output Compare 3 mode - bit 3
+        bitOffset: 16
+        bitWidth: 1
+      OC4M_3:
+        description: Output Compare 4 mode - bit 3
+        bitOffset: 24
+        bitWidth: 1
+
+TIM[18]:
+  CR2:
+    _add:
+      UIFREMAP:
+        description: UIF status bit remapping
+        bitOffset: 11
+        bitWidth: 1
+      OIS5:
+        description: Output Idle state 5 (OC5 output)
+        bitOffset: 16
+        bitWidth: 1
+      OIS6:
+        description: Output Idle state 6 (OC6 output)
+        bitOffset: 18
+        bitWidth: 1
+      MMS2:
+        description: Master mode selection 2
+        bitOffset: 20
+        bitWidth: 4
+  SR:
+    _add:
+      CC5IF:
+        description: Compare 5 interrupt flag
+        bitOffset: 16
+        bitWidth: 1
+      CC6IF:
+        description: Compare 6 interrupt flag
+        bitOffset: 17
+        bitWidth: 1
+  EGR:
+    _add:
+      B2G:
+        description: Break 2 generation
+        bitOffset: 8
+        bitWidth: 1
+  CCER:
+    _add:
+      CC5E:
+        description: Capture/Compare 5 output enable
+        bitOffset: 16
+        bitWidth: 1
+      CC5P:
+        description: Capture/Compare 5 output polarity
+        bitOffset: 17
+        bitWidth: 1
+      CC6E:
+        description: Capture/Compare 6 output enable
+        bitOffset: 20
+        bitWidth: 1
+      CC6P:
+        description: Capture/Compare 6 output polarity
+        bitOffset: 21
+        bitWidth: 1
+
+TIM[34]:
+  _delete:
+    - OR1
+    - OR2
+  CNT:
+    _delete:
+      - CNT_H
+  ARR:
+    _delete:
+      - ARR_H
+  CCR*:
+    _delete:
+      - CCR?_H
+
+TIM1[0134]:
+  _delete:
+    - SMCR
+
+TIM[13489],TIM12:
+  CNT:
+    _add:
+      UIFCPY:
+        description: >
+          UIF copy
+          This bit is a read-only copy of the UIF bit of the TIMx_ISR register. 
+          If the UIFREMAP bit in the TIMxCR1 is reset, bit 31 is reserved and read at 0
+        bitOffset: 31
+        bitWidth: 1
+        access: read-only
+
+TIM2:
+  _delete:
+    - OR2
+  _modify:
+    OR1:
+      name: OR
+  OR:
+    _delete:
+      - E*
+      - T*
+    _modify:
+      ITR1_RMP:
+        bitOffset: 10
+        bitWidth: 2
+
+# This is not working?!
+TIM5:
+  _add:
+    OR:
+      description: TIM5 option register
+      addressOffset: 0x50
+      size: 0x20
+      resetValue: 0x00000000
+      access: read-write
+      fields:
+        TI4_RMP:
+          description: Timer Input 4 remap
+          bitOffset: 6
+          bitWidth: 2
+
 Ethernet_MAC:
   MACFFR:
     _modify:


### PR DESCRIPTION
A lot of fields are wrong or missing for the timers for the STM32F7x7.
This pull request fix all of them regarding their definitions in the reference manual.