### PR TITLE
Make FLASH_WRP??R and FLASH_SECR writable

### DIFF
--- a/devices/common_patches/g0_flash.yaml
+++ b/devices/common_patches/g0_flash.yaml
@@ -1,0 +1,15 @@
+FLASH:
+  _modify:
+    # Fix access and reset values.
+    WRP??R:
+      access: read-write
+      resetValue: 0x000000ff
+    PCROP??SR:
+      access: read-write
+      resetValue: 0xffffffff
+    PCROP??ER:
+      access: read-write
+      resetValue: 0x00000000
+    SECR:
+      access: read-write
+      resetValue: 0x00000000

--- a/devices/stm32g030.yaml
+++ b/devices/stm32g030.yaml
@@ -36,3 +36,4 @@ _include:
  - common_patches/tim/common.yaml
  - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/tim/tim_advanced.yaml
+ - ./common_patches/g0_flash.yaml

--- a/devices/stm32g031.yaml
+++ b/devices/stm32g031.yaml
@@ -36,3 +36,4 @@ _include:
  - common_patches/tim/common.yaml
  - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/tim/tim_advanced.yaml
+ - ./common_patches/g0_flash.yaml

--- a/devices/stm32g041.yaml
+++ b/devices/stm32g041.yaml
@@ -29,3 +29,4 @@ _include:
  - common_patches/tim/common.yaml
  - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/tim/tim_advanced.yaml
+ - ./common_patches/g0_flash.yaml

--- a/devices/stm32g070.yaml
+++ b/devices/stm32g070.yaml
@@ -168,3 +168,5 @@ _include:
  - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim_advanced.yaml
+
+ - ./common_patches/g0_flash.yaml

--- a/devices/stm32g071.yaml
+++ b/devices/stm32g071.yaml
@@ -92,3 +92,4 @@ _include:
  - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim_advanced.yaml
+ - ./common_patches/g0_flash.yaml

--- a/devices/stm32g081.yaml
+++ b/devices/stm32g081.yaml
@@ -51,3 +51,4 @@ _include:
  - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim_advanced.yaml
+ - ./common_patches/g0_flash.yaml

--- a/devices/stm32g0b1.yaml
+++ b/devices/stm32g0b1.yaml
@@ -117,3 +117,4 @@ _include:
  - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim_advanced.yaml
+ - ./common_patches/g0_flash.yaml

--- a/devices/stm32g0c1.yaml
+++ b/devices/stm32g0c1.yaml
@@ -125,3 +125,4 @@ _include:
  - ../peripherals/tim/tim_basic.yaml
  - ../peripherals/tim/tim6.yaml
  - ../peripherals/tim/tim_advanced.yaml
+ - ./common_patches/g0_flash.yaml


### PR DESCRIPTION
See reference manual for [STM32G0x0](https://www.st.com/resource/en/reference_manual/rm0454-stm32g0x0-advanced-armbased-32bit-mcus-stmicroelectronics.pdf) and [STM32G0x1](https://www.st.com/resource/en/reference_manual/rm0444-stm32g0x1-advanced-armbased-32bit-mcus-stmicroelectronics.pdf). Both define FLASH_WRP1AR etc as read-write (but read-only in the SVD). STM32G0x1 defines FLASH_SECR as read-write (but read-only in the SVD). The STM32G0x0 doesn't have a FLASH_SECR register.