### PR TITLE
wl5x / wle5: put all timers in TIM group

### DIFF
--- a/devices/stm32wl5x_cm0p.yaml
+++ b/devices/stm32wl5x_cm0p.yaml
@@ -2,6 +2,8 @@ _svd: ../svd/stm32wl5x_cm0p.svd
 
 _modify:
   name: STM32WL5X_CM0P
+  TIM*:
+    groupName: TIM
 
 AES:
   CR:

--- a/devices/stm32wl5x_cm4.yaml
+++ b/devices/stm32wl5x_cm4.yaml
@@ -2,6 +2,8 @@ _svd: ../svd/stm32wl5x_cm4.svd
 
 _modify:
   name: STM32WL5X_CM4
+  TIM*:
+    groupName: TIM
 
 AES:
   CR:

--- a/devices/stm32wle5.yaml
+++ b/devices/stm32wle5.yaml
@@ -2,6 +2,8 @@ _svd: ../svd/stm32wle5.svd
 
 _modify:
   name: STM32WLE5
+  TIM*:
+    groupName: TIM
 
 AES:
   CR:


### PR DESCRIPTION
Other STM32 have timers in the TIM group.  For these devices, there was a mix of group names for different timer types, with a typo in one of the names 'AdavanceTimers'

This PR puts all timers in the TIM group for consistency with other STM32.