### PR TITLE
Fix Overdrive and BDMADR fields on h743/h753

### DIFF
--- a/devices/common_patches/h743_hrtim_common.yaml
+++ b/devices/common_patches/h743_hrtim_common.yaml
@@ -1,0 +1,4 @@
+HRTIM_Common:
+   _modify:
+     BDMADR:
+       addressOffset: 0x70

--- a/devices/common_patches/h74x_syscfg_pwrcr.yaml
+++ b/devices/common_patches/h74x_syscfg_pwrcr.yaml
@@ -1,0 +1,6 @@
+SYSCFG:
+  PWRCR:
+    _modify:
+      ODEN:
+        bitWidth: 1
+        description: "Overdrive enable"

--- a/devices/stm32h743.yaml
+++ b/devices/stm32h743.yaml
@@ -100,3 +100,5 @@ _include:
  - common_patches/h7_crc_addr_fix.yaml
  - common_patches/h7_wwdg.yaml
  - common_patches/h7_ethernet_mac.yaml
+ - common_patches/h74x_syscfg_pwrcr.yaml
+ - common_patches/h743_hrtim_common.yaml

--- a/devices/stm32h743v.yaml
+++ b/devices/stm32h743v.yaml
@@ -102,3 +102,5 @@ _include:
  - common_patches/h7_crc_addr_fix.yaml
  - common_patches/h7_wwdg.yaml
  - common_patches/h7_ethernet_mac.yaml
+ - common_patches/h74x_syscfg_pwrcr.yaml
+ - common_patches/h743_hrtim_common.yaml

--- a/devices/stm32h747cm4.yaml
+++ b/devices/stm32h747cm4.yaml
@@ -102,3 +102,4 @@ _include:
  - common_patches/h7_crc_addr_fix.yaml
  - common_patches/h7_wwdg.yaml
  - common_patches/h7_ethernet_mac.yaml
+ - common_patches/h74x_syscfg_pwrcr.yaml

--- a/devices/stm32h747cm7.yaml
+++ b/devices/stm32h747cm7.yaml
@@ -107,3 +107,4 @@ _include:
  - common_patches/h7_crc_addr_fix.yaml
  - common_patches/h7_wwdg.yaml
  - common_patches/h7_ethernet_mac.yaml
+ - common_patches/h74x_syscfg_pwrcr.yaml

--- a/devices/stm32h753.yaml
+++ b/devices/stm32h753.yaml
@@ -111,3 +111,5 @@ _include:
  - common_patches/h7_crc_addr_fix.yaml
  - common_patches/h7_wwdg.yaml
  - common_patches/h7_ethernet_mac.yaml
+ - common_patches/h74x_syscfg_pwrcr.yaml
+ - common_patches/h743_hrtim_common.yaml

--- a/devices/stm32h753v.yaml
+++ b/devices/stm32h753v.yaml
@@ -1,8 +1,5 @@
 _svd: ../svd/stm32h753v.svd
 
-_modify:
-     name: STM32H753v
-
 # Merge the hundreds of individual bit fields into single fields for the
 # crypt key/iv registers.
 CRYP:

--- a/devices/stm32h753v.yaml
+++ b/devices/stm32h753v.yaml
@@ -1,5 +1,8 @@
 _svd: ../svd/stm32h753v.svd
 
+_modify:
+     name: STM32H753v
+
 # Merge the hundreds of individual bit fields into single fields for the
 # crypt key/iv registers.
 CRYP:
@@ -113,3 +116,5 @@ _include:
  - common_patches/h7_crc_addr_fix.yaml
  - common_patches/h7_wwdg.yaml
  - common_patches/h7_ethernet_mac.yaml
+ - common_patches/h74x_syscfg_pwrcr.yaml
+ - common_patches/h743_hrtim_common.yaml


### PR DESCRIPTION
Adding fixes to two fields on h743/h753 micros. These bugs were found by comparing against h747 svd files and verified to not be present on any other h7 micros (beyond those fixed in this PR).

ODEN should be 1-bit and have an enumeration. H747 had the correct bit width already; the oden patch is now applied to more devices.
BDMADR should be at 0x70, not 0x60.