### PR TITLE
[scripts] Fix int base when parsing

### DIFF
--- a/scripts/comparesvd.py
+++ b/scripts/comparesvd.py
@@ -9,11 +9,11 @@ def getregs(s):
     regs = {}
     for peripheral in s.iter('peripheral'):
         pname = peripheral.find('name').text
-        base = int(peripheral.find('baseAddress').text, 16)
+        base = int(peripheral.find('baseAddress').text, 0)
         for register in peripheral.iter('register'):
             rname = register.find('name').text
             name = pname + "_" + rname
-            offset = int(register.find('addressOffset').text, 16)
+            offset = int(register.find('addressOffset').text, 0)
             regs[name] = hex(base+offset)
     return regs
 

--- a/scripts/htmlcomparesvd.py
+++ b/scripts/htmlcomparesvd.py
@@ -31,8 +31,8 @@ def parse(svdfile):
             roffset = int(rtag.find('addressOffset').text, 0)
             for ftag in iter_fields(rtag):
                 fname = ftag.find('name').text
-                foffset = int(ftag.find('bitOffset').text)
-                fwidth = int(ftag.find('bitWidth').text)
+                foffset = int(ftag.find('bitOffset').text, 0)
+                fwidth = int(ftag.find('bitWidth').text, 0)
                 fields[fname] = {"name": fname, "offset": foffset,
                                  "width": fwidth}
             registers[rname] = {"name": rname, "offset": roffset,

--- a/scripts/htmlcomparesvd.py
+++ b/scripts/htmlcomparesvd.py
@@ -24,11 +24,11 @@ def parse(svdfile):
     for ptag in iter_peripherals(tree):
         registers = {}
         pname = ptag.find('name').text
-        pbase = int(ptag.find('baseAddress').text, 16)
+        pbase = int(ptag.find('baseAddress').text, 0)
         for rtag in iter_registers(ptag):
             fields = {}
             rname = rtag.find('name').text
-            roffset = int(rtag.find('addressOffset').text, 16)
+            roffset = int(rtag.find('addressOffset').text, 0)
             for ftag in iter_fields(rtag):
                 fname = ftag.find('name').text
                 foffset = int(ftag.find('bitOffset').text)

--- a/scripts/makehtml.py
+++ b/scripts/makehtml.py
@@ -79,13 +79,13 @@ def parse_device(svdfile):
                 frange = ftag.findtext('bitRange')
                 if frange:
                     parts = frange[1:-1].split(':')
-                    end = int(parts[0])
-                    start = int(parts[1])
+                    end = int(parts[0], 0)
+                    start = int(parts[1], 0)
                     foffset = start
                     fwidth = end - start + 1
                 else:
-                    foffset = int(ftag.findtext('bitOffset'))
-                    fwidth = int(ftag.findtext('bitWidth'))
+                    foffset = int(ftag.findtext('bitOffset'), 0)
+                    fwidth = int(ftag.findtext('bitWidth'), 0)
                 faccs = ftag.findtext('access') or raccs
                 enum = ftag.find('enumeratedValues')
                 wc = ftag.find('writeConstraint')

--- a/scripts/makejson.py
+++ b/scripts/makejson.py
@@ -50,7 +50,7 @@ def parse_device(svdfile):
                 raccs = raccs.text
             else:
                 raccs = "Unspecified"
-            roffset = int(rtag.find('addressOffset').text, 16)
+            roffset = int(rtag.find('addressOffset').text, 0)
             for ftag in rtag.iter('field'):
                 register_fields_total += 1
                 fname = ftag.find('name').text

--- a/scripts/makejson.py
+++ b/scripts/makejson.py
@@ -55,8 +55,8 @@ def parse_device(svdfile):
                 register_fields_total += 1
                 fname = ftag.find('name').text
                 fdesc = ftag.find('description').text
-                foffset = int(ftag.find('bitOffset').text)
-                fwidth = int(ftag.find('bitWidth').text)
+                foffset = int(ftag.find('bitOffset').text, 0)
+                fwidth = int(ftag.find('bitWidth').text, 0)
                 enum = ftag.find('enumeratedValues')
                 if enum is not None:
                     register_fields_documented += 1

--- a/scripts/periphtemplate.py
+++ b/scripts/periphtemplate.py
@@ -32,8 +32,8 @@ def parse_periph(svdfile, pname):
         roffset = int(rtag.find('addressOffset').text, 0)
         for ftag in rtag.iter('field'):
             fname = ftag.find('name').text
-            foffset = int(ftag.find('bitOffset').text)
-            fwidth = int(ftag.find('bitWidth').text)
+            foffset = int(ftag.find('bitOffset').text, 0)
+            fwidth = int(ftag.find('bitWidth').text, 0)
             fields[foffset] = {"name": fname, "width": fwidth}
         registers[roffset] = {"name": rname, "fields": fields}
     return registers

--- a/scripts/periphtemplate.py
+++ b/scripts/periphtemplate.py
@@ -29,7 +29,7 @@ def parse_periph(svdfile, pname):
     for rtag in ptag.iter('register'):
         fields = {}
         rname = rtag.find('name').text
-        roffset = int(rtag.find('addressOffset').text, 16)
+        roffset = int(rtag.find('addressOffset').text, 0)
         for ftag in rtag.iter('field'):
             fname = ftag.find('name').text
             foffset = int(ftag.find('bitOffset').text)


### PR DESCRIPTION
When comparing some peripherals I saw that some `baseAddress` where parsed as base 10 but still prefixed with "0x".
I fixed every int parsing left in the `scripts` folder to automatically use the right base.