### PR TITLE
Remove DSI module from unsupported devices

### DIFF
--- a/devices/stm32h735.yaml
+++ b/devices/stm32h735.yaml
@@ -493,7 +493,6 @@ _include:
  - common_patches/h7_dmamux.yaml
  - common_patches/dma/dma2d_v2.yaml
  - common_patches/h7_adc.yaml
- - common_patches/h7_dsi.yaml
  - common_patches/h7_adc_boost_rev_v.yaml
  - common_patches/h7_octospi.yaml
  - common_patches/h7_sai.yaml

--- a/devices/stm32h7b3.yaml
+++ b/devices/stm32h7b3.yaml
@@ -88,7 +88,6 @@ _include:
  - common_patches/h7_dmamux.yaml
  - common_patches/dma/dma2d_v2.yaml
  - common_patches/h7_adc.yaml
- - common_patches/h7_dsi.yaml
  - common_patches/h7_adc_boost_rev_v.yaml
  - common_patches/h7_octospi.yaml
  - common_patches/h7_sai.yaml


### PR DESCRIPTION
remove DSI from stm32h735 and stm32h7b3 as it is not supported there.
STM32H7A3/7B3 [RM0455](https://www.st.com/resource/en/reference_manual/rm0455-stm32h7a37b3-and-stm32h7b0-value-line-advanced-armbased-32bit-mcus-stmicroelectronics.pdf)
stm32h735  [RM0468](https://www.st.com/resource/en/reference_manual/rm0468-stm32h723733-stm32h725735-and-stm32h730-value-line-advanced-armbased-32bit-mcus-stmicroelectronics.pdf)