### PR TITLE
 L4x6 missing registers for dfsdm filter1 #760 

### DIFF
--- a/devices/stm32l4x6.yaml
+++ b/devices/stm32l4x6.yaml
@@ -31,10 +31,6 @@ MPU:
   _strip:
     - "MPU_"
 
-#DFSDM1:
-#  _strip:
-#    - "DFSDM1_"
-
 _include:
  - common_patches/nvic/4_prio_bits.yaml
  - ./common_patches/usart/merge_CR2_ADDx_fields.yaml

--- a/devices/stm32l4x6.yaml
+++ b/devices/stm32l4x6.yaml
@@ -31,9 +31,9 @@ MPU:
   _strip:
     - "MPU_"
 
-DFSDM1:
-  _strip:
-    - "DFSDM1_"
+#DFSDM1:
+#  _strip:
+#    - "DFSDM1_"
 
 _include:
  - common_patches/nvic/4_prio_bits.yaml
@@ -51,6 +51,7 @@ _include:
  - common_patches/can/can_filter_bank.yaml
  - ../peripherals/can/can.yaml
  - common_patches/sai/sai_v1.yaml
+ - common_patches/dfsdm/dfsdm_v2.yaml
  - ./common_patches/rcc/l4_crrcr.yaml
  - ../peripherals/gpio/v2/common.yaml
  - ../peripherals/gpio/gpio_with_brr.yaml


### PR DESCRIPTION
I copied a patch from l4x5 and removed some code that the l4x5 yaml doesn't have.  I've compiled it with stm32-hal and it seems to recognize all the filters and channels like with l4x5.  However I don't really know what I'm doing so let me know what you think.