### PR TITLE
[scripts/makehtml] Add register map

### DIFF
--- a/scripts/makehtml.template.html
+++ b/scripts/makehtml.template.html
@@ -22,11 +22,21 @@
   border: solid 1px #eee;
   margin-bottom: 3px;
 }
-.registers {
+.registers,
+.register-map {
   display: none;
 }
 .bitfield td, .bitfield th {
   text-align: center;
+}
+.vertical {
+  padding: 5px 0 !important;
+  vertical-align: middle !important;
+  text-align: center;
+  text-align: -webkit-center;
+}
+.vertical div {
+  writing-mode: vertical-lr;
 }
 .doccol {
   color: rgb(92, 184, 92);
@@ -115,8 +125,40 @@ nav.menu a {
           {{ peripheral.fields_documented }}/{{peripheral.fields_total }}
           fields covered.
         </em>
-        <a class=toggle-registers href=#>Toggle Registers</a>.
+        <a class=toggle-registers href=#>Toggle Registers</a>
       </p>
+      <p><a class=toggle-register-map href=#>Show register map</a></p>
+      <div class="register-map" id="{{ pname }}-register-map">
+        <table class="table table-bordered register-map-table">
+          <tr>
+            <th>Offset</th>
+            <th>Name</th>
+            {% for i in range(31, -1, -1) %}
+            <th class=vertical><div>{{ i }}</div></th>
+            {% endfor %}
+          </tr>
+          {% for _, register in peripheral.registers|dictsort %}
+            <tr>
+              <td>{{ register.offset }}</td>
+              <td>{{ register.name }}</td>
+              {% for row in register.table %}
+                {% for field in row.fields %}
+                  {% if not field.name %}
+                    {% for _ in range(field.width) %}
+                    <td {% if field.separated %}class=separated{% endif %}></td>
+                    {% endfor %}
+                  {% endif %}
+                  {% if field.name %}
+                    <td colspan={{ field.width }} class="vertical{% if field.separated %} separated{% endif %}">
+                      <div><a class="fieldlink" href="#{{ pname }}:{{ register.name }}:{{ field.name }}">{{ field.name }}</a></div>
+                    </td>
+                  {% endif %}
+                {% endfor %}
+              {% endfor %}
+            </tr>
+          {% endfor %}
+        </table>
+      </div>
       <div class="container registers" id="{{ pname }}-registers">
         {% for _, register in peripheral.registers|dictsort %}
         <div class=row>
@@ -169,7 +211,7 @@ nav.menu a {
                     </tr>
                     {% endfor %}
                   </table>
-                  <a href=# class=toggle-fields>Toggle Fields</a>.
+                  <a href=# class=toggle-fields>Toggle Fields</a>
                 </div>
               </div>
             </div>
@@ -216,6 +258,10 @@ nav.menu a {
     $(this).parent().siblings(".registers").toggle();
     e.preventDefault();
   });
+  $('.toggle-register-map').click(function(e) {
+    $(this).parent().siblings(".register-map").toggle();
+    e.preventDefault();
+  });
   $('#show-all-registers').click(function(e) {
     $('.registers').show();
     e.preventDefault();
@@ -238,7 +284,6 @@ nav.menu a {
     var register = parts[1];
     $('#' + peripheral + '-registers').show(0, function() {
       if(parts.length == 3) {
-        console.log("parts.length == 3");
         $('#' + peripheral + '-' + register + '-fields').show(0, function() {
           window.location.hash = hash;
         });


### PR DESCRIPTION
This pull request adds a "Show register map" button for each peripheral in the HTML peripheral coverage for getting a quick overview of all the fields.

![image](https://user-images.githubusercontent.com/159235/129932120-65f5cdde-edad-4604-8506-9160621abcc6.png)
