### PR TITLE
H7 RM0433: Add NOMCK at SAI [AB]CR1 bit 19 and remove MCKEN

### DIFF
--- a/devices/common_patches/h7_sai.yaml
+++ b/devices/common_patches/h7_sai.yaml
@@ -3,6 +3,11 @@
     _modify:
       MCKDIV:
         bitWidth: 6
+    _add:
+      NODIV:
+        description: No fixed divider between MCLK and FS
+        bitOffset: 19
+        bitWidth: 1
   AFRCR:
     _modify:
       FSDEF:
@@ -11,6 +16,11 @@
     _modify:
       MCKDIV:
         bitWidth: 6
+    _add:
+      NODIV:
+        description: No fixed divider between MCLK and FS
+        bitOffset: 19
+        bitWidth: 1
   BFRCR:
     _modify:
       FSDEF:

--- a/devices/common_patches/h7_sai.yaml
+++ b/devices/common_patches/h7_sai.yaml
@@ -3,13 +3,6 @@
     _modify:
       MCKDIV:
         bitWidth: 6
-      NOMCK:
-        name: NODIV
-    _add:
-      MCKEN:
-        description: Master clock generation enable
-        bitOffset: 27
-        bitWidth: 1
   AFRCR:
     _modify:
       FSDEF:
@@ -18,13 +11,6 @@
     _modify:
       MCKDIV:
         bitWidth: 6
-      NOMCK:
-        name: NODIV
-    _add:
-      MCKEN:
-        description: Master clock generation enable
-        bitOffset: 27
-        bitWidth: 1
   BFRCR:
     _modify:
       FSDEF:

--- a/devices/common_patches/h7_sai_mcken.yaml
+++ b/devices/common_patches/h7_sai_mcken.yaml
@@ -1,17 +1,17 @@
+# Applies to H7 RM0399, RM0455, RM0468
+
 "SAI*":
   ACR1:
-    _modify:
-      NOMCK:
-        name: NODIV
+    _delete:
+      - NOMCK
     _add:
       MCKEN:
         description: Master clock generation enable
         bitOffset: 27
         bitWidth: 1
   BCR1:
-    _modify:
-      NOMCK:
-        name: NODIV
+    _delete:
+      - NOMCK
     _add:
       MCKEN:
         description: Master clock generation enable

--- a/devices/common_patches/h7_sai_mcken.yaml
+++ b/devices/common_patches/h7_sai_mcken.yaml
@@ -1,0 +1,19 @@
+"SAI*":
+  ACR1:
+    _modify:
+      NOMCK:
+        name: NODIV
+    _add:
+      MCKEN:
+        description: Master clock generation enable
+        bitOffset: 27
+        bitWidth: 1
+  BCR1:
+    _modify:
+      NOMCK:
+        name: NODIV
+    _add:
+      MCKEN:
+        description: Master clock generation enable
+        bitOffset: 27
+        bitWidth: 1

--- a/devices/stm32h735.yaml
+++ b/devices/stm32h735.yaml
@@ -497,6 +497,7 @@ _include:
  - common_patches/h7_adc_boost_rev_v.yaml
  - common_patches/h7_octospi.yaml
  - common_patches/h7_sai.yaml
+ - common_patches/h7_sai_mcken.yaml
  - common_patches/h735_747_753_dfsdm.yaml
  - common_patches/h7_spdifrx.yaml
  - common_patches/h7_otg.yaml

--- a/devices/stm32h747cm4.yaml
+++ b/devices/stm32h747cm4.yaml
@@ -38,6 +38,7 @@ _include:
  - common_patches/h7_dualcore_flash.yaml
  - common_patches/h7_hsicfgr_csicfgr_rev_v.yaml
  - common_patches/h7_sai.yaml
+ - common_patches/h7_sai_mcken.yaml
  - common_patches/h7_spdifrx.yaml
  - common_patches/h7_otg.yaml
  - common_patches/sai/sai_v1.yaml

--- a/devices/stm32h747cm7.yaml
+++ b/devices/stm32h747cm7.yaml
@@ -38,6 +38,7 @@ _include:
  - common_patches/h7_dualcore_flash.yaml
  - common_patches/h7_hsicfgr_csicfgr_rev_v.yaml
  - common_patches/h7_sai.yaml
+ - common_patches/h7_sai_mcken.yaml
  - common_patches/h735_747_753_dfsdm.yaml
  - common_patches/h7_spdifrx.yaml
  - common_patches/h7_otg.yaml

--- a/devices/stm32h7b3.yaml
+++ b/devices/stm32h7b3.yaml
@@ -92,6 +92,7 @@ _include:
  - common_patches/h7_adc_boost_rev_v.yaml
  - common_patches/h7_octospi.yaml
  - common_patches/h7_sai.yaml
+ - common_patches/h7_sai_mcken.yaml
  - common_patches/h7_spdifrx.yaml
  - common_patches/h7_otg.yaml
  - common_patches/flash/flash_dual_bank.yaml

--- a/peripherals/sai/sai.yaml
+++ b/peripherals/sai/sai.yaml
@@ -1,9 +1,9 @@
 "SAI,SAI?":
   "*CR1":
     #MCKDIV:
-    NODIV:
-      MasterClock: [0, "Master clock generator is enabled"]
-      NoDiv: [1, "No divider used in the clock generator (in this case Master Clock Divider bit has no effect)"]
+    NOMCK,NODIV:
+      MasterClock: [0, "MCLK output is enabled. Forces the ratio between FS and MCLK to 256 or 512 according to the OSR value"]
+      NoDiv: [1, "MCLK output enable set by the MCKEN bit (where present, else 0). Ratio between FS and MCLK depends on FRL."]
     DMAEN:
       Disabled: [0, "DMA disabled"]
       Enabled: [1, "DMA enabled"]


### PR DESCRIPTION
Other H7 parts are unchanged. Improve description of NOMCK/NODIV bit

See previous PR #347. Fixes #618