### PR TITLE
Updating STM32H7 ETH_MAC MMC mask register writable

### DIFF
--- a/devices/common_patches/h7_ethernet_mac.yaml
+++ b/devices/common_patches/h7_ethernet_mac.yaml
@@ -1,0 +1,10 @@
+Ethernet_MAC:
+  MMC_TX_INTERRUPT_MASK:
+    _modify:
+      TXLPITRCIM:
+        access: read-write
+
+  MMC_RX_INTERRUPT_MASK:
+    _modify:
+      RXLPITRCIM:
+        access: read-write

--- a/devices/stm32h735.yaml
+++ b/devices/stm32h735.yaml
@@ -557,3 +557,4 @@ _include:
  - ../peripherals/rtc/rtc_h7.yaml
  - common_patches/h7_crc_addr_fix.yaml
  - common_patches/h7_wwdg.yaml
+ - common_patches/h7_ethernet_mac.yaml

--- a/devices/stm32h743.yaml
+++ b/devices/stm32h743.yaml
@@ -94,3 +94,4 @@ _include:
  - ../peripherals/rtc/rtc_h7.yaml
  - common_patches/h7_crc_addr_fix.yaml
  - common_patches/h7_wwdg.yaml
+ - common_patches/h7_ethernet_mac.yaml

--- a/devices/stm32h743v.yaml
+++ b/devices/stm32h743v.yaml
@@ -96,3 +96,4 @@ _include:
  - ../peripherals/rtc/rtc_h7.yaml
  - common_patches/h7_crc_addr_fix.yaml
  - common_patches/h7_wwdg.yaml
+ - common_patches/h7_ethernet_mac.yaml

--- a/devices/stm32h747cm4.yaml
+++ b/devices/stm32h747cm4.yaml
@@ -95,3 +95,4 @@ _include:
  - ../peripherals/sai/sai.yaml
  - common_patches/h7_crc_addr_fix.yaml
  - common_patches/h7_wwdg.yaml
+ - common_patches/h7_ethernet_mac.yaml

--- a/devices/stm32h747cm7.yaml
+++ b/devices/stm32h747cm7.yaml
@@ -100,3 +100,4 @@ _include:
  - ../peripherals/rtc/rtc_h7.yaml
  - common_patches/h7_crc_addr_fix.yaml
  - common_patches/h7_wwdg.yaml
+ - common_patches/h7_ethernet_mac.yaml

--- a/devices/stm32h753.yaml
+++ b/devices/stm32h753.yaml
@@ -104,3 +104,4 @@ _include:
  - ../peripherals/rtc/rtc_h7.yaml
  - common_patches/h7_crc_addr_fix.yaml
  - common_patches/h7_wwdg.yaml
+ - common_patches/h7_ethernet_mac.yaml

--- a/devices/stm32h753v.yaml
+++ b/devices/stm32h753v.yaml
@@ -106,3 +106,4 @@ _include:
  - ../peripherals/rtc/rtc_h7.yaml
  - common_patches/h7_crc_addr_fix.yaml
  - common_patches/h7_wwdg.yaml
+ - common_patches/h7_ethernet_mac.yaml

--- a/devices/stm32h7b3.yaml
+++ b/devices/stm32h7b3.yaml
@@ -150,4 +150,3 @@ _include:
  - common_patches/h7_crc_addr_fix.yaml
  - common_patches/h7_wwdg.yaml
  - common_patches/h7b3_dfsdm.yaml
- - common_patches/h7_ethernet_mac.yaml

--- a/devices/stm32h7b3.yaml
+++ b/devices/stm32h7b3.yaml
@@ -150,3 +150,4 @@ _include:
  - common_patches/h7_crc_addr_fix.yaml
  - common_patches/h7_wwdg.yaml
  - common_patches/h7b3_dfsdm.yaml
+ - common_patches/h7_ethernet_mac.yaml


### PR DESCRIPTION
This PR fixes #656 by making the MMC_TX/RX_INTERRUPT_MASK register completely writable.

TODO:
- [x] Verify these bits can be written in hardware