### PR TITLE
g4 RCC Remove RNGSMEN -> RNGEN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ Family-specific:
 * G0:
     * Clear all vendor provided enumeratedValues
 
+* G4:
+    * RCC: Remove RNGSMEN -> RNGEN renaming to have AHB2SMENR.RNGSMEN
+
 * H7:
     * h7b3: clear all enumeratedValues
 

--- a/devices/common_patches/g4_rcc.yaml
+++ b/devices/common_patches/g4_rcc.yaml
@@ -166,8 +166,6 @@ RCC:
         name: ADC12SMEN
       CRYPTSMEN:
         name: AESMEN # sic, from RM0440 but likely should be AESSMEN
-      RNGSMEN:
-        name: RNGEN # sic, from RM0440 but RNGSMEN seems more correct
 
   AHB3SMENR:
     _modify:


### PR DESCRIPTION
In peripheral registers overview table this is correctly
listed as RNGSMEN, only in detailed register description
it says RNGEN which seems incorrect (as all fields in the register
use `SMEN` suffix).

Comment also suggets that this is likely an error.