### PR TITLE
f4xx: UART fix missing Guard Time and Prescaler Register, f413 UART should include USART-only fields.

### DIFF
--- a/devices/common_patches/f4_add_UART_GTPR.yaml
+++ b/devices/common_patches/f4_add_UART_GTPR.yaml
@@ -1,0 +1,11 @@
+"UART*":
+  _add:
+    GTPR:
+      description: Guard Time and Prescaler Register
+      addressOffset: 0x18
+      access: read-write
+      fields:
+        PSC:
+          description: IrDA Low-Power pulse width peripheral clock prescaler
+          bitOffset: 0
+          bitWidth: 8

--- a/devices/stm32f405.yaml
+++ b/devices/stm32f405.yaml
@@ -111,6 +111,7 @@ _include:
  - ../peripherals/usart/uart_sample.yaml
  - ../peripherals/usart/uart_uart.yaml
  - ../peripherals/usart/uart_usart.yaml
+ - common_patches/f4_add_UART_GTPR.yaml
  - ../peripherals/i2c/i2c_v1.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/iwdg/iwdg.yaml

--- a/devices/stm32f407.yaml
+++ b/devices/stm32f407.yaml
@@ -120,6 +120,7 @@ _include:
  - ../peripherals/usart/uart_sample.yaml
  - ../peripherals/usart/uart_uart.yaml
  - ../peripherals/usart/uart_common.yaml
+ - common_patches/f4_add_UART_GTPR.yaml
  - ../peripherals/i2c/i2c_v1.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/iwdg/iwdg.yaml

--- a/devices/stm32f413.yaml
+++ b/devices/stm32f413.yaml
@@ -166,6 +166,14 @@ TIM7:
   CNT:
     _delete: [UIFCPY]
 
+# UART4 is erroneously derived from a fully-featured USART (with extra fields which UARTs lack).
+_delete:
+  UART4:
+
+_copy:
+  UART4:
+    from: ../svd/stm32f405.svd:UART4
+
 _include:
  - common_patches/4_nvic_prio_bits.yaml
  - common_patches/merge_I2C_OAR1_ADDx_fields.yaml

--- a/devices/stm32f413.yaml
+++ b/devices/stm32f413.yaml
@@ -229,6 +229,7 @@ _include:
  - ../peripherals/usart/uart_common.yaml
  - ../peripherals/usart/uart_sample.yaml
  - ../peripherals/usart/uart_usart.yaml
+ - common_patches/f4_add_UART_GTPR.yaml
  - ../peripherals/i2c/i2c_v1.yaml
  - ../peripherals/i2c/i2c_v2_fmp.yaml
  - ../peripherals/wwdg/wwdg.yaml

--- a/devices/stm32f427.yaml
+++ b/devices/stm32f427.yaml
@@ -225,6 +225,7 @@ _include:
  - ../peripherals/usart/uart_sample.yaml
  - ../peripherals/usart/uart_uart.yaml
  - ../peripherals/usart/uart_usart.yaml
+ - common_patches/f4_add_UART_GTPR.yaml
  - ../peripherals/i2c/i2c_v1.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - common_patches/tim/tim_o24ce.yaml

--- a/devices/stm32f429.yaml
+++ b/devices/stm32f429.yaml
@@ -186,6 +186,7 @@ _include:
  - ../peripherals/usart/uart_sample.yaml
  - ../peripherals/usart/uart_uart.yaml
  - ../peripherals/usart/uart_usart.yaml
+ - common_patches/f4_add_UART_GTPR.yaml
  - ../peripherals/i2c/i2c_v1.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/iwdg/iwdg.yaml

--- a/devices/stm32f446.yaml
+++ b/devices/stm32f446.yaml
@@ -564,6 +564,7 @@ _include:
  - ../peripherals/usart/uart_sample.yaml
  - ../peripherals/usart/uart_uart.yaml
  - ../peripherals/usart/uart_usart.yaml
+ - common_patches/f4_add_UART_GTPR.yaml
  - ../peripherals/i2c/i2c_v1.yaml
  - ../peripherals/i2c/i2c_v2_fmp.yaml
  - ../peripherals/wwdg/wwdg.yaml

--- a/devices/stm32f469.yaml
+++ b/devices/stm32f469.yaml
@@ -165,6 +165,7 @@ _include:
  - ../peripherals/usart/uart_sample.yaml
  - ../peripherals/usart/uart_uart.yaml
  - ../peripherals/usart/uart_usart.yaml
+ - common_patches/f4_add_UART_GTPR.yaml
  - ../peripherals/i2c/i2c_v1.yaml
  - ../peripherals/wwdg/wwdg.yaml
  - ../peripherals/iwdg/iwdg.yaml


### PR DESCRIPTION
Currently, the F413 UART peripheral is a copy of its USART definition, whereas all of the other F4xx family use a separate independent definition for the UART peripheral (the independent definition doesn't include USART-specific fields which are not present in the UART peripheral).  Fix by using the F405 UART definition on the F413.

All F4xx UARTs support IrDA mode, which utilises the PSC fields of the GTPR register.  This field is missing in the UART definition (except F413 - see above) across the F4 family (presence and correct operation of the GTPR PSC field was verified by the author on F429 and F446 microcontrollers).

n.b. The other GTPR field (GT) appears to be specific to SmartCard mode - which is a USART-only feature, not supported on UART according to the reference manual, so the PR does not currently include that field for UARTs.