### PR TITLE
F301: Add missing P to JADST

### DIFF
--- a/devices/stm32f301.yaml
+++ b/devices/stm32f301.yaml
@@ -45,6 +45,8 @@ ADC1:
     _modify:
       '*':
         access: read-write
+      JADST:
+        name: JADSTP
 
 ADC1_2:
   _delete:

--- a/devices/stm32f3x4.yaml
+++ b/devices/stm32f3x4.yaml
@@ -5,6 +5,9 @@ _modify:
   Flash:
     name: FLASH
 
+  ADC_Common:
+    name: ADC1_2
+
 _rebase:
   SPI1: SPI3
 
@@ -100,7 +103,7 @@ SYSCFG:
       - PAGE6_WP
       - PAGE7_WP
 
-ADC_Common:
+ADC1_2:
   _strip:
     - ADC1_
 


### PR DESCRIPTION
The f301 is the only device in the F3 family, which has the field name
wrong. In the datasheet [RM0366] 12.5.3 `JADSTP` is also used.

[RM0366]: https://www.st.com/resource/en/reference_manual/dm00094350.pdf