### PR TITLE
Add timers TIM23 and TIM24 to stm32h735

### DIFF
--- a/devices/stm32h735.yaml
+++ b/devices/stm32h735.yaml
@@ -72,6 +72,22 @@ _add:
         description: BDMA Channel 7 interrupt
         value: 136
 
+  # Additional timers
+  TIM23:
+    derivedFrom: TIM2
+    baseAddress: 0x4000E000
+    interrupts:
+      TIM23:
+        description: TIM23 global interrupt
+        value: 161
+  TIM24:
+    derivedFrom: TIM2
+    baseAddress: 0x4000E400
+    interrupts:
+      TIM24:
+        description: TIM24 global interrupt
+        value: 162
+
 # PWR block
 PWR:
   CR3:


### PR DESCRIPTION
The SVD files in this repo don't include timers TIM23 and TIM24 for the RM0468-based chips (H730, H723, H725, H733, H735). There is an updated SVD that someone from STM posted [here](https://community.st.com/s/question/0D53W00000cyEKvSAM/bug-stm32cubeide-missing-tim23-and-tim24-in-sfrs-window), which just adds the lines:
```
    <peripheral derivedFrom="TIM2">
      <name>TIM23</name>
      <baseAddress>0x4000E000</baseAddress>
      <interrupt>
        <name>TIM23</name>
        <description>TIM23 global interrupt</description>
        <value>161</value>
      </interrupt>
    </peripheral>
	<peripheral derivedFrom="TIM2">
      <name>TIM24</name>
      <baseAddress>0x4000E400</baseAddress>
      <interrupt>
        <name>TIM24</name>
        <description>TIM24 global interrupt</description>
        <value>162</value>
      </interrupt>
    </peripheral>
```

As far as I can tell, the changes I made to the yaml file do the same thing.