### PR TITLE
Escape square braces in STM32WL docs

### DIFF
--- a/peripherals/pwr/pwr_wl.yaml
+++ b/peripherals/pwr/pwr_wl.yaml
@@ -45,8 +45,8 @@ PWR:
       Disabled: [0, "Internal wakeup line interrupt to CPU disabled"]
       Enabled: [1, "Internal wakeup line interrupt to CPU enabled"]
     EWRFIRQ:
-      Disabled: [0, "Radio IRQ[2:0] is disabled and does not trigger a wakeup from Standby event to CPU."]
-      Enabled: [1, "Radio IRQ[2:0] is enabled and triggers a wakeup from Standby event to CPU."]
+      Disabled: [0, "Radio IRQ\\[2:0\\] is disabled and does not trigger a wakeup from Standby event to CPU."]
+      Enabled: [1, "Radio IRQ\\[2:0\\] is enabled and triggers a wakeup from Standby event to CPU."]
     EWRFBUSY:
       Disabled: [0, "Radio Busy is disabled and does not trigger a wakeup from Standby event to CPUwhen a rising or a falling edge occurs"]
       Enabled: [1, "Radio Busy is enabled and triggers a wakeup from Standby event to CPUwhen a rising or a falling edge occurs. The active edge is configured via the WRFBUSYP bit in PWR_CR4"]
@@ -171,54 +171,54 @@ PWR:
       Enabled: [1, "Radio end-of-life detector enabled"]
   PUCRA:
     "PU1[012345]":
-      Disabled: [0, "Disable pull-up on PA[y] when both APC bits are set in PWR control register 3 (PWR_CR3)"]
-      Enabled: [1, "Enable pull-up on PA[y] when both APC bits are set in PWR control register 3 (PWR_CR3). The pull-up is not activated if the corresponding PA[y] bit is also set"]
+      Disabled: [0, "Disable pull-up on PA\\[y\\] when both APC bits are set in PWR control register 3 (PWR_CR3)"]
+      Enabled: [1, "Enable pull-up on PA\\[y\\] when both APC bits are set in PWR control register 3 (PWR_CR3). The pull-up is not activated if the corresponding PA\\[y\\] bit is also set"]
     "PU[0123456789]":
-      Disabled: [0, "Disable pull-up on PA[y] when both APC bits are set in PWR control register 3 (PWR_CR3)"]
-      Enabled: [1, "Enable pull-up on PA[y] when both APC bits are set in PWR control register 3 (PWR_CR3). The pull-up is not activated if the corresponding PA[y] bit is also set"]
+      Disabled: [0, "Disable pull-up on PA\\[y\\] when both APC bits are set in PWR control register 3 (PWR_CR3)"]
+      Enabled: [1, "Enable pull-up on PA\\[y\\] when both APC bits are set in PWR control register 3 (PWR_CR3). The pull-up is not activated if the corresponding PA\\[y\\] bit is also set"]
   PDCRA:
     "PD1[012345]":
-      Disabled: [0, "Disable the pull-down on PA[y] when both APC bits are set in PWR control register 3 (PWR_CR3)"]
-      Enabled: [1, "Enable the pull-down on PA[y] when both APC bits are set in PWR control register 3 (PWR_CR3)"]
+      Disabled: [0, "Disable the pull-down on PA\\[y\\] when both APC bits are set in PWR control register 3 (PWR_CR3)"]
+      Enabled: [1, "Enable the pull-down on PA\\[y\\] when both APC bits are set in PWR control register 3 (PWR_CR3)"]
     "PD[0123456789]":
-      Disabled: [0, "Disable the pull-down on PA[y] when both APC bits are set in PWR control register 3 (PWR_CR3)"]
-      Enabled: [1, "Enable the pull-down on PA[y] when both APC bits are set in PWR control register 3 (PWR_CR3)"]
+      Disabled: [0, "Disable the pull-down on PA\\[y\\] when both APC bits are set in PWR control register 3 (PWR_CR3)"]
+      Enabled: [1, "Enable the pull-down on PA\\[y\\] when both APC bits are set in PWR control register 3 (PWR_CR3)"]
   PUCRB:
     "PU1[012345]":
-      Disabled: [0, "Disable pull-up on PB[y] when both APC bits are set in PWR control register 3 (PWR_CR3)"]
-      Enabled: [1, "Enable pull-up on PB[y] when both APC bits are set in PWR control register 3 (PWR_CR3). The pull-up is not activated if the corresponding PB[y] bit is also set"]
+      Disabled: [0, "Disable pull-up on PB\\[y\\] when both APC bits are set in PWR control register 3 (PWR_CR3)"]
+      Enabled: [1, "Enable pull-up on PB\\[y\\] when both APC bits are set in PWR control register 3 (PWR_CR3). The pull-up is not activated if the corresponding PB\\[y\\] bit is also set"]
     "PU[0123456789]":
-      Disabled: [0, "Disable pull-up on PB[y] when both APC bits are set in PWR control register 3 (PWR_CR3)"]
-      Enabled: [1, "Enable pull-up on PB[y] when both APC bits are set in PWR control register 3 (PWR_CR3). The pull-up is not activated if the corresponding PB[y] bit is also set"]
+      Disabled: [0, "Disable pull-up on PB\\[y\\] when both APC bits are set in PWR control register 3 (PWR_CR3)"]
+      Enabled: [1, "Enable pull-up on PB\\[y\\] when both APC bits are set in PWR control register 3 (PWR_CR3). The pull-up is not activated if the corresponding PB\\[y\\] bit is also set"]
   PDCRB:
     "PD1[012345]":
-      Disabled: [0, "Disable the pull-down on PB[y] when both APC bits are set in PWR control register 3 (PWR_CR3)"]
-      Enabled: [1, "Enable the pull-down on PB[y] when both APC bits are set in PWR control register 3 (PWR_CR3)"]
+      Disabled: [0, "Disable the pull-down on PB\\[y\\] when both APC bits are set in PWR control register 3 (PWR_CR3)"]
+      Enabled: [1, "Enable the pull-down on PB\\[y\\] when both APC bits are set in PWR control register 3 (PWR_CR3)"]
     "PD[0123456789]":
-      Disabled: [0, "Disable the pull-down on PB[y] when both APC bits are set in PWR control register 3 (PWR_CR3)"]
-      Enabled: [1, "Enable the pull-down on PB[y] when both APC bits are set in PWR control register 3 (PWR_CR3)"]
+      Disabled: [0, "Disable the pull-down on PB\\[y\\] when both APC bits are set in PWR control register 3 (PWR_CR3)"]
+      Enabled: [1, "Enable the pull-down on PB\\[y\\] when both APC bits are set in PWR control register 3 (PWR_CR3)"]
   PUCRC:
     "PU1[345]":
-      Disabled: [0, "Disable pull-up on PC[y] when both APC bits are set in PWR control register 3 (PWR_CR3)"]
-      Enabled: [1, "Enable pull-up on PC[y] when both APC bits are set in PWR control register 3 (PWR_CR3). The pull-up is not activated if the corresponding PC[y] bit is also set"]
+      Disabled: [0, "Disable pull-up on PC\\[y\\] when both APC bits are set in PWR control register 3 (PWR_CR3)"]
+      Enabled: [1, "Enable pull-up on PC\\[y\\] when both APC bits are set in PWR control register 3 (PWR_CR3). The pull-up is not activated if the corresponding PC\\[y\\] bit is also set"]
     "PU[0123456]":
-      Disabled: [0, "Disable pull-up on PC[y] when both APC bits are set in PWR control register 3 (PWR_CR3)"]
-      Enabled: [1, "Enable pull-up on PC[y] when both APC bits are set in PWR control register 3 (PWR_CR3). The pull-up is not activated if the corresponding PC[y] bit is also set"]
+      Disabled: [0, "Disable pull-up on PC\\[y\\] when both APC bits are set in PWR control register 3 (PWR_CR3)"]
+      Enabled: [1, "Enable pull-up on PC\\[y\\] when both APC bits are set in PWR control register 3 (PWR_CR3). The pull-up is not activated if the corresponding PC\\[y\\] bit is also set"]
   PDCRC:
     "PD1[345]":
-      Disabled: [0, "Disable the pull-down on PC[y] when both APC bits are set in PWR control register 3 (PWR_CR3)"]
-      Enabled: [1, "Enable the pull-down on PC[y] when both APC bits are set in PWR control register 3 (PWR_CR3)"]
+      Disabled: [0, "Disable the pull-down on PC\\[y\\] when both APC bits are set in PWR control register 3 (PWR_CR3)"]
+      Enabled: [1, "Enable the pull-down on PC\\[y\\] when both APC bits are set in PWR control register 3 (PWR_CR3)"]
     "PD[0123456]":
-      Disabled: [0, "Disable the pull-down on PC[y] when both APC bits are set in PWR control register 3 (PWR_CR3)"]
-      Enabled: [1, "Enable the pull-down on PC[y] when both APC bits are set in PWR control register 3 (PWR_CR3)"]
+      Disabled: [0, "Disable the pull-down on PC\\[y\\] when both APC bits are set in PWR control register 3 (PWR_CR3)"]
+      Enabled: [1, "Enable the pull-down on PC\\[y\\] when both APC bits are set in PWR control register 3 (PWR_CR3)"]
   PUCRH:
     PU3:
-      Disabled: [0, "Disable pull-up on PH[y] when both APC bits are set in PWR control register 3 (PWR_CR3)"]
-      Enabled: [1, "Enable pull-up on PH[y] when both APC bits are set in PWR control register 3 (PWR_CR3). The pull-up is not activated if the corresponding PH[y] bit is also set"]
+      Disabled: [0, "Disable pull-up on PH\\[y\\] when both APC bits are set in PWR control register 3 (PWR_CR3)"]
+      Enabled: [1, "Enable pull-up on PH\\[y\\] when both APC bits are set in PWR control register 3 (PWR_CR3). The pull-up is not activated if the corresponding PH\\[y\\] bit is also set"]
   PDCRH:
     PD3:
-      Disabled: [0, "Disable the pull-down on PH[y] when both APC bits are set in PWR control register 3 (PWR_CR3)"]
-      Enabled: [1, "Enable the pull-down on PH[y] when both APC bits are set in PWR control register 3 (PWR_CR3)"]
+      Disabled: [0, "Disable the pull-down on PH\\[y\\] when both APC bits are set in PWR control register 3 (PWR_CR3)"]
+      Enabled: [1, "Enable the pull-down on PH\\[y\\] when both APC bits are set in PWR control register 3 (PWR_CR3)"]
   EXTSCR:
     C1DS:
       RunningOrSleep: [0, "CPU is running or in sleep"]

--- a/peripherals/rcc/rcc_wl.yaml
+++ b/peripherals/rcc/rcc_wl.yaml
@@ -51,8 +51,8 @@
       Range32M: [0b1010, "range 10 around 32 MHz"]
       Range48M: [0b1011, "range 11 around 48 MHz"]
     MSIRGSEL:
-      CSR: [0, "MSI frequency range defined by MSISRANGE[3:0] in the RCC_CSR register"]
-      CR: [1, "MSI frequency range defined by MSIRANGE[3:0] in the RCC_CR register"]
+      CSR: [0, "MSI frequency range defined by MSISRANGE\\[3:0\\] in the RCC_CSR register"]
+      CR: [1, "MSI frequency range defined by MSIRANGE\\[3:0\\] in the RCC_CR register"]
     MSIPLLEN:
       "Off": [0, "MSI PLL Off"]
       "On": [1, "MSI PLL On"]

--- a/peripherals/rng/rng_wl.yaml
+++ b/peripherals/rng/rng_wl.yaml
@@ -5,8 +5,8 @@ _include:
 RNG:
   CR:
     CONFIGLOCK:
-      Enabled: [0, "Writes to the RNG_CR configuration bits [29:4] are allowed"]
-      Disabled: [1, "Writes to the RNG_CR configuration bits [29:4] are ignored until the next RNG reset"]
+      Enabled: [0, "Writes to the RNG_CR configuration bits \\[29:4\\] are allowed"]
+      Disabled: [1, "Writes to the RNG_CR configuration bits \\[29:4\\] are ignored until the next RNG reset"]
     CONDRST:
     RNG_CONFIG1:
       ConfigA: [0x0F, "Recommended value for config A (NIST certifiable)"]

--- a/peripherals/rtc/rtc_wl.yaml
+++ b/peripherals/rtc/rtc_wl.yaml
@@ -26,14 +26,14 @@ RTC:
       _read:
         Pending: [1, "The RECALPF status flag is automatically set to 1 when software writes to the RTC_CALR register, indicating that the RTC_CALR register is blocked. When the new calibration settings are taken into account, this bit returns to 0"]
     BCDU:
-      Bit7: [0, "1s increment each time SS[7:0]=0"]
-      Bit8: [1, "1s increment each time SS[8:0]=0"]
-      Bit9: [2, "1s increment each time SS[9:0]=0"]
-      Bit10: [3, "1s increment each time SS[10:0]=0"]
-      Bit11: [4, "1s increment each time SS[11:0]=0"]
-      Bit12: [5, "1s increment each time SS[12:0]=0"]
-      Bit13: [6, "1s increment each time SS[13:0]=0"]
-      Bit14: [7, "1s increment each time SS[14:0]=0"]
+      Bit7: [0, "1s increment each time SS\\[7:0\\]=0"]
+      Bit8: [1, "1s increment each time SS\\[8:0\\]=0"]
+      Bit9: [2, "1s increment each time SS\\[9:0\\]=0"]
+      Bit10: [3, "1s increment each time SS\\[10:0\\]=0"]
+      Bit11: [4, "1s increment each time SS\\[11:0\\]=0"]
+      Bit12: [5, "1s increment each time SS\\[12:0\\]=0"]
+      Bit13: [6, "1s increment each time SS\\[13:0\\]=0"]
+      Bit14: [7, "1s increment each time SS\\[14:0\\]=0"]
     BIN:
       BCD: [0, "Free running BCD calendar mode (Binary mode disabled)"]
       Binary: [1, "Free running Binary mode (BCD mode disabled)"]
@@ -101,8 +101,8 @@ RTC:
       AlarmB: [2, "Alarm B output enabled"]
       Wakeup: [3, "Wakeup output enabled"]
     POL:
-      High: [0, "The pin is high when ALRAF/ALRBF/WUTF is asserted (depending on OSEL[1:0])"]
-      Low: [1, "The pin is low when ALRAF/ALRBF/WUTF is asserted (depending on OSEL[1:0])"]
+      High: [0, "The pin is high when ALRAF/ALRBF/WUTF is asserted (depending on OSEL\\[1:0\\])"]
+      Low: [1, "The pin is low when ALRAF/ALRBF/WUTF is asserted (depending on OSEL\\[1:0\\])"]
     COSEL:
       CalFreq_512Hz: [0, "Calibration output is 512 Hz (with default prescaler setting)"]
       CalFreq_1Hz: [1, "Calibration output is 1 Hz (with default prescaler setting)"]
@@ -214,8 +214,8 @@ RTC:
       Mask: [0, "Alarm set if the date/day match"]
       NotMask: [1, "Date/day don’t care in Alarm comparison"]
     WDSEL:
-      DateUnits: [0, "DU[3:0] represents the date units"]
-      WeekDay: [1, "DU[3:0] represents the week day. DT[1:0] is don’t care."]
+      DateUnits: [0, "DU\\[3:0\\] represents the date units"]
+      WeekDay: [1, "DU\\[3:0\\] represents the week day. DT\\[1:0\\] is don’t care."]
     DT: [0, 3]
     DU: [0, 15]
     PM:
@@ -230,8 +230,8 @@ RTC:
 
   "ALRM?SSR":
     SSCLR:
-      FreeRunning: [0, "The synchronous binary counter (SS[31:0] in RTC_SSR) is free-running"]
-      ALRMBINR: [1, "The synchronous binary counter (SS[31:0] in RTC_SSR) is running from 0xFFFF FFFF to RTC_ALRMABINR → SS[31:0] value and is automatically reloaded with 0xFFFF FFFF when reaching RTC_ALRMABINR → SS[31:0]"]
+      FreeRunning: [0, "The synchronous binary counter (SS\\[31:0\\] in RTC_SSR) is free-running"]
+      ALRMBINR: [1, "The synchronous binary counter (SS\\[31:0\\] in RTC_SSR) is running from 0xFFFF FFFF to RTC_ALRMABINR → SS\\[31:0\\] value and is automatically reloaded with `0xFFFF_FFFF` when reaching RTC_ALRMABINR → SS\\[31:0\\]"]
     MASKSS: [0, 0x3F]
     SS: [0, 0x7FFF]
 

--- a/peripherals/syscfg/syscfg_wl.yaml
+++ b/peripherals/syscfg/syscfg_wl.yaml
@@ -124,8 +124,8 @@ SYSCFG:
         Connect: [1, "Connect ECC error to TIM1/16/17 break input"]
     PVDL:
       _read:
-        Disconnected: [0, "PVD interrupt disconnected from TIM1/16/17 break input. PVDE and PLS[2:0] bits can be programmed by the application"]
-        Connected:    [1, "PVD interrupt connected to TIM1/16/17 break input. PVDE and PLS[2:0] bits are read only"]
+        Disconnected: [0, "PVD interrupt disconnected from TIM1/16/17 break input. PVDE and PLS\\[2:0\\] bits can be programmed by the application"]
+        Connected:    [1, "PVD interrupt connected to TIM1/16/17 break input. PVDE and PLS\\[2:0\\] bits are read only"]
       _write:
         Connect: [1, "Connect PVD interretup to TIM1/16/17 break input"]
     SPL:
@@ -157,5 +157,5 @@ SYSCFG:
 
   RFDCR:
     RFTBSEL:
-      Digital: [0, "Digital test bus selected on RF_ADTB[3:0]"]
-      Analog:  [1, "Analog test bus selected on RF_ADTB[3:0]"]
+      Digital: [0, "Digital test bus selected on RF_ADTB\\[3:0\\]"]
+      Analog:  [1, "Analog test bus selected on RF_ADTB\\[3:0\\]"]

--- a/peripherals/tim/tim12_common_wl.yaml
+++ b/peripherals/tim/tim12_common_wl.yaml
@@ -62,10 +62,10 @@
       TI2FP2: [6, "Filtered Timer Input 2 (TI2FP2)"]
       ETRF: [7, "External Trigger input (ETRF)"]
     SMS_3:
-      Disabled: [0, "Slave mode disabled (see SMS[0:2])"]
-      CombinedResetTrigger: [1, "SMS[0:2] must be 0b000 (DisabledOrCombined). Combined reset + trigger mode - Rising edge of the selected trigger input (TRGI) reinitializes the counter, generates an update of the registers and starts the counter"]
+      Disabled: [0, "Slave mode disabled (see SMS\\[0:2\\])"]
+      CombinedResetTrigger: [1, "SMS\\[0:2\\] must be 0b000 (DisabledOrCombined). Combined reset + trigger mode - Rising edge of the selected trigger input (TRGI) reinitializes the counter, generates an update of the registers and starts the counter"]
     SMS:
-      DisabledOrCombined: [0, "Slave mode disabled - if CEN = ‘1 then the prescaler is clocked directly by the internal clock. If SMS[3]=1 then Combined reset + trigger mode - Rising edge of the selected trigger input (TRGI) reinitializes the counter, generates an update of the registers and starts the counter"]
+      DisabledOrCombined: [0, "Slave mode disabled - if CEN = `1` then the prescaler is clocked directly by the internal clock. If SMS\\[3\\]=1 then Combined reset + trigger mode - Rising edge of the selected trigger input (TRGI) reinitializes the counter, generates an update of the registers and starts the counter"]
       EncoderMode1: [1, "Encoder mode 1 - Counter counts up/down on TI2FP1 edge depending on TI1FP2 level"]
       EncoderMode2: [2, "Encoder mode 2 - Counter counts up/down on TI1FP2 edge depending on TI2FP1 level"]
       EncoderMode3: [3, "Encoder mode 3 - Counter counts up/down on both TI1FP1 and TI2FP2 edges depending on the level of the other input"]


### PR DESCRIPTION
Fixes all the dead links for the STM32WL crate.

cc @jorgeig-space