### PR TITLE
Apply OTG_FS v1 fixes to F215/F217

### DIFF
--- a/devices/common_patches/usb_otg/otg_fs_fixes_v1.yaml
+++ b/devices/common_patches/usb_otg/otg_fs_fixes_v1.yaml
@@ -1,4 +1,4 @@
-# For F401, F411
+# For F215, F217, F401, F411
 
 OTG_FS_GLOBAL:
   _add:

--- a/devices/stm32f215.yaml
+++ b/devices/stm32f215.yaml
@@ -91,4 +91,6 @@ _include:
  - common_patches/hash/hash_v1.yaml
  - common_patches/rtc/rtc_bkpr.yaml
  - common_patches/rtc/rtc_cr.yaml
+ - common_patches/usb_otg/otg_fs_remove_prefix.yaml
+ - common_patches/usb_otg/otg_fs_fixes_v1.yaml
  - common_patches/dbgmcu.yaml


### PR DESCRIPTION
These devices have OTG_FS with CID 0x0000 1200 (same as F401), and the SVD files seem to have the same bugs as F401/F411 SVD files.