### PR TITLE
STM32L4xx: Add GPIOx ASCR & BRR registers

### DIFF
--- a/devices/common_patches/l4_gpio_ascr.yaml
+++ b/devices/common_patches/l4_gpio_ascr.yaml
@@ -9,12 +9,9 @@
           access: read-write
           bitOffset: 0
           bitWidth: 16
-    BRR:
-      description: GPIO port bit reset register
-      addressOffset: 0x28
-      fields:
-        BR:
-          description: These bits are write-only. A read to these bits returns the value 0x0000
-          access: read-only
-          bitOffset: 0
-          bitWidth: 16
+  ASCR:
+    _split: [ASC]
+    ASC*:
+      _write:
+          NoAction: [0, "Disconnect analog switch to the ADC input"]
+          Reset: [1, " Connect analog switch to the ADC input"]

--- a/devices/common_patches/l4_gpio_ascr_brr.yaml
+++ b/devices/common_patches/l4_gpio_ascr_brr.yaml
@@ -1,0 +1,20 @@
+"GPIO*":
+  _add:
+    ASCR:
+      description: GPIO port analog switch control register
+      addressOffset: 0x2C
+      fields:
+        ASC:
+          description: These bits are written by software to configure the analog connection of the IOs.
+          access: read-write
+          bitOffset: 0
+          bitWidth: 16
+    BRR:
+      description: GPIO port bit reset register
+      addressOffset: 0x28
+      fields:
+        BR:
+          description: These bits are write-only. A read to these bits returns the value 0x0000
+          access: read-only
+          bitOffset: 0
+          bitWidth: 16

--- a/devices/common_patches/l4_gpio_brr.yaml
+++ b/devices/common_patches/l4_gpio_brr.yaml
@@ -1,0 +1,17 @@
+"GPIO*":
+  _add:
+    BRR:
+      description: GPIO port bit reset register
+      addressOffset: 0x28
+      fields:
+        BR:
+          description: These bits are write-only. A read to these bits returns the value 0x0000
+          access: write-only
+          bitOffset: 0
+          bitWidth: 16
+  BRR:
+    _split: [BR]
+    BR*:
+      _write:
+          NoAction: [0, "No action on the corresponding ODx bit"]
+          Reset: [1, "Reset the corresponding ODx bit"]

--- a/devices/stm32l4x1.yaml
+++ b/devices/stm32l4x1.yaml
@@ -130,4 +130,5 @@ _include:
  - ./common_patches/l4_adc_smpr.yaml
  - ./common_patches/l4_adc_sqr1.yaml
  - ./common_patches/l4_spi.yaml
+ - ./common_patches/l4_gpio_brr.yaml
  - ../peripherals/spi/spi_l4.yaml

--- a/devices/stm32l4x2.yaml
+++ b/devices/stm32l4x2.yaml
@@ -9,4 +9,5 @@ MPU:
 _include:
  - ./common_patches/stm32l4x2_l412.yaml
  - common_patches/rtc/rtc_bkpr.yaml
+ - ./common_patches/l4_gpio_brr.yaml
  - ../peripherals/fw/fw_l0_l4.yaml

--- a/devices/stm32l4x3.yaml
+++ b/devices/stm32l4x3.yaml
@@ -161,5 +161,6 @@ _include:
  - ./common_patches/l4_adc_smpr.yaml
  - ./common_patches/l4_adc_sqr1.yaml
  - ./common_patches/l4_spi.yaml
+ - ./common_patches/l4_gpio_brr.yaml
  - ../peripherals/spi/spi_l4.yaml
  - ./common_patches/l4_lcd_segment.yaml

--- a/devices/stm32l4x5.yaml
+++ b/devices/stm32l4x5.yaml
@@ -9,12 +9,21 @@ _modify:
 ADC_Common:
   CCR:
     _modify:
+      MULT:
+        name: DUAL
+        description: Dual ADC mode selection
       TSEN:
         name: CH18SEL
         description: CH18 selection (Vbat)
       VBATEN:
         name: CH17SEL
         description: CH17 selection (temperature)
+    _add:
+      PRESC:
+        description: ADC prescaler
+        bitOffset: 18
+        bitWidth: 4
+        access: read-write
 
 # Merge the thousands of individal bit fields into a single field for each
 # CAN filter register. This is not only much easier to use but also saves
@@ -179,4 +188,5 @@ _include:
  - ./common_patches/l4_adc_smpr.yaml
  - ./common_patches/l4_adc_sqr1.yaml
  - ./common_patches/l4_spi.yaml
+ - ./common_patches/l4_gpio_ascr_brr.yaml
  - ../peripherals/spi/spi_l4.yaml

--- a/devices/stm32l4x5.yaml
+++ b/devices/stm32l4x5.yaml
@@ -188,5 +188,6 @@ _include:
  - ./common_patches/l4_adc_smpr.yaml
  - ./common_patches/l4_adc_sqr1.yaml
  - ./common_patches/l4_spi.yaml
- - ./common_patches/l4_gpio_ascr_brr.yaml
+ - ./common_patches/l4_gpio_ascr.yaml
+ - ./common_patches/l4_gpio_brr.yaml
  - ../peripherals/spi/spi_l4.yaml


### PR DESCRIPTION
Also corrects naming on L4x5 ADC `Mult` to `Dual` field, as per the reference manual, and adds prescaler field under ADC_CRR.

Fixes https://github.com/stm32-rs/stm32-rs/issues/342