### PR TITLE
stm32wb: syscfg: fix split sections

### DIFF
--- a/devices/stm32wb55.yaml
+++ b/devices/stm32wb55.yaml
@@ -5,6 +5,10 @@ _modify:
   ADC:
     # Consistent naming across families
     name: ADC1
+  SYSCFG:
+    baseAddress: "0x40010000"
+    addressBlock:
+      size: 0x200
 
 # Rename registers starting with a number 802 (related to IEEE 802.15.4)
 # since it's not allowed to have a register/field name start with a number.
@@ -73,6 +77,18 @@ EXTI:
   C2IMR2:
     _split: [IM]
 
+SYSCFG:
+  _modify:
+    IMR1:
+      addressOffset: 0x100
+    IMR2:
+      addressOffset: 0x104
+    C2IMR1:
+      addressOffset: 0x108
+    C2IMR2:
+      addressOffset: 0x10c
+    SIPCR:
+      addressOffset: 0x110
 
 TIM16:
   CR1:


### PR DESCRIPTION
Fixes: https://github.com/stm32-rs/stm32-rs/pull/473

Fixes the base address, and then for the registers after the split,
fixup their addresses manually.

Signed-off-by: Karl Palsson <karlp@etactica.com>

Is there really any need to specifically mark the VREFBUF as "reserved" within the syscfg block as discussed in #473? is that important? the memory map generated looks correct.