### PR TITLE
[html-compare] f7: Change order of MCUs in the table

### DIFF
--- a/scripts/htmlcomparesvdall.sh
+++ b/scripts/htmlcomparesvdall.sh
@@ -2,7 +2,7 @@
 set -euxo pipefail
 
 mkdir -p html/stm32f
-python3 scripts/htmlcomparesvd.py html/stm32f svd/stm32f{0x8,103,107,217,303,3x4,469,7x2,7x9}.svd.patched
+python3 scripts/htmlcomparesvd.py html/stm32f svd/stm32f{0x8,103,107,217,303,3x4,469,7x9}.svd.patched
 sed -i 's#<table>#<p>Only a representative member of each family included; click to view entire family</p><table>#' html/stm32f/index.html
 sed -i 's#stm32f0x8#<a href="stm32f0/index.html">STM32F0x8</a>#' html/stm32f/index.html
 sed -i 's#stm32f103#<a href="stm32f1/index.html">STM32F103</a>#' html/stm32f/index.html
@@ -11,7 +11,6 @@ sed -i 's#stm32f217#<a href="stm32f2/index.html">STM32F217</a>#' html/stm32f/ind
 sed -i 's#stm32f303#<a href="stm32f3/index.html">STM32F303</a>#' html/stm32f/index.html
 sed -i 's#stm32f3x4#<a href="stm32f3/index.html">STM32F3x4</a>#' html/stm32f/index.html
 sed -i 's#stm32f469#<a href="stm32f4/index.html">STM32F469</a>#' html/stm32f/index.html
-sed -i 's#stm32f7x2#<a href="stm32f7/index.html">STM32F7x2</a>#' html/stm32f/index.html
 sed -i 's#stm32f7x9#<a href="stm32f7/index.html">STM32F7x9</a>#' html/stm32f/index.html
 
 mkdir -p html/stm32f/stm32f0
@@ -30,7 +29,7 @@ mkdir -p html/stm32f/stm32f4
 python3 scripts/htmlcomparesvd.py html/stm32f/stm32f4 svd/stm32f4*.svd.patched
 
 mkdir -p html/stm32f/stm32f7
-python3 scripts/htmlcomparesvd.py html/stm32f/stm32f7 svd/stm32f7*.svd.patched
+python3 scripts/htmlcomparesvd.py html/stm32f/stm32f7 svd/stm32f7{x2,x3,30,45,50,x6,65,x7,x9}.svd.patched
 
 mkdir -p html/stm32l
 python3 scripts/htmlcomparesvd.py html/stm32l svd/stm32l{0x3,162,4x6}.svd.patched


### PR DESCRIPTION
When comparing peripherals and fields from the F7 family, there is 3 big groups of MCU that we can distinguish:

- RM0431: F7x2, F7x3, F30x
- RM0385: F745, F750, F7x6
- RM0410: F765, F7x7, F7x9

This PR reorder the chips in the table so it's easier to detect a missing field or register in each group.