### PR TITLE
Fix make html on macOS with python 3.8+

### DIFF
--- a/scripts/makehtml.py
+++ b/scripts/makehtml.py
@@ -325,7 +325,7 @@ if __name__ == "__main__":
     devices = {}
     with multiprocessing.pool.ThreadPool() if sys.platform == 'win32' else multiprocessing.Pool() as p:
         devices = p.map(process_svd, args.svdfiles)
-        p.map(generate_if_newer, [(device,args.htmldir) for device in devices])
+        p.map(generate_if_newer, [(device, args.htmldir) for device in devices])
     devices = {d['name']: d for d in devices}
     index_page = generate_index_page(devices)
     with open(os.path.join(args.htmldir, "index.html"), "w", encoding='utf-8') as f:


### PR DESCRIPTION
Python3.8 and above [changed](https://chrissardegna.com/blog/multiprocessing-changes-python-3-8/) the behavior of the multiprocessing module on macOS, resulting in variable scoping being tighter than on other platforms or versions.

As a simplified case, this code crashes on such a machine:

```python
import multiprocessing

def worker(local):
	print(v)

if __name__ == "__main__":
	v = "can i access this?"
	with multiprocessing.Pool() as p:
		devices = p.map(worker, [None])
```

This patch passes in the relevant variable into the worker in a different style to fix. I've tested this on linux and Mac platforms for regressions.