### PR TITLE
Add enumerated values for STM32F405/415/407/417/427/437/429/439 TIM2 ITR1_RMP

### DIFF
--- a/devices/common_patches/tim/tim2_itr1_rmp.yaml
+++ b/devices/common_patches/tim/tim2_itr1_rmp.yaml
@@ -1,0 +1,13 @@
+# TIM2 peripheral on STM32F405/415, STM32F407/F417, STM32F427/437, STM32F429/439
+# can remap ITR1 to internal trigger signals
+#
+#
+
+TIM2:
+  OR:
+    ITR1_RMP:
+      _replace_enum:
+        TIM8_TRGOUT: [0, "TIM8 trigger output is connected to TIM2_ITR1 input"]
+        PTP: [1, "Ethernet PTP clock is connected to TIM2_ITR1 input"]
+        OTG_FS_SOF: [2, "OTG FS SOF is connected to the TIM2_ITR1 input"]
+        OTG_HS_SOF: [3, "OTG HS SOF is connected to the TIM2_ITR1 input"]

--- a/devices/stm32f405.yaml
+++ b/devices/stm32f405.yaml
@@ -28,6 +28,15 @@ _modify:
         bitWidth: 1
         access: read-write
 
+TIM2:
+  OR:
+    ITR1_RMP:
+      _replace_enum:
+        TIM8_TRGOUT: [0, "TIM8 trigger output is connected to TIM2_ITR1 input"]
+        PTP_TRGOUT: [1, "PTP trigger output is connected to TIM2_ITR1 input"]
+        OTG_FS_SOF: [2, "OTG FS SOF is connected to the TIM2_ITR1 input"]
+        OTG_HS_SOF: [3, "OTG HS SOF is connected to the TIM2_ITR1 input"]
+
 CRC:
   # The SVD calls the RESET field "CR", fix per RM0090
   CR:

--- a/devices/stm32f405.yaml
+++ b/devices/stm32f405.yaml
@@ -28,15 +28,6 @@ _modify:
         bitWidth: 1
         access: read-write
 
-TIM2:
-  OR:
-    ITR1_RMP:
-      _replace_enum:
-        TIM8_TRGOUT: [0, "TIM8 trigger output is connected to TIM2_ITR1 input"]
-        PTP_TRGOUT: [1, "PTP trigger output is connected to TIM2_ITR1 input"]
-        OTG_FS_SOF: [2, "OTG FS SOF is connected to the TIM2_ITR1 input"]
-        OTG_HS_SOF: [3, "OTG HS SOF is connected to the TIM2_ITR1 input"]
-
 CRC:
   # The SVD calls the RESET field "CR", fix per RM0090
   CR:
@@ -116,6 +107,7 @@ _include:
  - ../peripherals/tim/tim_advanced.yaml
  - common_patches/tim/tim_ccr.yaml
  - ../peripherals/tim/v1/ccm.yaml
+ - common_patches/tim/tim2_itr1_rmp.yaml
  - ../peripherals/usart/uart_common.yaml
  - ../peripherals/usart/uart_sample.yaml
  - ../peripherals/usart/uart_uart.yaml

--- a/devices/stm32f407.yaml
+++ b/devices/stm32f407.yaml
@@ -107,6 +107,7 @@ _include:
  - ../peripherals/tim/tim_advanced.yaml
  - common_patches/tim/tim_ccr.yaml
  - ../peripherals/tim/v1/ccm.yaml
+ - common_patches/tim/tim2_itr1_rmp.yaml
  - ../peripherals/eth/eth_dma_common.yaml
  - ../peripherals/eth/eth_dma_mb_edfe_dmarswtr.yaml
  - ../peripherals/eth/eth_mac_common.yaml

--- a/devices/stm32f427.yaml
+++ b/devices/stm32f427.yaml
@@ -234,6 +234,7 @@ _include:
  - ../peripherals/tim/tim_advanced.yaml
  - common_patches/tim/tim_ccr.yaml
  - ../peripherals/tim/v1/ccm.yaml
+ - common_patches/tim/tim2_itr1_rmp.yaml
  - ../peripherals/iwdg/iwdg.yaml
  - ../peripherals/exti/exti.yaml
  - common_patches/hash/hash.yaml

--- a/devices/stm32f429.yaml
+++ b/devices/stm32f429.yaml
@@ -173,6 +173,7 @@ _include:
  - ../peripherals/tim/tim_advanced.yaml
  - common_patches/tim/tim_ccr.yaml
  - ../peripherals/tim/v1/ccm.yaml
+ - common_patches/tim/tim2_itr1_rmp.yaml
  - ../peripherals/eth/eth_dma_common.yaml
  - ../peripherals/eth/eth_dma_mb_edfe_dmarswtr.yaml
  - ../peripherals/eth/eth_mac_common.yaml


### PR DESCRIPTION
These values are from STMicro RM0090, 18.4.19:

<img width="842" alt="image" src="https://user-images.githubusercontent.com/399/146279854-b12586e5-41b4-43ae-bb7e-edd1efde1744.png">

This reference manual covers "STM32F405/415, STM32F407/417, STM32F427/437 and STM32F429/439", so it's likely that this change could apply to those other devices as well. I don't have one to test, though, so defer to maintainers' preferences here. ~~Happy to extract this to a common patch if folks are happy with that approach.~~ EDIT: I've pushed 3a7e8e4 which does just this.