### PR TITLE
Fix allowable cortex-m-rt versions

### DIFF
--- a/scripts/makecrates.py
+++ b/scripts/makecrates.py
@@ -78,7 +78,7 @@ cortex-m = "0.7.2"
 
 [dependencies.cortex-m-rt]
 optional = true
-version = ">=0.6.13,<0.8"
+version = ">=0.6.15,<0.8"
 
 [package.metadata.docs.rs]
 features = {docs_features}


### PR DESCRIPTION
This should prevent Cargo from pulling in two different versions of cortex-m-rt, as happened in #602. This is done by requiring a cortex-m-rt version >=0.6.15, which was the first version where the `link=cortex-m-rt` field was set in Cargo.toml. 

~~The second fix is to clearly allow a cortex-m version >= 0.7.2, but still <0.8. I suspect that cargo would still allow newer versions to resolve version conflicts (as happened in #602), but I think it's better to be explicit about it.~~

EDIT: just realized that the second fix doesn't make sense.