### PR TITLE
devices/stm32l4r9.yaml: patch TIM3 and TIM4

### DIFF
--- a/devices/stm32l4r9.yaml
+++ b/devices/stm32l4r9.yaml
@@ -28,6 +28,13 @@ RCC:
         name: SPI3EN
         description: SPI peripheral 3 clock enable
 
+_copy:
+  TIM3:
+    from: TIM2
+
+_derive:
+  TIM4: TIM3
+
 MPU:
   _strip:
     - "MPU_"


### PR DESCRIPTION
TIM3 and TIM4 work the same way in stm32l4r9 and stm32l4x6.
Since `stm32l4x6.yaml` contains these `_copy` and `_derive` lines, they should also be added to this yaml file.

Note that I've simply verified this empirically, with these lines added I can now use TIM3 and TIM4 to generate a PWM signal,
and that I don't fully comprehend the SVD files yet. 