### PR TITLE
Fix ADC disable

### DIFF
--- a/peripherals/adc/adc_v3.yaml
+++ b/peripherals/adc/adc_v3.yaml
@@ -97,7 +97,7 @@
       Start: [1, "Starts conversion of channel"]
     ADDIS:
       _write:
-        Disable: [0, "Disable ADC conversion and go to power down mode"]
+        Disable: [1, "Disable ADC conversion and go to power down mode"]
     ADEN:
       _write:
         Enable: [1, "Enable ADC"]

--- a/peripherals/adc/adc_v3.yaml
+++ b/peripherals/adc/adc_v3.yaml
@@ -92,15 +92,29 @@
       SingleEnded: [0, "Calibration for single-ended mode"]
       Differential: [1, "Calibration for differential mode"]
     JADSTP,ADSTP:
-      Stop: [1, "Stop conversion of channel"]
+      _read:
+        NotStopping: [0, "No stop command active"]
+        Stopping: [1, "ADC stopping conversion"]
+      _write:
+        StopConversion: [1, "Stop the active conversion"]
     JADSTART,ADSTART:
-      Start: [1, "Starts conversion of channel"]
+      _read:
+        NotActive: [0, "No conversion ongoing"]
+        Active: [1, "ADC operating and may be converting"]
+      _write:
+        StartConversion: [1, "Start the ADC conversion (may be delayed for hardware triggers)"]
     ADDIS:
+      _read:
+        NotDisabling: [0, "No disable command active"]
+        Disabling: [1, "ADC disabling"]
       _write:
-        Disable: [1, "Disable ADC conversion and go to power down mode"]
+        Disable: [1, "Disable the ADC"]
     ADEN:
+      _read:
+        Disabled: [0, "ADC disabled"]
+        Enabled: [1, "ADC enabled"]
       _write:
-        Enable: [1, "Enable ADC"]
+        Enabled: [1, "Enable the ADC"]
   CFGR:
     AWD1CH: [0, 19]
     JAUTO:


### PR DESCRIPTION
`ADDIS`, as `ADEN`, is a signal to the ADC peripheral to change it's
state. Both signals have to be "1" to change the state.

In case of `ADDIS` it will be only reset to "0", after the state has
successfully changed.

The procedure of disabling is the same between `stm32f303xc` (RM0316
15.3.10), where I've noticed the bug, and `stm32h7x3` (RM0443 25.4.9),
for which this code was initially committed, so I assume this affects
every device using the `adc_v3.yaml`.