### PR TITLE
Fix missing author name in APACHE license

### DIFF
--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -186,7 +186,7 @@ APPENDIX: How to apply the Apache License to your work.
    same "printed page" as the copyright notice for easier
    identification within third-party archives.
 
-Copyright [yyyy] [name of copyright owner]
+Copyright 2017 Adam Greig
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
Hey @adamgreig I've noticed that your name is not mentioned in the Apache license, while being in the MIT license.

I've copied name and year from the MIT license. 