### PR TITLE
Fix various issues with STM32L562

### DIFF
--- a/devices/stm32l562.yaml
+++ b/devices/stm32l562.yaml
@@ -53,12 +53,16 @@ GTZC_TZSC:
         description: Number of data to transfer
         bitOffset: 0
         bitWidth: 18
+    _delete:
+      - MA
   "CNDTR[6-8]":
     _add:
       NDT:
         description: Number of data to transfer
         bitOffset: 0
         bitWidth: 16
+    _delete:
+      - MA
 
 # exclude CCR1 and CCR5, since they already contains the correct regs
   "CCR[2-4]":
@@ -132,6 +136,8 @@ GTZC_TZSC:
         description: privileged mode
         bitOffset: 20
         bitWidth: 1
+    _delete:
+      - MA
   "CCR[6-8]":
     _add:
       MEM2MEM:
@@ -203,6 +209,8 @@ GTZC_TZSC:
         description: privileged mode
         bitOffset: 20
         bitWidth: 1
+    _delete:
+      - MA
 
 _include:
  - common_patches/dma_interrupt_names.yaml

--- a/devices/stm32l562.yaml
+++ b/devices/stm32l562.yaml
@@ -28,10 +28,15 @@ PKA:
 GTZC_MPCBB1:
   _strip:
     - "MPCBB1_"
-
+  _array:
+    "VCTR*":
+      name: VCTR%s
 GTZC_MPCBB2:
   _strip:
     - "MPCBB2_"
+  _array:
+    "VCTR*":
+      name: VCTR%s
 
 GTZC_TZIC:
   _strip:

--- a/devices/stm32l562.yaml
+++ b/devices/stm32l562.yaml
@@ -9,7 +9,6 @@ _modify:
     fpuPresent: "true"
     nvicPrioBits: 3
     vendorSystickConfig: "false"
-
 FMC:
   _strip:
     - "FMC_"
@@ -41,6 +40,164 @@ GTZC_TZIC:
 GTZC_TZSC:
   _strip:
     - "TZSC_"
+
+"DMA[1-2]":
+  "CNDTR[2-4]":
+    _add:
+      NDT:
+        description: Number of data to transfer
+        bitOffset: 0
+        bitWidth: 18
+  "CNDTR[6-8]":
+    _add:
+      NDT:
+        description: Number of data to transfer
+        bitOffset: 0
+        bitWidth: 16
+
+# exclude CCR1 and CCR5, since they already contains the correct regs
+  "CCR[2-4]":
+    _add:
+      MEM2MEM:
+        description: Memory to memory mode
+        bitOffset: 14
+        bitWidth: 1
+      PL:
+        description: Channel priority level
+        bitOffset: 12
+        bitWidth: 2
+      MSIZE:
+        description: Memory size
+        bitOffset: 10
+        bitWidth: 2
+      PSIZE:
+        description: Peripheral size
+        bitOffset: 8
+        bitWidth: 2
+      MINC:
+        description: Memory increment mdoe
+        bitOffset: 7
+        bitWidth: 1
+      PINC:
+        description: Peripheral increment mode
+        bitOffset: 7
+        bitWidth: 1
+      CIRC:
+        description: Ciruclar mode
+        bitOffset: 5
+        bitWidth: 1
+      DIR:
+        description: Data transfer direction
+        bitOffset: 4
+        bitWidth: 1
+      TEIE:
+        description: Transfer error interupt enable
+        bitOffset: 3
+        bitWidth: 1
+      HTIE:
+        description: Half transfer interrupt enable
+        bitOffset: 2
+        bitWidth: 1
+      TCIE:
+        description: Transfer complete interrupt enable
+        bitOffset: 1
+        bitWidth: 1
+      EN:
+        description: Channel enable
+        bitOffset: 0
+        bitWidth: 1
+      DBM:
+        description: double-buffer mode
+        bitOffset: 15
+        bitWidth: 1
+      CT:
+        description: Current target memory of DMA transfer in double-bufer mode
+        bitOffset: 16
+        bitWidth: 1
+      SECM:
+        bitOffset: 17
+        bitWidth: 1
+      SSEC:
+        bitOffset: 18
+        bitWidth: 1
+      DSEC:
+        bitOffset: 19
+        bitWidth: 1
+      PRIV:
+        description: privileged mode
+        bitOffset: 20
+        bitWidth: 1
+  "CCR[6-8]":
+    _add:
+      MEM2MEM:
+        description: Memory to memory mode
+        bitOffset: 14
+        bitWidth: 1
+      PL:
+        description: Channel priority level
+        bitOffset: 12
+        bitWidth: 2
+      MSIZE:
+        description: Memory size
+        bitOffset: 10
+        bitWidth: 2
+      PSIZE:
+        description: Peripheral size
+        bitOffset: 8
+        bitWidth: 2
+      MINC:
+        description: Memory increment mdoe
+        bitOffset: 7
+        bitWidth: 1
+      PINC:
+        description: Peripheral increment mode
+        bitOffset: 7
+        bitWidth: 1
+      CIRC:
+        description: Ciruclar mode
+        bitOffset: 5
+        bitWidth: 1
+      DIR:
+        description: Data transfer direction
+        bitOffset: 4
+        bitWidth: 1
+      TEIE:
+        description: Transfer error interupt enable
+        bitOffset: 3
+        bitWidth: 1
+      HTIE:
+        description: Half transfer interrupt enable
+        bitOffset: 2
+        bitWidth: 1
+      TCIE:
+        description: Transfer complete interrupt enable
+        bitOffset: 1
+        bitWidth: 1
+      EN:
+        description: Channel enable
+        bitOffset: 0
+        bitWidth: 1
+      DBM:
+        description: double-buffer mode
+        bitOffset: 15
+        bitWidth: 1
+      CT:
+        description: Current target memory of DMA transfer in double-bufer mode
+        bitOffset: 16
+        bitWidth: 1
+      SECM:
+        bitOffset: 17
+        bitWidth: 1
+      SSEC:
+        bitOffset: 18
+        bitWidth: 1
+      DSEC:
+        bitOffset: 19
+        bitWidth: 1
+      PRIV:
+        description: privileged mode
+        bitOffset: 20
+        bitWidth: 1
 
 _include:
  - common_patches/dma_interrupt_names.yaml


### PR DESCRIPTION
This PR fixes two issues with the STM32L562's SVD files. In particular the DMA registers CCR registers only included the correct fields on the first register. This PR fixes that.

It also merges the GTZC VCTR into an array, rather than individual fields. 