### PR TITLE
Adds DCMI/PSSI peripheral and adds DCMI/PSSI support to H735

### DIFF
--- a/devices/common_patches/pssi/h735.yaml
+++ b/devices/common_patches/pssi/h735.yaml
@@ -1,0 +1,3 @@
+_add:
+  PSSI:
+    baseAddress: 0x48020400

--- a/devices/common_patches/pssi/h735.yaml
+++ b/devices/common_patches/pssi/h735.yaml
@@ -1,3 +1,0 @@
-_add:
-  PSSI:
-    baseAddress: 0x48020400

--- a/devices/stm32h735.yaml
+++ b/devices/stm32h735.yaml
@@ -802,13 +802,6 @@ TIM1:
       TIM_CC:
         name: TIM1_CC
 
-DCMI:
-  _modify:
-    _interrupts:
-      DCMI:
-        name: DCMI_PSSI
-        description: DCMI/PSSI global interrupt
-
 OTG1_HS_GLOBAL:
   _add:
     _interrupts:
@@ -1004,3 +997,5 @@ _include:
  - common_patches/wwdg/h7.yaml
  - common_patches/ethernet/h7_mac.yaml
  - ../peripherals/cordic/cordic_h7.yaml
+ - ../peripherals/dcmi/dcmi.yaml
+ - ../peripherals/pssi/pssi.yaml

--- a/peripherals/dcmi/dcmi.yaml
+++ b/peripherals/dcmi/dcmi.yaml
@@ -1,0 +1,158 @@
+"DCMI":
+  _modify:
+    _interrupts:
+      DCMI:
+        name: DCMI_PSSI
+        description: DCMI/PSSI global interrupt
+
+  CR:
+    OELS:
+      Odd: [0, "Interface captures first line after the frame start, second one being dropped"]
+      Even: [1, "Interface captures second line from the frame start, first one being dropped"]
+    LSM:
+      All: [0, "Interface captures all received lines"]
+      Half: [1, "Interface captures one line out of two"]
+    OEBS:
+      Odd: [0, "Interface captures first data (byte or double byte) from the frame/line start, second one being dropped"]
+      Even: [1, " Interface captures second data (byte or double byte) from the frame/line start, first one being dropped"]
+    BSM:
+      All: [0, "Interface captures all received data"]
+      EveryOther: [1, "Interface captures every other byte from the received data"]
+      Fourth: [2, "Interface captures one byte out of four"]
+      TwoOfFour: [3, "Interface captures two bytes out of four"]
+    ENABLE:
+      Disabled: [0, "DCMI disabled"]
+      Enabled: [1, "DCMI enabled"]
+    EDM:
+      BitWidth8: [0, "Interface captures 8-bit data on every pixel clock"]
+      BitWidth10: [1, "Interface captures 10-bit data on every pixel clock"]
+      BitWidth12: [2, "Interface captures 12-bit data on every pixel clock"]
+      BitWidth14: [3, "Interface captures 14-bit data on every pixel clock"]
+    FCRC:
+      All: [0, "All frames are captured"]
+      Alternate: [1, "Every alternate frame captured (50% bandwidth reduction)"]
+      OneOfFour: [2, "One frame out of four captured (75% bandwidth reduction)"]
+    VSPOL:
+      ActiveLow: [0, "DCMI_VSYNC active low"]
+      ActiveHigh: [1, "DCMI_VSYNC active high"]
+    HSPOL:
+      ActiveLow: [0, "DCMI_HSYNC active low" ]
+      ActiveHigh: [1, "DCMI_HSYNC active high" ]
+    PCKPOL:
+      FallingEdge: [0, "Falling edge active"]
+      RisingEdge: [1, "Rising edge active"]
+    ESS:
+      Hardware: [0, "Hardware synchronization data capture (frame/line start/stop) is synchronized with the DCMI_HSYNC/DCMI_VSYNC signals"]
+      Embedded: [1, "Embedded synchronization data capture is synchronized with synchronization codes embedded in the data flow"]
+    JPEG:
+      Uncompressed: [0, "Uncompressed video format"]
+      JPEG: [1, "This bit is used for JPEG data transfers. The DCMI_HSYNC signal is used as data enable. The crop and embedded synchronization features (ESS bit) cannot be used in this mode"]
+    CROP:
+      Full: [0, "The full image is captured. In this case the total number of bytes in an image frame must be a multiple of four"]
+      Cropped: [1, "Only the data inside the window specified by the crop register is captured. If the size of the crop window exceeds the picture size, then only the picture size is captured"]
+    CM:
+      Continuous: [0, "Continuous grab mode - The received data are transferred into the destination memory through the DMA. The buffer location and mode (linear or circular buffer) is controlled through the system DMA"]
+      Snapshot: [1, "Snapshot mode (single frame) - Once activated, the interface waits for the start of frame and then transfers a single frame through the DMA. At the end of the frame, the CAPTURE bit is automatically reset"]
+    CAPTURE:
+      Disabled: [0, "Capture disabled"]
+      Enabled: [1, "Capture enabled"]
+
+  SR:
+    FNE:
+      NotEmpty: [0, "FIFO contains valid data"]
+      Empty: [1, "FIFO empty"]
+    VSYNC:
+      ActiveFrame: [0, "Active frame"]
+      BetweenFrames: [1, "Synchronization between frames"]
+    HSYNC:
+      ActiveLine: [0, "Active line"]
+      BetweenLines: [1, "Synchronization between lines"]
+
+  RIS:
+    LINE_RIS:
+      Set: [1, "Interrupt set"]
+      Cleared: [0, "Interrupt cleared"]
+    VSYNC_RIS:
+      Set: [1, "Interrupt set"]
+      Cleared: [0, "Interrupt cleared"]
+    ERR_RIS:
+      SynchronizationError: [1, "Embedded synchronization characters are not received in the correct order"]
+      NoError: [0, "No synchronization error detected"]
+    OVR_RIS:
+      OverrunOccured: [1, "A data buffer overrun occurred and the data FIFO is corrupted. The bit is cleared by setting the OVR_ISC bit of the DCMI_ICR register"]
+      NoOverrun: [0, "No data buffer overrun occurred"]
+    FRAME_RIS:
+      FrameCaptured: [1, "A frame has been captured"]
+      NoNewCapture: [0, "No new capture"]
+
+  IER:
+    LINE_IE:
+      Disabled: [0, "No interrupt generation when the line is received"]
+      Enabled: [1, "An Interrupt is generated when a line has been completely received"]
+    VSYNC_IE:
+      Disabled: [0, "No interrupt generation"]
+      Enabled: [1, "An interrupt is generated on each DCMI_VSYNC transition from the inactive to the active state"]
+    ERR_IE:
+      Disabled: [0, "No interrupt generation"]
+      Enabled: [1, "An interrupt is generated if the embedded synchronization codes are not received in the correct order"]
+    OVR_IE:
+      Disabled: [0, "No interrupt generation"]
+      Enabled: [1, "An interrupt is generated if the DMA was not able to transfer the last data before new data (32-bit) are received"]
+    FRAME_IE:
+      Disabled: [0, "No interrupt generation"]
+      Enabled: [1, "An interrupt is generated at the end of each received frame/crop window (in crop mode)"]
+
+  MIS:
+    LINE_MIS:
+      Disabled: [0, "No interrupt generation when the line is received"]
+      Enabled: [1, "An Interrupt is generated when a line has been completely received and the LINE_IE bit is set in DCMI_IER"]
+    VSYNC_MIS:
+      Disabled: [0, "No interrupt is generated on DCMI_VSYNC transitions"]
+      Enabled: [1, "An interrupt is generated on each DCMI_VSYNC transition from the inactive to the active state and the VSYNC_IE bit is set in DCMI_IER"]
+    ERR_MIS:
+      Disabled: [0, "No interrupt is generated on a synchronization error"]
+      Enabled: [1, "An interrupt is generated if the embedded synchronization codes are not received in the correct order and the ERR_IE bit in DCMI_IER is set"]
+    OVR_MIS:
+      Disabled: [0, "No interrupt is generated on overrun"]
+      Enabled: [1, "An interrupt is generated if the DMA was not able to transfer the last data before new data (32-bit) are received and the OVR_IE bit is set in DCMI_IER"]
+    FRAME_MIS:
+      Disabled: [0, "No interrupt is generated after a complete capture"]
+      Enabled: [1, "An interrupt is generated at the end of each received frame/crop window (in crop mode) and the FRAME_IE bit is set in DCMI_IER"]
+
+  ICR:
+    LINE_ISC:
+      Clear: [1, "Setting this bit clears the LINE_RIS flag in the DCMI_RIS register"]
+    VSYNC_ISC:
+      Clear: [1, "Setting this bit clears the VSYNC_RIS flag in the DCMI_RIS register"]
+    ERR_ISC:
+      Clear: [1, "Setting this bit clears the ERR_RIS flag in the DCMI_RIS register"]
+    OVR_ISC:
+      Clear: [1, "Setting this bit clears the OVR_RIS flag in the DCMI_RIS register"]
+    FRAME_ISC:
+      Clear: [1, "Setting this bit clears the FRAME_RIS flag in the DCMI_RIS register"]
+
+  ESCR:
+    FEC:
+    LEC:
+    LSC:
+    FSC:
+
+  ESUR:
+    FEU:
+    LEU:
+    LSU:
+    FSU:
+
+  CWSTRT:
+    VST:
+    HOFFCNT:
+
+  CWSIZE:
+    VLINE:
+    CAPCNT:
+
+  DR:
+    Byte3:
+    Byte2:
+    Byte1:
+    Byte0:

--- a/peripherals/pssi/pssi.yaml
+++ b/peripherals/pssi/pssi.yaml
@@ -1,0 +1,206 @@
+_copy:
+  PSSI:
+    from: DCMI
+
+_modify:
+  PSSI:
+    description: Parallel synchronous slave interface
+    groupName: PSSI
+    addressBlock:
+      offset: 0x0
+      size: 0x400
+      usage: "registers"
+
+    registers:
+      CR:
+        description: PSSI control register
+        addressOffset: 0x0
+        size: 0x20
+        access: read-write
+        resetValue:  0x40000000
+        fields:
+          OUTEN:
+            description: Data direction selection bit
+            bitOffset: 31
+            bitWidth: 1
+          DMAEN:
+            description: DMA enable bit
+            bitOffset: 30
+            bitWidth: 1
+          DERDYCFG:
+            description: Data enable and ready configuration
+            bitOffset: 18
+            bitWidth: 3
+          ENABLE:
+            description: PSSI enable
+            bitOffset: 14
+            bitWidth: 1
+          EDM:
+            description: Extended data mode
+            bitOffset: 10
+            bitWidth: 2
+          RDYPOL:
+            description: Ready (PSSI_RDY) polarity
+            bitOffset: 8
+            bitWidth: 1
+          DEPOL:
+            description: Data enable (PSSI_DE) polarity
+            bitOffset: 8
+            bitWidth: 1
+          CKPOL:
+            description: Parallel data clock polarity
+            bitOffset: 8
+            bitWidth: 1
+
+      SR:
+        description: PSSI status register
+        addressOffset: 0x4
+        size: 0x20
+        access: read-only
+        resetValue: 0x00000000
+        fields:
+          RTT1B:
+            description: FIFO is ready to transfer one byte
+            bitOffset: 3
+            bitWidth: 1
+          RTT4B:
+            description: FIFO is ready to transfer four bytes
+            bitOffset: 2
+            bitWidth: 1
+
+      RIS:
+        description: PSSI raw interrupt status register
+        addressOffset: 0x8
+        size: 0x20
+        access: read-only
+        resetValue: 0x00000000
+        fields:
+          OVR_RIS:
+            description: Data buffer overrun/underrun raw interrupt status
+            bitOffset: 1
+            bitWidth: 1
+
+      IER:
+        description: PSSI interrupt enable register
+        addressOffset: 0xC
+        size: 0x20
+        access: read-write
+        resetValue: 0x00000000
+        fields:
+          OVR_IE:
+            description: Data buffer overrun/underrun interrupt enable
+            bitOffset: 1
+            bitWidth: 1
+
+      MIS:
+        description: PSSI masked interrupt status register
+        addressOffset: 0x10
+        size: 0x20
+        access: read-only
+        resetValue: 0x00000000
+        fields:
+          OVR_MIS:
+            description: Data buffer overrun/underrun masked interrupt status
+            bitOffset: 1
+            bitWidth: 1
+
+      ICR:
+        description: PSSI interrupt clear register
+        addressOffset: 0x14
+        size: 0x20
+        access: write-only
+        resetValue: 0x00000000
+        fields:
+          OVR_ISC:
+            description: Data buffer overrun/underrun interrupt status clear
+            bitOffset: 1
+            bitWidth: 1
+
+      DR:
+        description: PSSI data register
+        addressOffset: 0x28
+        size: 0x20
+        access: read-write
+        resetValue: 0x00000000
+        fields:
+          Byte3:
+            bitOffset: 24
+            bitWidth: 8
+          Byte2:
+            bitOffset: 16
+            bitWidth: 8
+          Byte1:
+            bitOffset: 8
+            bitWidth: 8
+          Byte0:
+            bitOffset: 0
+            bitWidth: 8
+
+PSSI:
+  CR:
+    OUTEN:
+      ReceiveMode: [ 0, "Data is input synchronously with PSSI_PDCK" ]
+      TransmitMode: [ 1, "Data is output synchronously with PSSI_PDCK" ]
+
+    DMAEN:
+      Disabled: [ 0, "DMA transfers are disabled. The user application can directly access the PSSI_DR register when DMA transfers are disabled." ]
+      Enabled: [ 1, "DMA transfers are enabled (default configuration). A DMA channel in the general-purpose DMA controller must be configured to perform transfers from/to PSSI_DR" ]
+
+    DERDYCFG:
+      Disabled: [ 0, "PSSI_DE and PSSI_RDY both disabled" ]
+      Rdy: [ 1, "Only PSSI_RDY enabled" ]
+      De: [ 2, "Only PSSI_DE enabled" ]
+      RdyDeAlt: [ 3, "Both PSSI_RDY and PSSI_DE alternate functions enabled" ]
+      RdyDe: [ 4, "Both PSSI_RDY and PSSI_DE features enabled - bidirectional on PSSI_RDY pin" ]
+      RdyRemapped: [ 5, "Only PSSI_RDY function enabled, but mapped to PSSI_DE pin" ]
+      DeRemapped: [ 6, "Only PSSI_DE function enabled, but mapped to PSSI_RDY pin" ]
+      RdyDeBidi: [ 7, "Both PSSI_RDY and PSSI_DE features enabled - bidirectional on PSSI_DE pin" ]
+
+    ENABLE:
+      Disabled: [ 0, "PSSI disabled" ]
+      Enabled: [ 1, "PSSI enabled" ]
+
+    EDM:
+      BitWidth8: [ 0, "Interface captures 8-bit data on every parallel data clock" ]
+      BitWidth16: [ 3, "The interface captures 16-bit data on every parallel data clock" ]
+
+    RDYPOL:
+      ActiveLow: [ 0, "PSSI_RDY active low (0 indicates that the receiver is ready to receive)" ]
+      ActiveHigh: [ 1, "PSSI_RDY active high (1 indicates that the receiver is ready to receive)" ]
+
+    DEPOL:
+      ActiveLow: [ 0, "PSSI_DE active low (0 indicates that data is valid)" ]
+      ActiveHigh: [ 1, "PSSI_DE active high (1 indicates that data is valid)" ]
+
+    CKPOL:
+      FallingEdge: [ 0, "Falling edge active for inputs or rising edge active for outputs" ]
+      RisingEdge: [ 1, "Rising edge active for inputs or falling edge active for outputs" ]
+
+  SR:
+    RTT1B:
+      Ready: [ 1, "FIFO is ready for a one byte (32-bit) transfer. In receive mode, this means that at least one valid data byte is in the FIFO. In transmit mode, this means that there is at least one byte free in the FIFO" ]
+      NotReady: [ 0, "FIFO is not ready for a 1-byte transfer" ]
+
+    RTT4B:
+      Ready: [ 1, "FIFO is ready for a four-byte (32-bit) transfer. In receive mode, this means that at least four valid data bytes are in the FIFO. In transmit mode, this means that there are at least four bytes free in the FIFO" ]
+      NotReady: [ 0, "FIFO is not ready for a four-byte transfer" ]
+
+  RIS:
+    OVR_RIS:
+      Cleared: [ 0, "No overrun/underrun occurred" ]
+      Occurred: [ 1, "An overrun/underrun occurred: overrun in receive mode, underrun in transmit mode. This bit is cleared by writing a 1 to the OVR_ISC bit in PSSI_ICR" ]
+
+  IER:
+    OVR_IE:
+      Disabled: [ 0, "No interrupt generation" ]
+      Enabled: [ 1, "An interrupt is generated if either an overrun or an underrun error occurred" ]
+
+  MIS:
+    OVR_MIS:
+      Disabled: [ 0, "No interrupt is generated when an overrun/underrun error occurs" ]
+      Enabled: [ 1, "An interrupt is generated if there is either an overrun or an underrun error and the OVR_IE bit is set in PSSI_IER" ]
+
+  ICR:
+    OVR_ISC:
+      Clear: [ 1, "Writing this bit to 1 clears the OVR_RIS bit in PSSI_RIS" ]
+


### PR DESCRIPTION
This PR adds initial support for the DCMI and PSSI peripherals.
So far I know of at least the H735 and L4+ series that support these peripherals.
As a starting point the peripherals have been added to the H735 series but are also available in other SVDs. Happy to add them to those if required - but I don't have experience with those devices so didn't want to add them initially.

Remarks:
- PSSI peripheral is on the same address as DCMI for those devices - maybe we could even merge both together but I'm not sure if there are any exceptions from this rule which would mandate two files
- I haven't found a solution to add the enumerated values (especially PSSI) directly when defining registers so had to split into two. It's kinda ugly - so any hints on how to merge them is highly appreciated

Additional Devices where DCMI is available in the SVDs:
- F215
- F217
- F405
- F407
- F427
- F429
- F446
- L4P5
- L4Q5