### PR TITLE
Change the groupName of ADC_Common from ADC to ADC_Common

### DIFF
--- a/devices/common_patches/adc_common_group_name.yaml
+++ b/devices/common_patches/adc_common_group_name.yaml
@@ -1,0 +1,5 @@
+# Rename group name of ADC_Common from ADC to ADC_Common
+
+_modify:
+  ADC_Common:
+    groupName: ADC_Common

--- a/devices/common_patches/l4_adc_common.yaml
+++ b/devices/common_patches/l4_adc_common.yaml
@@ -4,7 +4,7 @@ _add:
   # from RM0394.
   ADC_Common:
     description: ADC common registers
-    groupName: ADC
+    groupName: ADC_Common
     baseAddress: 0x50040300
     addressBlock:
       offset: 0

--- a/devices/common_patches/wb_adc_common.yaml
+++ b/devices/common_patches/wb_adc_common.yaml
@@ -5,7 +5,7 @@ _add:
   # from RM0434.
   ADC_Common:
     description: ADC common registers
-    groupName: ADC
+    groupName: ADC_Common
     baseAddress: 0x50040300
     addressBlock:
       offset: 0

--- a/devices/stm32f215.yaml
+++ b/devices/stm32f215.yaml
@@ -96,3 +96,4 @@ _include:
  - common_patches/usb_otg/otg_fs_remove_prefix.yaml
  - common_patches/usb_otg/otg_fs_fixes_v1.yaml
  - common_patches/dbgmcu.yaml
+ - common_patches/adc_common_group_name.yaml

--- a/devices/stm32f217.yaml
+++ b/devices/stm32f217.yaml
@@ -93,3 +93,4 @@ _include:
  - common_patches/rtc/rtc_bkpr.yaml
  - common_patches/rtc/rtc_cr.yaml
  - common_patches/dbgmcu.yaml
+ - common_patches/adc_common_group_name.yaml

--- a/devices/stm32f401.yaml
+++ b/devices/stm32f401.yaml
@@ -163,3 +163,4 @@ _include:
  - ../peripherals/sdio/sdio_f4.yaml
  - common_patches/i2c_v1_fltr.yaml
  - ../peripherals/i2c/i2c_v1_fltr.yaml
+ - common_patches/adc_common_group_name.yaml

--- a/devices/stm32f405.yaml
+++ b/devices/stm32f405.yaml
@@ -133,3 +133,4 @@ _include:
  - common_patches/f4_rtc_cr.yaml
  - common_patches/rtc/rtc_cr.yaml
  - ../peripherals/rtc/rtc_common.yaml
+ - common_patches/adc_common_group_name.yaml

--- a/devices/stm32f407.yaml
+++ b/devices/stm32f407.yaml
@@ -141,3 +141,4 @@ _include:
  - common_patches/rtc/rtc_cr.yaml
  - ../peripherals/rtc/rtc_common.yaml
  - ../peripherals/sdio/sdio_f4.yaml
+ - common_patches/adc_common_group_name.yaml

--- a/devices/stm32f410.yaml
+++ b/devices/stm32f410.yaml
@@ -211,3 +211,4 @@ _include:
  - ../peripherals/rtc/rtc_common.yaml
  - common_patches/i2c_v1_fltr.yaml
  - ../peripherals/i2c/i2c_v1_fltr.yaml
+ - common_patches/adc_common_group_name.yaml

--- a/devices/stm32f411.yaml
+++ b/devices/stm32f411.yaml
@@ -184,3 +184,4 @@ _include:
  - ../peripherals/sdio/sdio_f4.yaml
  - common_patches/i2c_v1_fltr.yaml
  - ../peripherals/i2c/i2c_v1_fltr.yaml
+ - common_patches/adc_common_group_name.yaml

--- a/devices/stm32f412.yaml
+++ b/devices/stm32f412.yaml
@@ -459,3 +459,4 @@ _include:
  - ../peripherals/sdio/sdio_f4.yaml
  - common_patches/i2c_v1_fltr.yaml
  - ../peripherals/i2c/i2c_v1_fltr.yaml
+ - common_patches/adc_common_group_name.yaml

--- a/devices/stm32f413.yaml
+++ b/devices/stm32f413.yaml
@@ -247,3 +247,4 @@ _include:
  - ../peripherals/rtc/rtc_common.yaml
  - ../peripherals/sdio/sdio_f4.yaml
  - ../peripherals/i2c/i2c_v1_fltr.yaml
+ - common_patches/adc_common_group_name.yaml

--- a/devices/stm32f427.yaml
+++ b/devices/stm32f427.yaml
@@ -259,3 +259,4 @@ _include:
  - ../peripherals/rtc/rtc_common.yaml
  - ../peripherals/sdio/sdio_f4.yaml
  - ../peripherals/i2c/i2c_v1_fltr.yaml
+ - common_patches/adc_common_group_name.yaml

--- a/devices/stm32f429.yaml
+++ b/devices/stm32f429.yaml
@@ -217,3 +217,4 @@ _include:
  - ../peripherals/flash/flash_latency16.yaml
  - ../peripherals/sdio/sdio_f4.yaml
  - ../peripherals/i2c/i2c_v1_fltr.yaml
+ - common_patches/adc_common_group_name.yaml

--- a/devices/stm32f446.yaml
+++ b/devices/stm32f446.yaml
@@ -597,3 +597,4 @@ _include:
  - ../peripherals/flash/flash_latency16.yaml
  - ../peripherals/rcc/rcc_v2_pllcfgr_pllr.yaml
  - ../peripherals/i2c/i2c_v1_fltr.yaml
+ - common_patches/adc_common_group_name.yaml

--- a/devices/stm32f469.yaml
+++ b/devices/stm32f469.yaml
@@ -193,3 +193,4 @@ _include:
  - ../peripherals/rtc/rtc_common.yaml
  - ../peripherals/sdio/sdio_f4.yaml
  - ../peripherals/i2c/i2c_v1_fltr.yaml
+ - common_patches/adc_common_group_name.yaml

--- a/devices/stm32f730.yaml
+++ b/devices/stm32f730.yaml
@@ -81,3 +81,4 @@ _include:
  - ../peripherals/sai/sai.yaml
  - common_patches/rtc/rtc_cr.yaml
  - ../peripherals/rtc/rtc_common.yaml
+ - common_patches/adc_common_group_name.yaml

--- a/devices/stm32f745.yaml
+++ b/devices/stm32f745.yaml
@@ -195,3 +195,4 @@ _include:
  - ../peripherals/dma/dma2d_v1.yaml
  - common_patches/rtc/rtc_cr.yaml
  - ../peripherals/rtc/rtc_common.yaml
+ - common_patches/adc_common_group_name.yaml

--- a/devices/stm32f750.yaml
+++ b/devices/stm32f750.yaml
@@ -121,3 +121,4 @@ _include:
  - common_patches/ltdc/ltdc.yaml
  - common_patches/ltdc/f4_f7_ltdc_bccr.yaml
  - ../peripherals/ltdc/ltdc.yaml
+ - common_patches/adc_common_group_name.yaml

--- a/devices/stm32f765.yaml
+++ b/devices/stm32f765.yaml
@@ -218,3 +218,4 @@ _include:
  - ../peripherals/dma/dma2d_v1.yaml
  - common_patches/rtc/rtc_cr.yaml
  - ../peripherals/rtc/rtc_common.yaml
+ - common_patches/adc_common_group_name.yaml

--- a/devices/stm32f7x2.yaml
+++ b/devices/stm32f7x2.yaml
@@ -82,3 +82,4 @@ _include:
  - ../peripherals/sai/sai.yaml
  - common_patches/rtc/rtc_cr.yaml
  - ../peripherals/rtc/rtc_common.yaml
+ - common_patches/adc_common_group_name.yaml

--- a/devices/stm32f7x3.yaml
+++ b/devices/stm32f7x3.yaml
@@ -92,3 +92,4 @@ _include:
  - ../peripherals/sai/sai.yaml
  - common_patches/rtc/rtc_cr.yaml
  - ../peripherals/rtc/rtc_common.yaml
+ - common_patches/adc_common_group_name.yaml

--- a/devices/stm32f7x6.yaml
+++ b/devices/stm32f7x6.yaml
@@ -181,3 +181,4 @@ _include:
  - ../peripherals/dma/dma2d_v1.yaml
  - common_patches/rtc/rtc_cr.yaml
  - ../peripherals/rtc/rtc_common.yaml
+ - common_patches/adc_common_group_name.yaml

--- a/devices/stm32f7x7.yaml
+++ b/devices/stm32f7x7.yaml
@@ -9,7 +9,7 @@ _add:
   # from RM0410.
   ADC_Common:
     description: ADC common registers
-    groupName: ADC
+    groupName: ADC_Common
     baseAddress: 0x40012300
     addressBlock:
       offset: 0x0

--- a/devices/stm32f7x9.yaml
+++ b/devices/stm32f7x9.yaml
@@ -9,7 +9,7 @@ _add:
   # from RM0410.
   ADC_Common:
     description: ADC common registers
-    groupName: ADC
+    groupName: ADC_Common
     baseAddress: 0x40012300
     addressBlock:
       offset: 0x0

--- a/devices/stm32l4r9.yaml
+++ b/devices/stm32l4r9.yaml
@@ -97,4 +97,4 @@ _include:
   - common_patches/usb_otg/otg_fs_remove_prefix.yaml
   - common_patches/usb_otg/otg_fs_fixes_v1.yaml
   - common_patches/l4_lpuart_presc.yaml
- - common_patches/adc_common_group_name.yaml
+  - common_patches/adc_common_group_name.yaml

--- a/devices/stm32l4r9.yaml
+++ b/devices/stm32l4r9.yaml
@@ -97,4 +97,4 @@ _include:
   - common_patches/usb_otg/otg_fs_remove_prefix.yaml
   - common_patches/usb_otg/otg_fs_fixes_v1.yaml
   - common_patches/l4_lpuart_presc.yaml
-  
+ - common_patches/adc_common_group_name.yaml

--- a/devices/stm32l4x5.yaml
+++ b/devices/stm32l4x5.yaml
@@ -198,3 +198,4 @@ _include:
  - ./common_patches/l4_dbg_apb_fzr_rename.yaml
  - ../peripherals/spi/spi_l4.yaml
  - ./common_patches/l4_tim15_ch2.yaml
+ - common_patches/adc_common_group_name.yaml

--- a/devices/stm32l4x6.yaml
+++ b/devices/stm32l4x6.yaml
@@ -92,3 +92,4 @@ _include:
  - ../peripherals/spi/spi_l4.yaml
  - ./common_patches/l4_dbg_apb_fzr_rename.yaml
  - ./common_patches/l4_lcd_segment.yaml
+ - common_patches/adc_common_group_name.yaml

--- a/devices/stm32l552.yaml
+++ b/devices/stm32l552.yaml
@@ -47,3 +47,4 @@ _include:
  - ./common_patches/sai/sai_v1.yaml
  - common_patches/tim/v2/l5.yaml
  - ../peripherals/tim/v2/ccm.yaml
+ - common_patches/adc_common_group_name.yaml

--- a/devices/stm32l562.yaml
+++ b/devices/stm32l562.yaml
@@ -221,3 +221,4 @@ _include:
  - ../peripherals/tim/v2/ccm.yaml
  - common_patches/rtc/alarm.yaml
  - common_patches/rtc/tamp_bkpr.yaml
+ - common_patches/adc_common_group_name.yaml


### PR DESCRIPTION
In the https://github.com/tinygo-org/stm32-svd project, it depends this project and generates types by the peripheral's groupName. Because the ADC_Common's groupName is ADC, it can't generate the types ADC and ADC_Common correctly. I want to change the ADC_Common's groupName to ADC to make it work fine.  See https://github.com/tinygo-org/tinygo/pull/2717 , https://github.com/tinygo-org/stm32-svd/pull/7 , but those are not good way.

I checked the generated rust code, it's not changed after apply this change and run make, seems it doesn't depend groupName. So can you accept this PR? 