### PR TITLE
CRC peripheral corrections

### DIFF
--- a/devices/common_patches/crc/crc_add_pol.yaml
+++ b/devices/common_patches/crc/crc_add_pol.yaml
@@ -1,0 +1,16 @@
+CRC:
+  # The SVD is missing the programmable polynomial register "POL"
+  _add:
+    POL:
+      displayName: POL
+      description: CRC polynomial
+      addressOffset: 0x14
+      size: 0x20
+      access: read-write
+      resetValue: 0x04C11DB7
+      fields:
+        POL:
+          description: Programmable polynomial
+          bitOffset: 0
+          bitWidth: 32
+          access: read-write

--- a/devices/common_patches/crc/crc_rename_pol.yaml
+++ b/devices/common_patches/crc/crc_rename_pol.yaml
@@ -1,0 +1,5 @@
+CRC:
+  POL:
+    _modify:
+      Polynomialcoefficients:
+        name: POL

--- a/devices/common_patches/stm32l4x2_l412.yaml
+++ b/devices/common_patches/stm32l4x2_l412.yaml
@@ -122,6 +122,7 @@ _include:
  - dfsdm/dfsdm_v2.yaml
  - ../../peripherals/gpio/v2/common.yaml
  - crc/crc_rename_init.yaml
+ - crc/crc_rename_pol.yaml
  - ../../peripherals/crc/crc_advanced.yaml
  - ../../peripherals/crc/crc_idr_8bit.yaml
  - ../../peripherals/crc/crc_with_polysize.yaml

--- a/devices/common_patches/stm32l4x2_l412.yaml
+++ b/devices/common_patches/stm32l4x2_l412.yaml
@@ -125,7 +125,7 @@ _include:
  - crc/crc_rename_pol.yaml
  - ../../peripherals/crc/crc_advanced.yaml
  - ../../peripherals/crc/crc_idr_8bit.yaml
- - ../../peripherals/crc/crc_with_polysize.yaml
+ - ../../peripherals/crc/crc_pol.yaml
  - ../../peripherals/wwdg/wwdg.yaml
  - ../../peripherals/rcc/rcc_l4.yaml
  - tim/common.yaml

--- a/devices/stm32f0x0.yaml
+++ b/devices/stm32f0x0.yaml
@@ -59,7 +59,6 @@ _include:
  - ../peripherals/gpio/gpio_with_brr.yaml
  - ../peripherals/crc/crc_advanced.yaml
  - ../peripherals/crc/crc_idr_8bit.yaml
- - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml
  - ../peripherals/iwdg/iwdg_with_WINR.yaml

--- a/devices/stm32f0x1.yaml
+++ b/devices/stm32f0x1.yaml
@@ -50,6 +50,7 @@ _include:
  - ../peripherals/dac/dac_dmaudr.yaml
  - ../peripherals/gpio/v2/common.yaml
  - ../peripherals/gpio/gpio_with_brr.yaml
+ - common_patches/crc/crc_add_pol.yaml
  - ../peripherals/crc/crc_advanced.yaml
  - ../peripherals/crc/crc_idr_8bit.yaml
  - ../peripherals/crc/crc_with_polysize.yaml

--- a/devices/stm32f0x1.yaml
+++ b/devices/stm32f0x1.yaml
@@ -53,7 +53,7 @@ _include:
  - common_patches/crc/crc_add_pol.yaml
  - ../peripherals/crc/crc_advanced.yaml
  - ../peripherals/crc/crc_idr_8bit.yaml
- - ../peripherals/crc/crc_with_polysize.yaml
+ - ../peripherals/crc/crc_pol.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml
  - ../peripherals/iwdg/iwdg_with_WINR.yaml

--- a/devices/stm32f0x2.yaml
+++ b/devices/stm32f0x2.yaml
@@ -61,7 +61,7 @@ _include:
  - common_patches/crc/crc_add_pol.yaml
  - ../peripherals/crc/crc_advanced.yaml
  - ../peripherals/crc/crc_idr_8bit.yaml
- - ../peripherals/crc/crc_with_polysize.yaml
+ - ../peripherals/crc/crc_pol.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml
  - ../peripherals/iwdg/iwdg_with_WINR.yaml

--- a/devices/stm32f0x2.yaml
+++ b/devices/stm32f0x2.yaml
@@ -58,6 +58,7 @@ _include:
  - ../peripherals/dac/dac_dmaudr.yaml
  - ../peripherals/gpio/v2/common.yaml
  - ../peripherals/gpio/gpio_with_brr.yaml
+ - common_patches/crc/crc_add_pol.yaml
  - ../peripherals/crc/crc_advanced.yaml
  - ../peripherals/crc/crc_idr_8bit.yaml
  - ../peripherals/crc/crc_with_polysize.yaml

--- a/devices/stm32f0x8.yaml
+++ b/devices/stm32f0x8.yaml
@@ -37,7 +37,7 @@ _include:
  - common_patches/crc/crc_add_pol.yaml
  - ../peripherals/crc/crc_advanced.yaml
  - ../peripherals/crc/crc_idr_8bit.yaml
- - ../peripherals/crc/crc_with_polysize.yaml
+ - ../peripherals/crc/crc_pol.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/pwr/pwr_v1.yaml
  - ../peripherals/iwdg/iwdg_with_WINR.yaml

--- a/devices/stm32f0x8.yaml
+++ b/devices/stm32f0x8.yaml
@@ -34,6 +34,7 @@ _include:
  - ../peripherals/dac/dac_dmaudr.yaml
  - ../peripherals/gpio/v2/common.yaml
  - ../peripherals/gpio/gpio_with_brr.yaml
+ - common_patches/crc/crc_add_pol.yaml
  - ../peripherals/crc/crc_advanced.yaml
  - ../peripherals/crc/crc_idr_8bit.yaml
  - ../peripherals/crc/crc_with_polysize.yaml

--- a/devices/stm32f301.yaml
+++ b/devices/stm32f301.yaml
@@ -161,7 +161,6 @@ _include:
  - ./common_patches/unprefix_USB_registers.yaml
  - ../peripherals/crc/crc_advanced.yaml
  - ../peripherals/crc/crc_idr_8bit.yaml
- - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/crc/crc_pol.yaml
  - ../peripherals/spi/spi_v2.yaml
  - ../peripherals/wwdg/wwdg.yaml

--- a/devices/stm32f302.yaml
+++ b/devices/stm32f302.yaml
@@ -143,7 +143,6 @@ _include:
  - common_patches/f3_gpio_ospeedr.yaml
  - ../peripherals/crc/crc_advanced.yaml
  - ../peripherals/crc/crc_idr_8bit.yaml
- - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/crc/crc_pol.yaml
  - ../peripherals/spi/spi_v2.yaml
  - ../peripherals/wwdg/wwdg.yaml

--- a/devices/stm32f303.yaml
+++ b/devices/stm32f303.yaml
@@ -142,7 +142,6 @@ _include:
  - common_patches/f3_gpio_ospeedr.yaml
  - ../peripherals/crc/crc_advanced.yaml
  - ../peripherals/crc/crc_idr_8bit.yaml
- - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/crc/crc_pol.yaml
  - ../peripherals/spi/spi_v2.yaml
  - ../peripherals/wwdg/wwdg.yaml

--- a/devices/stm32f373.yaml
+++ b/devices/stm32f373.yaml
@@ -155,7 +155,6 @@ _include:
  - ./common_patches/unprefix_USB_registers.yaml
  - ../peripherals/crc/crc_advanced.yaml
  - ../peripherals/crc/crc_idr_8bit.yaml
- - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/crc/crc_pol.yaml
  - ../peripherals/spi/spi_v2.yaml
  - ../peripherals/wwdg/wwdg.yaml

--- a/devices/stm32f3x4.yaml
+++ b/devices/stm32f3x4.yaml
@@ -280,7 +280,6 @@ _include:
  - common_patches/f3_gpio_ospeedr.yaml
  - ../peripherals/crc/crc_advanced.yaml
  - ../peripherals/crc/crc_idr_32bit.yaml
- - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/crc/crc_pol.yaml
  - ../peripherals/spi/spi_v2.yaml
  - ../peripherals/wwdg/wwdg.yaml

--- a/devices/stm32f730.yaml
+++ b/devices/stm32f730.yaml
@@ -40,7 +40,6 @@ _include:
  - common_patches/crc/crc_rename_init.yaml
  - ../peripherals/crc/crc_advanced.yaml
  - ../peripherals/crc/crc_idr_8bit.yaml
- - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/crc/crc_pol.yaml
  - ../peripherals/spi/spi_v2.yaml
  - ../peripherals/adc/adc_v2_smpr.yaml

--- a/devices/stm32f745.yaml
+++ b/devices/stm32f745.yaml
@@ -144,7 +144,6 @@ _include:
  - common_patches/crc/f7_polysize_rev_in_rev_out.yaml
  - ../peripherals/crc/crc_advanced.yaml
  - ../peripherals/crc/crc_idr_8bit.yaml
- - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/crc/crc_pol.yaml
  - ../peripherals/adc/adc_v2_multi.yaml
  - ../peripherals/adc/adc_v2/adc_v2_extsel_d.yaml

--- a/devices/stm32f750.yaml
+++ b/devices/stm32f750.yaml
@@ -63,7 +63,6 @@ _include:
  - common_patches/crc/crc_rename_init.yaml
  - common_patches/crc/f7_polysize_rev_in_rev_out.yaml
  - ../peripherals/crc/crc_advanced.yaml
- - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/crc/crc_pol.yaml
  - ../peripherals/spi/spi_v2.yaml
  - ../peripherals/adc/adc_v2_multi.yaml

--- a/devices/stm32f765.yaml
+++ b/devices/stm32f765.yaml
@@ -163,7 +163,6 @@ _include:
  - common_patches/crc/f7_polysize_rev_in_rev_out.yaml
  - ../peripherals/crc/crc_advanced.yaml
  - ../peripherals/crc/crc_idr_8bit.yaml
- - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/crc/crc_pol.yaml
  - ../peripherals/adc/adc_v2_multi.yaml
  - ../peripherals/adc/adc_v2/adc_v2_extsel_d.yaml

--- a/devices/stm32f7x2.yaml
+++ b/devices/stm32f7x2.yaml
@@ -41,7 +41,6 @@ _include:
  - common_patches/crc/crc_rename_init.yaml
  - ../peripherals/crc/crc_advanced.yaml
  - ../peripherals/crc/crc_idr_8bit.yaml
- - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/crc/crc_pol.yaml
  - ../peripherals/spi/spi_v2.yaml
  - ../peripherals/adc/adc_v2_smpr.yaml

--- a/devices/stm32f7x3.yaml
+++ b/devices/stm32f7x3.yaml
@@ -51,7 +51,6 @@ _include:
  - common_patches/crc/crc_rename_init.yaml
  - ../peripherals/crc/crc_advanced.yaml
  - ../peripherals/crc/crc_idr_8bit.yaml
- - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/crc/crc_pol.yaml
  - ../peripherals/spi/spi_v2.yaml
  - ../peripherals/adc/adc_v2_smpr.yaml

--- a/devices/stm32f7x6.yaml
+++ b/devices/stm32f7x6.yaml
@@ -129,7 +129,6 @@ _include:
  - common_patches/crc/f7_polysize_rev_in_rev_out.yaml
  - ../peripherals/crc/crc_advanced.yaml
  - ../peripherals/crc/crc_idr_8bit.yaml
- - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/crc/crc_pol.yaml
  - ../peripherals/spi/spi_v2.yaml
  - ../peripherals/adc/adc_v2_multi.yaml

--- a/devices/stm32f7x7.yaml
+++ b/devices/stm32f7x7.yaml
@@ -299,7 +299,6 @@ _include:
  - common_patches/crc/f7_polysize_rev_in_rev_out.yaml
  - ../peripherals/crc/crc_advanced.yaml
  - ../peripherals/crc/crc_idr_8bit.yaml
- - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/crc/crc_pol.yaml
  - ../peripherals/spi/spi_v2.yaml
  - ../peripherals/adc/adc_v2_smpr.yaml

--- a/devices/stm32f7x9.yaml
+++ b/devices/stm32f7x9.yaml
@@ -307,7 +307,6 @@ _include:
  - common_patches/crc/f7_polysize_rev_in_rev_out.yaml
  - ../peripherals/crc/crc_advanced.yaml
  - ../peripherals/crc/crc_idr_8bit.yaml
- - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/crc/crc_pol.yaml
  - ../peripherals/spi/spi_v2.yaml
  - ../peripherals/adc/adc_v2_multi.yaml

--- a/devices/stm32h735.yaml
+++ b/devices/stm32h735.yaml
@@ -545,7 +545,6 @@ _include:
  - common_patches/crc/crc_rename_init.yaml
  - ../peripherals/crc/crc_advanced.yaml
  - ../peripherals/crc/crc_idr_32bit.yaml
- - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/crc/crc_pol.yaml
  - ../peripherals/dma/bdma.yaml
  - ../peripherals/dma/dma_v3.yaml

--- a/devices/stm32h743.yaml
+++ b/devices/stm32h743.yaml
@@ -61,7 +61,6 @@ _include:
  - common_patches/crc/crc_rename_init.yaml
  - ../peripherals/crc/crc_advanced.yaml
  - ../peripherals/crc/crc_idr_32bit.yaml
- - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/crc/crc_pol.yaml
  - ../peripherals/dma/bdma.yaml
  - ../peripherals/dma/dma_v3.yaml

--- a/devices/stm32h743v.yaml
+++ b/devices/stm32h743v.yaml
@@ -63,7 +63,6 @@ _include:
  - common_patches/crc/crc_rename_init.yaml
  - ../peripherals/crc/crc_advanced.yaml
  - ../peripherals/crc/crc_idr_32bit.yaml
- - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/crc/crc_pol.yaml
  - ../peripherals/dma/bdma.yaml
  - ../peripherals/dma/dma_v3.yaml

--- a/devices/stm32h747cm4.yaml
+++ b/devices/stm32h747cm4.yaml
@@ -66,7 +66,6 @@ _include:
  - common_patches/crc/crc_rename_init.yaml
  - ../peripherals/crc/crc_advanced.yaml
  - ../peripherals/crc/crc_idr_32bit.yaml
- - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/crc/crc_pol.yaml
  - ../peripherals/dma/bdma.yaml
  - ../peripherals/dma/dma_v3.yaml

--- a/devices/stm32h747cm7.yaml
+++ b/devices/stm32h747cm7.yaml
@@ -67,7 +67,6 @@ _include:
  - common_patches/crc/crc_rename_init.yaml
  - ../peripherals/crc/crc_advanced.yaml
  - ../peripherals/crc/crc_idr_32bit.yaml
- - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/crc/crc_pol.yaml
  - ../peripherals/dma/bdma.yaml
  - ../peripherals/dma/dma_v3.yaml

--- a/devices/stm32h753.yaml
+++ b/devices/stm32h753.yaml
@@ -72,7 +72,6 @@ _include:
  - common_patches/crc/crc_rename_init.yaml
  - ../peripherals/crc/crc_advanced.yaml
  - ../peripherals/crc/crc_idr_32bit.yaml
- - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/crc/crc_pol.yaml
  - ../peripherals/dma/bdma.yaml
  - ../peripherals/dma/dma_v3.yaml

--- a/devices/stm32h753v.yaml
+++ b/devices/stm32h753v.yaml
@@ -74,7 +74,6 @@ _include:
  - common_patches/crc/crc_rename_init.yaml
  - ../peripherals/crc/crc_advanced.yaml
  - ../peripherals/crc/crc_idr_32bit.yaml
- - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/crc/crc_pol.yaml
  - ../peripherals/dma/bdma.yaml
  - ../peripherals/dma/dma_v3.yaml

--- a/devices/stm32h7b3.yaml
+++ b/devices/stm32h7b3.yaml
@@ -120,7 +120,6 @@ _include:
  - common_patches/crc/crc_rename_init.yaml
  - ../peripherals/crc/crc_advanced.yaml
  - ../peripherals/crc/crc_idr_32bit.yaml
- - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/crc/crc_pol.yaml
  - ../peripherals/dma/bdma.yaml
  - ../peripherals/dma/dma_v3.yaml

--- a/devices/stm32l0x0.yaml
+++ b/devices/stm32l0x0.yaml
@@ -14,12 +14,6 @@ ADC:
       SMPR:
         name: SMP
 
-CRC:
-  POL:
-    _modify:
-      Polynomialcoefficients:
-        name: POL
-
 "SPI*,I2S*":
   SR:
     _modify:
@@ -84,6 +78,7 @@ _include:
  - ./common_patches/remove_l0_stk.yaml
  - ../peripherals/adc/adc_l0.yaml
  - common_patches/crc/crc_rename_init.yaml
+ - common_patches/crc/crc_rename_pol.yaml
  - ../peripherals/crc/crc_advanced.yaml
  - ../peripherals/crc/crc_idr_8bit.yaml
  - ../peripherals/crc/crc_pol.yaml

--- a/devices/stm32l0x0.yaml
+++ b/devices/stm32l0x0.yaml
@@ -86,7 +86,6 @@ _include:
  - common_patches/crc/crc_rename_init.yaml
  - ../peripherals/crc/crc_advanced.yaml
  - ../peripherals/crc/crc_idr_8bit.yaml
- - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/crc/crc_pol.yaml
  - ../peripherals/dbg/dbg_l0.yaml
  - ../peripherals/dma/dma_v1_with_remapping.yaml

--- a/devices/stm32l0x1.yaml
+++ b/devices/stm32l0x1.yaml
@@ -136,7 +136,6 @@ _include:
  - common_patches/crc/crc_rename_init.yaml
  - ../peripherals/crc/crc_advanced.yaml
  - ../peripherals/crc/crc_idr_8bit.yaml
- - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/crc/crc_pol.yaml
  - ../peripherals/dbg/dbg_l0.yaml
  - ../peripherals/dma/dma_v1_with_remapping.yaml

--- a/devices/stm32l0x1.yaml
+++ b/devices/stm32l0x1.yaml
@@ -21,12 +21,6 @@ ADC:
       Disabled: [0, "VLCD reading circuitry disabled"]
       Enabled: [1, "VLCD reading circuitry enabled"]
 
-CRC:
-  POL:
-    _modify:
-      Polynomialcoefficients:
-        name: POL
-
 DBG:
   _modify:
     DBG_APB2_FZ:
@@ -134,6 +128,7 @@ _include:
  - ../peripherals/adc/adc_l0.yaml
  - ../peripherals/aes/aes_l0.yaml
  - common_patches/crc/crc_rename_init.yaml
+ - common_patches/crc/crc_rename_pol.yaml
  - ../peripherals/crc/crc_advanced.yaml
  - ../peripherals/crc/crc_idr_8bit.yaml
  - ../peripherals/crc/crc_pol.yaml

--- a/devices/stm32l0x2.yaml
+++ b/devices/stm32l0x2.yaml
@@ -24,12 +24,6 @@ ADC:
       SMPR:
         name: SMP
 
-CRC:
-  POL:
-    _modify:
-      Polynomialcoefficients:
-        name: POL
-
 FLASH:
   _modify:
     OBR:
@@ -133,6 +127,7 @@ _include:
  - ../peripherals/adc/adc_l0.yaml
  - ../peripherals/aes/aes_l0.yaml
  - common_patches/crc/crc_rename_init.yaml
+ - common_patches/crc/crc_rename_pol.yaml
  - ../peripherals/crc/crc_advanced.yaml
  - ../peripherals/crc/crc_idr_8bit.yaml
  - ../peripherals/crc/crc_pol.yaml

--- a/devices/stm32l0x2.yaml
+++ b/devices/stm32l0x2.yaml
@@ -135,7 +135,6 @@ _include:
  - common_patches/crc/crc_rename_init.yaml
  - ../peripherals/crc/crc_advanced.yaml
  - ../peripherals/crc/crc_idr_8bit.yaml
- - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/crc/crc_pol.yaml
  - ../peripherals/dbg/dbg_l0.yaml
  - ../peripherals/dac/dac_common_1ch.yaml

--- a/devices/stm32l0x3.yaml
+++ b/devices/stm32l0x3.yaml
@@ -35,12 +35,6 @@ ADC:
       Disabled: [0, "VLCD reading circuitry disabled"]
       Enabled: [1, "VLCD reading circuitry enabled"]
 
-CRC:
-  POL:
-    _modify:
-      Polynomialcoefficients:
-        name: POL
-
 FLASH:
   _modify:
     OBR:
@@ -143,6 +137,7 @@ _include:
  - ../peripherals/adc/adc_l0.yaml
  - ../peripherals/aes/aes_l0.yaml
  - common_patches/crc/crc_rename_init.yaml
+ - common_patches/crc/crc_rename_pol.yaml
  - ../peripherals/crc/crc_advanced.yaml
  - ../peripherals/crc/crc_idr_8bit.yaml
  - ../peripherals/crc/crc_pol.yaml

--- a/devices/stm32l0x3.yaml
+++ b/devices/stm32l0x3.yaml
@@ -145,7 +145,6 @@ _include:
  - common_patches/crc/crc_rename_init.yaml
  - ../peripherals/crc/crc_advanced.yaml
  - ../peripherals/crc/crc_idr_8bit.yaml
- - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/crc/crc_pol.yaml
  - ../peripherals/dbg/dbg_l0.yaml
  - ../peripherals/dac/dac_common_1ch.yaml

--- a/devices/stm32l4r5.yaml
+++ b/devices/stm32l4r5.yaml
@@ -228,6 +228,7 @@ _include:
   - ../peripherals/gpio/v2/common.yaml
   - ../peripherals/gpio/gpio_with_brr.yaml
   - common_patches/crc/crc_rename_init.yaml
+  - common_patches/crc/crc_rename_pol.yaml
   - ../peripherals/crc/crc_advanced.yaml
   - ../peripherals/crc/crc_idr_8bit.yaml
   - ../peripherals/crc/crc_pol.yaml

--- a/devices/stm32l4r5.yaml
+++ b/devices/stm32l4r5.yaml
@@ -230,7 +230,7 @@ _include:
   - common_patches/crc/crc_rename_init.yaml
   - ../peripherals/crc/crc_advanced.yaml
   - ../peripherals/crc/crc_idr_8bit.yaml
-  - ../peripherals/crc/crc_with_polysize.yaml
+  - ../peripherals/crc/crc_pol.yaml
   - ../peripherals/wwdg/wwdg.yaml
   - ../peripherals/rcc/rcc_l4.yaml
   - common_patches/tim/common.yaml

--- a/devices/stm32l4r9.yaml
+++ b/devices/stm32l4r9.yaml
@@ -63,9 +63,10 @@ _include:
   - ../peripherals/gpio/v2/common.yaml
   - ../peripherals/gpio/gpio_with_brr.yaml
   - common_patches/crc/crc_rename_init.yaml
+  - common_patches/crc/crc_rename_pol.yaml
   - ../peripherals/crc/crc_advanced.yaml
   - ../peripherals/crc/crc_idr_8bit.yaml
-  - ../peripherals/crc/crc_with_polysize.yaml
+  - ../peripherals/crc/crc_pol.yaml
   - ../peripherals/wwdg/wwdg.yaml
   - ../peripherals/rcc/rcc_l4.yaml
   - common_patches/tim/common.yaml

--- a/devices/stm32l4x1.yaml
+++ b/devices/stm32l4x1.yaml
@@ -98,6 +98,7 @@ _include:
  - common_patches/dfsdm/dfsdm_v2.yaml
  - ../peripherals/gpio/v2/common.yaml
  - common_patches/crc/crc_rename_init.yaml
+ - common_patches/crc/crc_rename_pol.yaml
  - ../peripherals/crc/crc_advanced.yaml
  - ../peripherals/crc/crc_idr_8bit.yaml
  - ../peripherals/crc/crc_with_polysize.yaml

--- a/devices/stm32l4x1.yaml
+++ b/devices/stm32l4x1.yaml
@@ -101,7 +101,7 @@ _include:
  - common_patches/crc/crc_rename_pol.yaml
  - ../peripherals/crc/crc_advanced.yaml
  - ../peripherals/crc/crc_idr_8bit.yaml
- - ../peripherals/crc/crc_with_polysize.yaml
+ - ../peripherals/crc/crc_pol.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/rcc/rcc_l4.yaml
  - ../peripherals/rcc/rcc_l4_usart2_3.yaml

--- a/devices/stm32l4x3.yaml
+++ b/devices/stm32l4x3.yaml
@@ -129,6 +129,7 @@ _include:
  - common_patches/sai/sai_v1.yaml
  - ../peripherals/gpio/v2/common.yaml
  - common_patches/crc/crc_rename_init.yaml
+ - common_patches/crc/crc_rename_pol.yaml
  - ../peripherals/crc/crc_advanced.yaml
  - ../peripherals/crc/crc_idr_8bit.yaml
  - ../peripherals/crc/crc_with_polysize.yaml

--- a/devices/stm32l4x3.yaml
+++ b/devices/stm32l4x3.yaml
@@ -132,7 +132,7 @@ _include:
  - common_patches/crc/crc_rename_pol.yaml
  - ../peripherals/crc/crc_advanced.yaml
  - ../peripherals/crc/crc_idr_8bit.yaml
- - ../peripherals/crc/crc_with_polysize.yaml
+ - ../peripherals/crc/crc_pol.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/rcc/rcc_l4.yaml
  - ../peripherals/rcc/rcc_l4_usart2_3.yaml

--- a/devices/stm32l4x5.yaml
+++ b/devices/stm32l4x5.yaml
@@ -160,7 +160,7 @@ _include:
  - common_patches/crc/crc_rename_pol.yaml
  - ../peripherals/crc/crc_advanced.yaml
  - ../peripherals/crc/crc_idr_8bit.yaml
- - ../peripherals/crc/crc_with_polysize.yaml
+ - ../peripherals/crc/crc_pol.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/rcc/rcc_l4.yaml
  - ../peripherals/rcc/rcc_l4_usart2_3.yaml

--- a/devices/stm32l4x5.yaml
+++ b/devices/stm32l4x5.yaml
@@ -157,6 +157,7 @@ _include:
  - ../peripherals/fsmc/fsmc_nand.yaml
  - ../peripherals/gpio/v2/common.yaml
  - common_patches/crc/crc_rename_init.yaml
+ - common_patches/crc/crc_rename_pol.yaml
  - ../peripherals/crc/crc_advanced.yaml
  - ../peripherals/crc/crc_idr_8bit.yaml
  - ../peripherals/crc/crc_with_polysize.yaml

--- a/devices/stm32l4x6.yaml
+++ b/devices/stm32l4x6.yaml
@@ -58,7 +58,7 @@ _include:
  - common_patches/crc/crc_rename_pol.yaml
  - ../peripherals/crc/crc_advanced.yaml
  - ../peripherals/crc/crc_idr_8bit.yaml
- - ../peripherals/crc/crc_with_polysize.yaml
+ - ../peripherals/crc/crc_pol.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/rcc/rcc_l4.yaml
  - ../peripherals/rcc/rcc_l4_usart2_3.yaml

--- a/devices/stm32l4x6.yaml
+++ b/devices/stm32l4x6.yaml
@@ -55,6 +55,7 @@ _include:
  - ../peripherals/gpio/v2/common.yaml
  - ../peripherals/gpio/gpio_with_brr.yaml
  - common_patches/crc/crc_rename_init.yaml
+ - common_patches/crc/crc_rename_pol.yaml
  - ../peripherals/crc/crc_advanced.yaml
  - ../peripherals/crc/crc_idr_8bit.yaml
  - ../peripherals/crc/crc_with_polysize.yaml

--- a/devices/stm32wl5x_cm0p.yaml
+++ b/devices/stm32wl5x_cm0p.yaml
@@ -135,7 +135,6 @@ _include:
  - ../peripherals/comp/comp_wl.yaml
  - ../peripherals/crc/crc_advanced.yaml
  - ../peripherals/crc/crc_pol.yaml
- - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/dac/dac_wl.yaml
  - ../peripherals/dac/dac_wl_12bit.yaml
  - ../peripherals/dac/dac_wl_8bit.yaml

--- a/devices/stm32wl5x_cm4.yaml
+++ b/devices/stm32wl5x_cm4.yaml
@@ -133,7 +133,6 @@ _include:
  - ../peripherals/comp/comp_wl.yaml
  - ../peripherals/crc/crc_advanced.yaml
  - ../peripherals/crc/crc_pol.yaml
- - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/dac/dac_wl.yaml
  - ../peripherals/dac/dac_wl_12bit.yaml
  - ../peripherals/dac/dac_wl_8bit.yaml

--- a/devices/stm32wle5.yaml
+++ b/devices/stm32wle5.yaml
@@ -181,7 +181,6 @@ _include:
  - ../peripherals/comp/comp_wl.yaml
  - ../peripherals/crc/crc_advanced.yaml
  - ../peripherals/crc/crc_pol.yaml
- - ../peripherals/crc/crc_with_polysize.yaml
  - ../peripherals/dac/dac_wl.yaml
  - ../peripherals/dac/dac_wl_12bit.yaml
  - ../peripherals/dac/dac_wl_8bit.yaml

--- a/peripherals/crc/crc_pol.yaml
+++ b/peripherals/crc/crc_pol.yaml
@@ -1,3 +1,10 @@
 CRC:
+  CR:
+    POLYSIZE:
+      Polysize32: [0, "32-bit polynomial"]
+      Polysize16: [1, "16-bit polynomial"]
+      Polysize8: [2, "8-bit polynomial"]
+      Polysize7: [3, "7-bit polynomial"]
+
   POL:
     POL: [0, 0xFFFFFFFF]

--- a/peripherals/crc/crc_with_polysize.yaml
+++ b/peripherals/crc/crc_with_polysize.yaml
@@ -1,9 +1,0 @@
-# CRC peripheral with polysize feature
-
-CRC:
-  CR:
-    POLYSIZE:
-      Polysize32: [0, "32-bit polynomial"]
-      Polysize16: [1, "16-bit polynomial"]
-      Polysize8: [2, "8-bit polynomial"]
-      Polysize7: [3, "7-bit polynomial"]


### PR DESCRIPTION
This PR proposes the following corrections related to the CRC peripheral.

### 1. Remove the CRC:Polysize field from the STM32F0x0
According to [RM0360](https://www.st.com/resource/en/reference_manual/rm0360-stm32f030x4x6x8xc-and-stm32f070x6xb-advanced-armbased-32bit-mcus-stmicroelectronics.pdf), these devices do not have a programmable polygonal size.

### 2. Ensure the polynomial field within CRC:POL has the same name in all devices
In the following devices, this field was named `Polynomialcoefficients` instead of `POL` like in other devices.
 * STM32L4x2
 * STM32L4R9
 * STM32L4x1
 * STM32L4x3
 * STM32L4x5
 * STM32L4x6

### 3. Add missing CRC:POL register to STM32F0x1, STM32F0x2, STM32F0x8
According to [RM0091](https://www.st.com/resource/en/reference_manual/rm0091-stm32f0x1stm32f0x2stm32f0x8-advanced-armbased-32bit-mcus-stmicroelectronics.pdf), these devices have a CRC:POL register but it is missing from the SVD.

Note: for the STM32F03x, STM32F04x and STM32F05x the CRC:POL register is read-only. However, since no separate SVD file is in place for these device sub-ranges, the register will be incorrectly marked as read-write for them. The same applies to the CRC:CR:POLYSIZE field, which was already present in these devices before this PR.

### 4. Merge `crc_with_polysize.yaml` into `crc_pol.yaml` and update devices accordingly
As far as I can tell, the CRC:CR:POLYSIZE field (for setting the size of the CRC polynomial) and the CRC:POL register (for reading/writing the CRC polynomial itself) always coincide.

Quite a number of devices only had `crc_with_polysize.yaml` without `crc_pol.yaml`, which does not make sense to me, because why would a device support setting the size of the polynomial if it doesn't support setting the polynomial itself? For all devices that now have access to the CRC:POL register because of this change, I verified that this is in line with the applicable reference manual.
