### PR TITLE
Set SAI FSDEF to read-write to match described usage, despite all the RMs calling it read-only

### DIFF
--- a/devices/common_patches/sai/sai_v1.yaml
+++ b/devices/common_patches/sai/sai_v1.yaml
@@ -34,7 +34,7 @@
           FSALL:
             access: read-write
           FSDEF:
-            access: read-only
+            access: read-write
           FSPOL:
             access: read-write
           FSOFF:

--- a/devices/common_patches/sai/sai_v2.yaml
+++ b/devices/common_patches/sai/sai_v2.yaml
@@ -38,7 +38,7 @@
           FSALL:
             access: read-write
           FSDEF:
-            access: read-only
+            access: read-write
           FSPOL:
             access: read-write
           FSOFF:


### PR DESCRIPTION
Closes #749 