### PR TITLE
Change H7 DMA CR patch to only include SxCR registers

### DIFF
--- a/devices/common_patches/h7_dmacr.yaml
+++ b/devices/common_patches/h7_dmacr.yaml
@@ -1,5 +1,5 @@
 "DMA?":
-  "*CR":
+  "S?CR":
     _add:
       TRBUFF:
         description: Enable the DMA to handle bufferable transfers


### PR DESCRIPTION
I noticed that the patch to add a TRBUFF field to the H7 DMA SxCR registers also erroneously adds it to SxFCR, LIFCR, and HIFCR registers. This PR restricts it to only the SxCR registers.

It's not much of an issue since the incorrect fields are easily ignorable, but it is also easily fixable.