### PR TITLE
Add missing BDCR LSEMOD field for STM32F410/11/12

### DIFF
--- a/devices/common_patches/f41x_bdcr_lsemod.yaml
+++ b/devices/common_patches/f41x_bdcr_lsemod.yaml
@@ -1,0 +1,7 @@
+RCC:
+  BDCR:
+    _add:
+      LSEMOD:
+        description: External low speed oscillator
+        bitOffset: 3
+        bitWidth: 1

--- a/devices/stm32f410.yaml
+++ b/devices/stm32f410.yaml
@@ -163,11 +163,13 @@ _include:
  - common_patches/f4_rcc_fmpi2c.yaml
  - common_patches/f4_adc_single_csr.yaml
  - common_patches/f4_adc_single_ccr.yaml
+ - common_patches/f41x_bdcr_lsemod.yaml
  - ../peripherals/dac/dac_wavegen.yaml
  - ../peripherals/dac/dac_common_2ch.yaml
  - ../peripherals/dac/dac_dmaudr.yaml
  - ../peripherals/rcc/rcc_merge_sw_sws.yaml
  - ../peripherals/rcc/rcc_v2.yaml
+ - ../peripherals/rcc/rcc_v2_bdcr_lsemod.yaml
  - ../peripherals/rcc/rcc_v2_pllcfgr_pllr.yaml
  - ../peripherals/rcc/rcc_v2_cfgr_mcoen.yaml
  - ../peripherals/rcc/rcc_v2_dckcfgr_timpre.yaml

--- a/devices/stm32f411.yaml
+++ b/devices/stm32f411.yaml
@@ -139,8 +139,10 @@ _include:
  - common_patches/f4_rcc_dckcfgr.yaml
  - common_patches/f4_adc_no_csr.yaml
  - common_patches/f4_adc_single_ccr.yaml
+ - common_patches/f41x_bdcr_lsemod.yaml
  - ../peripherals/rcc/rcc_merge_sw_sws.yaml
  - ../peripherals/rcc/rcc_v2.yaml
+ - ../peripherals/rcc/rcc_v2_bdcr_lsemod.yaml
  - ../peripherals/rcc/rcc_v2_i2s.yaml
  - ../peripherals/rcc/rcc_v2_i2s_pll.yaml
  - ../peripherals/rcc/rcc_v2_i2s_pllm.yaml

--- a/devices/stm32f412.yaml
+++ b/devices/stm32f412.yaml
@@ -405,9 +405,11 @@ _include:
  - common_patches/f4_adc_single_ccr.yaml
  - common_patches/fsmc/fsmc_sram.yaml
  - common_patches/fsmc/fsmc_sramfix_common.yaml
+ - common_patches/f41x_bdcr_lsemod.yaml
  - ../peripherals/fsmc/fsmc_sram.yaml
  - ../peripherals/rcc/rcc_merge_sw_sws.yaml
  - ../peripherals/rcc/rcc_v2.yaml
+ - ../peripherals/rcc/rcc_v2_bdcr_lsemod.yaml
  - ../peripherals/rcc/rcc_v2_pllcfgr_pllr.yaml
  - ../peripherals/rcc/rcc_v2_i2s.yaml
  - ../peripherals/rcc/rcc_v2_i2s_pll.yaml


### PR DESCRIPTION
According to this design guide,
https://www.st.com/resource/en/application_note/an2867-oscillator-design-guide-for-stm8afals-stm32-mcus-and-mpus-stmicroelectronics.pdf#page=25,
as well the reference manuals for those MCUs
(https://www.st.com/resource/en/reference_manual/rm0401-stm32f410-advanced-armbased-32bit-mcus-stmicroelectronics.pdf,
https://www.st.com/resource/en/reference_manual/rm0383-stm32f411xce-advanced-armbased-32bit-mcus-stmicroelectronics.pdf,
https://www.st.com/resource/en/reference_manual/rm0402-stm32f412-advanced-armbased-32bit-mcus-stmicroelectronics.pdf)
the LSEMOD bit should be available.