### PR TITLE
stm32wl: add register descriptions for dual-core variants

### DIFF
--- a/devices/stm32wl5x_cm0p.yaml
+++ b/devices/stm32wl5x_cm0p.yaml
@@ -41,6 +41,10 @@ HSEM:
     HSEM_C2ICR:
       access: read-write
 
+IPCC:
+  _strip:
+    - IPCC_
+
 TIM1:
   _modify:
     CCMR3OutputComparemode:
@@ -125,9 +129,11 @@ _include:
  - ../peripherals/dma/dmamux_wl.yaml
  - ../peripherals/exti/exti.yaml
  - ../peripherals/flash/flash_wl.yaml
+ - ../peripherals/flash/flash_wl_c2.yaml
  - ../peripherals/gpio/gpio_v2_common.yaml
  - ../peripherals/gpio/gpio_wl_with_brr.yaml
  - ../peripherals/hsem/hsem_wl.yaml
+ - ../peripherals/ipcc/ipcc_wl.yaml
  - ../peripherals/i2c/i2c_v2.yaml
  - ../peripherals/iwdg/iwdg.yaml
  - ../peripherals/iwdg/iwdg_sr.yaml
@@ -136,7 +142,9 @@ _include:
  - ../peripherals/usart/lpuart_wl.yaml
  - ../peripherals/pka/pka.yaml
  - ../peripherals/pwr/pwr_wl.yaml
+ - ../peripherals/pwr/pwr_wl_c2.yaml
  - ../peripherals/rcc/rcc_wl.yaml
+ - ../peripherals/rcc/rcc_wl_c2.yaml
  - ../peripherals/rtc/rtc_wl.yaml
  - ../peripherals/rng/rng_wl.yaml
  - ../peripherals/spi/spi_v2.yaml

--- a/devices/stm32wl5x_cm4.yaml
+++ b/devices/stm32wl5x_cm4.yaml
@@ -41,6 +41,10 @@ HSEM:
     HSEM_C2ICR:
       access: read-write
 
+IPCC:
+  _strip:
+    - IPCC_
+
 TIM1:
   _modify:
     CCMR3OutputComparemode:
@@ -128,9 +132,11 @@ _include:
  - ../peripherals/dbg/dbg_wl.yaml
  - ../peripherals/exti/exti.yaml
  - ../peripherals/flash/flash_wl.yaml
+ - ../peripherals/flash/flash_wl_c2.yaml
  - ../peripherals/gpio/gpio_v2_common.yaml
  - ../peripherals/gpio/gpio_wl_with_brr.yaml
  - ../peripherals/hsem/hsem_wl.yaml
+ - ../peripherals/ipcc/ipcc_wl.yaml
  - ../peripherals/i2c/i2c_v2.yaml
  - ../peripherals/iwdg/iwdg.yaml
  - ../peripherals/iwdg/iwdg_sr.yaml
@@ -139,7 +145,9 @@ _include:
  - ../peripherals/usart/lpuart_wl.yaml
  - ../peripherals/pka/pka.yaml
  - ../peripherals/pwr/pwr_wl.yaml
+ - ../peripherals/pwr/pwr_wl_c2.yaml
  - ../peripherals/rcc/rcc_wl.yaml
+ - ../peripherals/rcc/rcc_wl_c2.yaml
  - ../peripherals/rtc/rtc_wl.yaml
  - ../peripherals/rng/rng_wl.yaml
  - ../peripherals/spi/spi_v2.yaml

--- a/peripherals/flash/flash_wl.yaml
+++ b/peripherals/flash/flash_wl.yaml
@@ -5,7 +5,7 @@ FLASH:
       Empty: [1, "User Flash empty"]
     PES:
       Granted: [0, "Flash program and erase operations granted"]
-      Suspended: [1, "Any new Flash program and erase operation is suspended until this bit is cleared. The PESD bit in FLASH_SR is set when PES bit in FLASH_ACRis set"]
+      Suspended: [1, "Any new Flash program and erase operation is suspended until this bit is cleared. The PESD bit in FLASH_SR is set when PES bit in FLASH_ACR is set"]
     DCRST:
       NotReset: [0, "Data cache is not reset"]
       Reset: [1, "Data cache is reset"]
@@ -156,7 +156,7 @@ FLASH:
         Done: [0, "Options modification completed or idle"]
       _write:
         Start: [1, "Trigger options programming operation"]
-    PNB: [0, 0x63]
+    PNB: [0, 0x7F]
     MER:
       NoErase: [0, "No mass erase"]
       MassErase: [1, "Trigger mass erase"]

--- a/peripherals/flash/flash_wl_c2.yaml
+++ b/peripherals/flash/flash_wl_c2.yaml
@@ -1,6 +1,6 @@
 FLASH:
   IPCCBR:
-    IPCCDBA: [0, 0x1FFF]
+    IPCCDBA: [0, 0x3FFF]
   C2ACR:
     PES:
       Granted: [0, "Flash program and erase operations granted"]

--- a/peripherals/flash/flash_wl_c2.yaml
+++ b/peripherals/flash/flash_wl_c2.yaml
@@ -1,0 +1,145 @@
+FLASH:
+  IPCCBR:
+    IPCCDBA: [0, 0x1FFF]
+  C2ACR:
+    PES:
+      Granted: [0, "Flash program and erase operations granted"]
+      Suspended: [1, "Any new Flash program and erase operation is suspended until this bit is cleared. The PESD bit in FLASH_C2SR is set when PES bit in FLASH_C2ACR is set"]
+    ICRST:
+      NotReset: [0, "CPU2 instruction cache is not reset"]
+      Reset: [1, "CPU2 instruction cache is reset"]
+    ICEN:
+      Disabled: [0, "CPU2 instruction cache is disabled"]
+      Enabled: [1, "CPU2 instruction cache is enabled"]
+    PRFTEN:
+      Disabled: [0, "CPU2 prefetch is disabled"]
+      Enabled: [1, "CPU2 prefetch is enabled"]
+  C2SR:
+    _modify:
+      MISERR:
+        name: MISSERR
+    PESD:
+      Granted: [0, "Flash program and erase operations granted"]
+      Suspended: [1, "Any new Flash program and erase operation is suspended until this bit is cleared. This bit is set when at least one PES bit in FLASH_ACR or FLASH_C2ACR is set."]
+    CFGBSY:
+      Free: [0, "PG, PNB, PER, MER bits available for writing"]
+      Busy: [1, "PG, PNB, PER, MER bits not available for writing (operation ongoing)"]
+    BSY:
+      Inactive: [0, "No write/erase operation is in progress"]
+      Active: [1, "No write/erase operation is in progress"]
+    RDERR:
+      _read:
+        NoError: [0, "No read-only error happened"]
+        Error: [1, "Read-only error happened"]
+      _write:
+        Clear: [1, "Clear the flag"]
+    FASTERR:
+      _read:
+        NoError: [0, "No fast programming error happened"]
+        Error: [1, "Fast programming error happened"]
+      _write:
+        Clear: [1, "Clear the flag"]
+    MISSERR:
+      _read:
+        NoError: [0, "No fast programming data miss error happened"]
+        Error: [1, "Fast programming data miss error happened"]
+      _write:
+        Clear: [1, "Clear the flag"]
+    PGSERR:
+      _read:
+        NoError: [0, "No fast programming sequence error happened"]
+        Error: [1, "Fast programming sequence error happened"]
+      _write:
+        Clear: [1, "Clear the flag"]
+    SIZERR:
+      _read:
+        NoError: [0, "No size error happened"]
+        Error: [1, "Size error happened"]
+      _write:
+        Clear: [1, "Clear the flag"]
+    PGAERR:
+      _read:
+        NoError: [0, "No programming alignment error happened"]
+        Error: [1, "Programming alignment error happened"]
+      _write:
+        Clear: [1, "Clear the flag"]
+    WRPERR:
+      _read:
+        NoError: [0, "No write protection error happened"]
+        Error: [1, "Write protection error happened"]
+      _write:
+        Clear: [1, "Clear the flag"]
+    PROGERR:
+      _read:
+        NoError: [0, "No size programming error happened"]
+        Error: [1, "Programming error happened"]
+      _write:
+        Clear: [1, "Clear the flag"]
+    OPERR:
+      _read:
+        NoError: [0, "No memory opreation error happened"]
+        Error: [1, "Memory operation error happened"]
+      _write:
+        Clear: [1, "Clear the flag"]
+    EOP:
+      _read:
+        NoEvent: [0, "No EOP operation occurred"]
+        Event: [1, "An EOP event occurred"]
+      _write:
+        Clear: [1, "Clear the flag"]
+  C2CR:
+    RDERRIE:
+      Disabled: [0, "PCROP read error interrupt disable"]
+      Enabled: [1, "PCROP read error interrupt enable"]
+    ERRIE:
+      Disabled: [0, "OPERR Error interrupt disable"]
+      Enabled: [1, "OPERR Error interrupt enable"]
+    EOPIE:
+      Disabled: [0, "End of program interrupt disable"]
+      Enabled: [1, "End of program interrupt enable"]
+    FSTPG:
+      Disabled: [0, "Fast programming disabled"]
+      Enabled: [1, "Fast programming enabled"]
+    STRT:
+      _read:
+        Done: [0, "Options modification completed or idle"]
+      _write:
+        Start: [1, "Trigger options programming operation"]
+    PNB: [0, 0x7F]
+    MER:
+      NoErase: [0, "No mass erase"]
+      MassErase: [1, "Trigger mass erase"]
+    PER:
+      Disabled: [0, "Page erase disabled"]
+      Enabled: [1, "Page erase enabled"]
+    PG:
+      Disabled: [0, "Flash programming disabled"]
+      Enabled: [1, "Flash programming enabled"]
+  SFR:
+    SUBGHSPISD:
+      Enabled: [0, "sub-GHz radio SPI security enabled"]
+      Disabled: [1, "sub-GHz radio SPI security disabled"]
+    HDPAD:
+      Enabled: [0, "User Flash memory hide protection area enabled. HDPSA[6:0] contains the start address of the first 2-Kbyte page of the user Flash memory hide protection area"]
+      Disabled: [1, "User Flash memory hide protection area disabled"]
+    HDPSA: [0, 0x7F]
+    DDS:
+      Enabled: [0, "CPU2 debug access enabled"]
+      Disabled: [1, "CPU2 debug access disabled"]
+    FSD:
+      Secure: [0, "System and Flash memory secure"]
+      NonSecure: [1, "System and Flash memory non-secure"]
+    SFSA: [0, 0x7F]
+  SRRVR:
+    C2OPT:
+      SRAM: [0, "SBRV offset addresses SRAM1 or SRAM2, from start address 0x2000_0000 + SBRV"]
+      Flash: [1, "SBRV offset addresses the Flash memory, from start address 0x0800_0000 + SBRV"]
+    NBRSD:
+      Secure: [0, 'SRAM1 is secure. SNBRSA[4:0] contains the start address of the first 1-Kbyte page of the secure non-backup SRAM1 area']
+      NonSecure: [1, 'SRAM1 is non-secure']
+    SNBRSA: [0, 0x1F]
+    BRSD:
+      Secure: [0, 'SRAM2 is secure. SNBRSA[4:0] contains the start address of the first 1-Kbyte page of the secure backup SRAM2 area']
+      NonSecure: [1, 'SRAM2 is non-secure']
+    SBRSA: [0, 0x1F]
+    SBRV: [0, 0xFFFF]

--- a/peripherals/ipcc/ipcc_wl.yaml
+++ b/peripherals/ipcc/ipcc_wl.yaml
@@ -1,0 +1,26 @@
+IPCC:
+  "C[12]CR":
+    TXFIE:
+      Enabled: [1, "Enable an unmasked processor transmit channel free to generate a TX free interrupt"]
+      Disabled: [0, "Processor TX free interrupt disabled"]
+    RXOIE:
+      Enabled: [1, "Enable an unmasked processor receive channel occupied to generate an RX occupied interrupt"]
+      Disabled: [0, "Processor RX occupied interrupt disabled"]
+  "C[12]MR":
+    "CH[1-6]FM":
+      Masked: [1, "Transmit channel n free interrupt masked"]
+      Unmasked: [0, "Transmit channel n free interrupt not masked"]
+    "CH[1-6]OM":
+      Masked: [1, "Receive channel n occupied interrupt masked"]
+      Unmasked: [0, "Receive channel n occupied interrupt not masked"]
+  "C[12]SCR":
+    "CH[1-6]S":
+      Clear: [1, "Processor transmit channel n status bit set"]
+      NoAction: [0, "No action"]
+    "CH[1-6]C":
+      Clear: [1, "Processor receive channel n status bit set"]
+      NoAction: [0, "No action"]
+  "C[12]TOC[12]SR":
+    "CH[1-5]F":
+      Occupied: [1, "Channel occupied, data can be read by the receiving processor. Generates a channel RX occupied interrupt to the other processor, when unmasked"]
+      Free: [0, "Channel free, data can be written by the sending processor. Generates a channel TX free interrupt to the current processor, when unmasked"]

--- a/peripherals/ipcc/ipcc_wl.yaml
+++ b/peripherals/ipcc/ipcc_wl.yaml
@@ -15,10 +15,10 @@ IPCC:
       Unmasked: [0, "Receive channel n occupied interrupt not masked"]
   "C[12]SCR":
     "CH[1-6]S":
-      Clear: [1, "Processor transmit channel n status bit set"]
+      Set: [1, "Processor transmit channel n status bit set"]
       NoAction: [0, "No action"]
     "CH[1-6]C":
-      Clear: [1, "Processor receive channel n status bit set"]
+      Clear: [1, "Processor receive channel n status bit clear"]
       NoAction: [0, "No action"]
   "C[12]TOC[12]SR":
     "CH[1-5]F":

--- a/peripherals/pwr/pwr_wl.yaml
+++ b/peripherals/pwr/pwr_wl.yaml
@@ -42,14 +42,14 @@ PWR:
       Enabled: [1, "PVD Enabled"]
   CR3:
     EIWUL:
-      Disabled: [0, "Internal wakeup line interrupt to CPU disabled"]
-      Enabled: [1, "Internal wakeup line interrupt to CPU enabled"]
+      Disabled: [0, "Internal wakeup line interrupt to CPU1 disabled"]
+      Enabled: [1, "Internal wakeup line interrupt to CPU1 enabled"]
     EWRFIRQ:
-      Disabled: [0, "Radio IRQ[2:0] is disabled and does not trigger a wakeup from Standby event to CPU."]
-      Enabled: [1, "Radio IRQ[2:0] is enabled and triggers a wakeup from Standby event to CPU."]
+      Disabled: [0, "Radio IRQ[2:0] is disabled and does not trigger a wakeup from Standby event to CPU1."]
+      Enabled: [1, "Radio IRQ[2:0] is enabled and triggers a wakeup from Standby event to CPU1."]
     EWRFBUSY:
-      Disabled: [0, "Radio Busy is disabled and does not trigger a wakeup from Standby event to CPUwhen a rising or a falling edge occurs"]
-      Enabled: [1, "Radio Busy is enabled and triggers a wakeup from Standby event to CPUwhen a rising or a falling edge occurs. The active edge is configured via the WRFBUSYP bit in PWR_CR4"]
+      Disabled: [0, "Radio Busy is disabled and does not trigger a wakeup from Standby event to CPU1 when a rising or a falling edge occurs"]
+      Enabled: [1, "Radio Busy is enabled and triggers a wakeup from Standby event to CPU1 when a rising or a falling edge occurs. The active edge is configured via the WRFBUSYP bit in PWR_CR4"]
     APC:
       Disabled: [0, "I/O pull-up and pull-down configurations defined in the PWR_PUCRx and PWR_PDCRx registers are applied"]
       Enabled: [1, "PWR_PUCRx and PWR_PDCRx registers are NOT applied to the I/Os"]

--- a/peripherals/pwr/pwr_wl_c2.yaml
+++ b/peripherals/pwr/pwr_wl_c2.yaml
@@ -1,0 +1,39 @@
+PWR:
+  C2CR1:
+    FPDS:
+      Idle: [0, "Flash memory in Idle mode when system is in LPSleep mode"]
+      PowerDown: [1, "Flash memory in Power-down mode when system is in LPSleep mode"]
+    FPDR:
+      Idle: [0, "Flash memory in Idle mode when system is in LPRun mode"]
+      PowerDown: [1, "Flash memory in Power-down mode when system is in LPRun mode"]
+    LPMS:
+      Stop0: [0, "Stop 0 mode"]
+      Stop1: [1, "Stop 1 mode"]
+      Stop2: [2, "Stop 2 mode"]
+      Standby: [3, "Standby mode"]
+      Shutdown: [4, "Shutdown mode"]
+  C2CR3:
+    EIWUL:
+      Disabled: [0, "Internal wakeup line interrupt to CPU2 disabled"]
+      Enabled: [1, "Internal wakeup line interrupt to CPU2 enabled"]
+    EWRFIRQ:
+      Disabled: [0, "Radio IRQ[2:0] is disabled and does not trigger a wakeup from Standby event to CPU2."]
+      Enabled: [1, "Radio IRQ[2:0] is enabled and triggers a wakeup from Standby event to CPU2."]
+    EWRFBUSY:
+      Disabled: [0, "Radio Busy is disabled and does not trigger a wakeup from Standby event to CPU2 when a rising or a falling edge occurs"]
+      Enabled: [1, "Radio Busy is enabled and triggers a wakeup from Standby event to CPU2 when a rising or a falling edge occurs. The active edge is configured via the WRFBUSYP bit in PWR_CR4"]
+    APC:
+      Disabled: [0, "I/O pull-up and pull-down configurations defined in the PWR_PUCRx and PWR_PDCRx registers are applied"]
+      Enabled: [1, "PWR_PUCRx and PWR_PDCRx registers are NOT applied to the I/Os"]
+    EWPVD:
+      Disabled: [0, "PVD not enabled by the sub-GHz radio active state"]
+      Enabled: [1, "PVD enabled while the sub-GHz radio is active"]
+    EWUP3:
+      Disabled: [0, "WKUP pin 3 is used for general purpose I/Os. An event on the WKUP pin 3 does not wakeup the device from Standby mode"]
+      Enabled: [1, "WKUP pin 3 is used for wakeup from Standby mode and forced in input pull down configuration (rising edge on WKUP pin 3wakes-up the system from Standby mode)"]
+    EWUP2:
+      Disabled: [0, "WKUP pin 2 is used for general purpose I/Os. An event on the WKUP pin 2 does not wakeup the device from Standby mode"]
+      Enabled: [1, "WKUP pin 2 is used for wakeup from Standby mode and forced in input pull down configuration (rising edge on WKUP pin 2 wakes-up the system from Standby mode)"]
+    EWUP1:
+      Disabled: [0, "WKUP pin 1 is used for general purpose I/Os. An event on the WKUP pin 1 does not wakeup the device from Standby mode"]
+      Enabled: [1, "WKUP pin 1 is used for wakeup from Standby mode and forced in input pull down configuration (rising edge on WKUP pin 1 wakes-up the system from Standby mode)"]

--- a/peripherals/rcc/rcc_wl_c2.yaml
+++ b/peripherals/rcc/rcc_wl_c2.yaml
@@ -1,0 +1,15 @@
+RCC:
+  "C2A[PH]B[123]ENR":
+    "*":
+      Disabled: [0, "Clock disabled"]
+      Enabled: [1, "Clock enabled"]
+
+  "C2APB[123]ENR?":
+    "*":
+      Disabled: [0, "Clock disabled"]
+      Enabled: [1, "Clock enabled"]
+
+  "C2A[PH]B[123]SMENR?":
+    "*":
+      Disabled: [0, "Clock disabled"]
+      Enabled: [1, "Clock enabled"]


### PR DESCRIPTION
This adds register descriptions for registers that are exclusive to the dual-core STM32WL's

cc @jorgeig-space 