### PR TITLE
F7/tim: access to bits() without unsafe for single-field registers

### DIFF
--- a/devices/common_patches/f7_tim.yaml
+++ b/devices/common_patches/f7_tim.yaml
@@ -56,3 +56,11 @@ TIM[1-58]:
       # specific register field documentation in RMs
       DMAB:
         bitWidth: 32
+
+"TIM9,TIM1[0-4]":
+  CNT:
+    CNT: [0, 65535]
+  ARR:
+    ARR: [0, 65535]
+  CCR%s:
+    CCR: [0, 65535]


### PR DESCRIPTION
When writing to  `CNT`/`ARR`/`CCR%s` single-field registers via `bits()`, it requires the use of unsafe for timers 9 to 14.
This PR allows to use safe `bits()` writing just like the other timers