### PR TITLE
Add bit ranges to HDMI CEC registers

### DIFF
--- a/devices/common_patches/hdmi_cec.yaml
+++ b/devices/common_patches/hdmi_cec.yaml
@@ -1,0 +1,6 @@
+CEC:
+  CFGR:
+    OAR: [0, 0x7FFF]
+    SFT: [0, 0x7]
+  TXDR:
+    TXD: [0, 0xFF]

--- a/devices/stm32f0x1.yaml
+++ b/devices/stm32f0x1.yaml
@@ -13,6 +13,7 @@ _copy:
     from: TIM2
 
 _include:
+ - common_patches/hdmi_cec.yaml
  - ./common_patches/rename_RCC_CIR_HSI14RDYIE_field.yaml
  - ./common_patches/rename_f0_SPI_registers.yaml
  - ./common_patches/merge_I2C_CR2_SADDx_fields.yaml

--- a/devices/stm32f0x2.yaml
+++ b/devices/stm32f0x2.yaml
@@ -31,6 +31,7 @@ _copy:
     from: TIM2
 
 _include:
+ - common_patches/hdmi_cec.yaml
  - ./common_patches/rename_RCC_CIR_HSI14RDYIE_field.yaml
  - ./common_patches/rename_f0_SPI_registers.yaml
  - ./common_patches/merge_I2C_CR2_SADDx_fields.yaml

--- a/devices/stm32f0x8.yaml
+++ b/devices/stm32f0x8.yaml
@@ -6,6 +6,7 @@ _copy:
     from: TIM2
 
 _include:
+ - common_patches/hdmi_cec.yaml
  - ./common_patches/rename_RCC_CIR_HSI14RDYIE_field.yaml
  - ./common_patches/rename_f0_SPI_registers.yaml
  - ./common_patches/merge_I2C_CR2_SADDx_fields.yaml

--- a/devices/stm32f765.yaml
+++ b/devices/stm32f765.yaml
@@ -116,6 +116,7 @@ JPEG:
     - "JPEG_"
 
 _include:
+ - common_patches/hdmi_cec.yaml
  - common_patches/f7_interrupts.yaml
  - common_patches/f7_lptim_interrupt.yaml
  - common_patches/ltdc/f7_ltdc_interrupts.yaml

--- a/devices/stm32h735.yaml
+++ b/devices/stm32h735.yaml
@@ -487,6 +487,7 @@ MDIOS:
     - "MDIOS_"
 
 _include:
+ - common_patches/hdmi_cec.yaml
  - common_patches/h7_common_singlecore.yaml
  - common_patches/dma_fcr_wo.yaml
  - common_patches/dma/bdma_v2_new.yaml

--- a/devices/stm32h743.yaml
+++ b/devices/stm32h743.yaml
@@ -21,6 +21,7 @@ MPU:
     - "MPU_"
 
 _include:
+ - common_patches/hdmi_cec.yaml
  - common_patches/h7_common_singlecore.yaml
  - common_patches/h7_ethernet_dma_mr.yaml
  - common_patches/dma_fcr_wo.yaml

--- a/devices/stm32h743v.yaml
+++ b/devices/stm32h743v.yaml
@@ -21,6 +21,7 @@ MPU:
     - "MPU_"
 
 _include:
+ - common_patches/hdmi_cec.yaml
  - common_patches/h7_common_singlecore.yaml
  - common_patches/h7_ethernet_dma_mr.yaml
  - common_patches/dma_fcr_wo.yaml

--- a/devices/stm32h747cm4.yaml
+++ b/devices/stm32h747cm4.yaml
@@ -22,6 +22,7 @@ MPU:
     - "MPU_"
 
 _include:
+ - common_patches/hdmi_cec.yaml
  - common_patches/h7_common_dualcore.yaml
  - common_patches/4_nvic_prio_bits.yaml  # Specifically for CM4 core
  - common_patches/dma_fcr_wo.yaml

--- a/devices/stm32h747cm7.yaml
+++ b/devices/stm32h747cm7.yaml
@@ -22,6 +22,7 @@ MPU:
     - "MPU_"
 
 _include:
+ - common_patches/hdmi_cec.yaml
  - common_patches/h7_common_dualcore.yaml
  - common_patches/dma_fcr_wo.yaml
  - common_patches/dma/bdma.yaml

--- a/devices/stm32h753.yaml
+++ b/devices/stm32h753.yaml
@@ -31,6 +31,7 @@ MPU:
     - "MPU_"
 
 _include:
+ - common_patches/hdmi_cec.yaml
  - common_patches/h7_common_singlecore.yaml
  - common_patches/h7_ethernet_dma_mr.yaml
  - common_patches/dma_fcr_wo.yaml

--- a/devices/stm32h753v.yaml
+++ b/devices/stm32h753v.yaml
@@ -31,6 +31,7 @@ MPU:
     - "MPU_"
 
 _include:
+ - common_patches/hdmi_cec.yaml
  - common_patches/h7_common_singlecore.yaml
  - common_patches/h7_ethernet_dma_mr.yaml
  - common_patches/dma_fcr_wo.yaml

--- a/devices/stm32h7b3.yaml
+++ b/devices/stm32h7b3.yaml
@@ -83,6 +83,7 @@ COMP1:
     - "COMP1_"
 
 _include:
+ - common_patches/hdmi_cec.yaml
  - common_patches/h7_common_highmemory.yaml
  - common_patches/dma_fcr_wo.yaml
  - common_patches/dma/bdma_v2.yaml


### PR DESCRIPTION
This applies to the H7, F0x{1,2,8}, F7{6,7} which share identical register layouts.