### PR TITLE
Add missing DSI interrupt number for Stm32h747cm4 and Stm32h747cm7

### DIFF
--- a/devices/common_patches/h7_dsi.yaml
+++ b/devices/common_patches/h7_dsi.yaml
@@ -12,6 +12,10 @@ _add:
       offset: 0x000
       size: 0x500
       usage: registers
+    interrupts:
+      DSI:
+        description: DSI Host global interrupt
+        value: 123
     registers:
       VR:
         description: DSI Host version register


### PR DESCRIPTION
According to [RM0399](https://www.st.com/resource/en/reference_manual/rm0399-stm32h745755-and-stm32h747757-advanced-armbased-32bit-mcus-stmicroelectronics.pdf): DSI interrupt should have number 123. 

This PR addresses #645 issue.
