### PR TITLE
F302: rename `DAC` to `DAC1`

### DIFF
--- a/devices/stm32f302.yaml
+++ b/devices/stm32f302.yaml
@@ -5,6 +5,10 @@ _modify:
   Flash:
     name: FLASH
 
+  # Rename DAC to DAC1 in accordance with the reference manual.
+  DAC:
+    name: DAC1
+
 "SPI*":
   SR:
     _modify:


### PR DESCRIPTION
This matches other chips in the F30x lineage and is also how the reference manual calls it.

cc https://github.com/stm32-rs/stm32f3xx-hal/pull/318, where the inconsistent name required some extra `#[cfg]`s