### PR TITLE
Add reduced ADC3 found on RM0468 parts

### DIFF
--- a/devices/common_patches/adc/h7_adc3.yaml
+++ b/devices/common_patches/adc/h7_adc3.yaml
@@ -1,0 +1,252 @@
+# Patches for the reduced ADC3 peripheral found on RM0468 devies
+
+"ADC3":
+  _delete:
+    - PCSEL
+    - LTR?                      # LTR1 added again with name TR1
+    - HTR?                      # HTR1 added again with name TR2
+    - OFR?                      # Added again below
+    - DIFSEL                    # Added again at the right address
+    - CALFACT                   # Added again at the right address
+    - CALFACT2
+
+  CR:
+    _delete:
+      - BOOST
+      - ADCALLIN
+      - LINCALRDYW?
+
+  CFGR:
+    _delete:
+      - DMNGT
+    _modify:
+      RES:
+        bitOffset: 3
+        bitWidth: 2
+      AUTDLY:
+        description: Delayed conversion mode
+    _add:
+      DMAEN:
+        description: Direct memory access enable
+        bitOffset: 0
+        bitWidth: 1
+      DMACFG:
+        description: Direct memory access configuration
+        bitOffset: 1
+        bitWidth: 1
+      DFSDMCFG:
+        description: DFSDM mode configuration
+        bitOffset: 2
+        bitWidth: 1
+      ALIGN:
+        description: Data alignment
+        bitOffset: 15
+        bitWidth: 1
+  CFGR2:
+    _delete:
+      - RSHIFT?
+      - OVSR
+      - LSHIFT
+    _add:
+      OVSR:
+        description: Oversampling ratio
+        bitOffset: 2
+        bitWidth: 3
+      SWTRIG:
+        description: Software trigger bit for sampling time control trigger mode
+        bitOffset: 25
+        bitWidth: 1
+      BULB:
+        description: Bulb sampling mode
+        bitOffset: 26
+        bitWidth: 1
+      SMPTRIG:
+        description: Sampling time control trigger mode
+        bitOffset: 27
+        bitWidth: 1
+  SMPR1:
+    _add:
+      SMPPLUS:
+        description: Addition of one clock cycle to the sampling time
+        bitOffset: 31
+        bitWidth: 1
+  SMPR2:
+    _delete:
+      - SMP19
+  AWD2CR:
+    _modify:
+      AWD2CH:
+        bitOffset: 0
+        bitWidth: 18
+  AWD3CR:
+    _modify:
+      AWD3CH:
+        bitOffset: 0
+        bitWidth: 18
+
+  _add:
+    TR1:
+      description: ADC watchdog threshold register 1
+      addressOffset: 0x20
+      resetValue: 0x0FFF0000
+      fields:
+        HT1:
+          description: Analog watchdog 1 higher threshold
+          bitOffset: 16
+          bitWidth: 12
+        AWDFILT:
+          description: Analog watchdog filtering parameter
+          bitOffset: 12
+          bitWidth: 3
+        LT1:
+          description: Analog watchdog 1 lower threshold
+          bitOffset: 0
+          bitWidth: 12
+    TR2:
+      description: ADC watchdog threshold register 2
+      addressOffset: 0x24
+      resetValue: 0x00FF0000
+      fields:
+        HT2:
+          description: Analog watchdog 2 higher threshold
+          bitOffset: 16
+          bitWidth: 8
+        LT2:
+          description: Analog watchdog 2 lower threshold
+          bitOffset: 0
+          bitWidth: 8
+    TR3:
+      description: ADC watchdog threshold register 3
+      addressOffset: 0x28
+      resetValue: 0x00FF0000
+      fields:
+        HT3:
+          description: Analog watchdog 3 higher threshold
+          bitOffset: 16
+          bitWidth: 8
+        LT3:
+          description: Analog watchdog 3 lower threshold
+          bitOffset: 0
+          bitWidth: 8
+    OFR1:
+      description: ADC offset number 1 register
+      addressOffset: 0x60
+      resetValue: 0x00000000
+      fields:
+        OFFSET1_EN:
+          description: Offset 1 Enable
+          bitOffset: 31
+          bitWidth: 1
+        OFFSET1_CH:
+          description: Channel selection for the data offset 1
+          bitOffset: 26
+          bitWidth: 5
+        SATEN:
+          description: Saturation enable
+          bitOffset: 25
+          bitWidth: 1
+        OFFSETPOS:
+          description: Positive offset
+          bitOffset: 24
+          bitWidth: 1
+        OFFSET1:
+          description: Data offset 1 for the channel programmed into bits OFFSET1_CH
+          bitOffset: 0
+          bitWidth: 12
+    OFR2:
+      description: ADC offset number 2 register
+      addressOffset: 0x64
+      resetValue: 0x00000000
+      fields:
+        OFFSET2_EN:
+          description: Offset 2 Enable
+          bitOffset: 31
+          bitWidth: 1
+        OFFSET2_CH:
+          description: Channel selection for the data offset 2
+          bitOffset: 26
+          bitWidth: 5
+        SATEN:
+          description: Saturation enable
+          bitOffset: 25
+          bitWidth: 1
+        OFFSETPOS:
+          description: Positive offset
+          bitOffset: 24
+          bitWidth: 1
+        OFFSET2:
+          description: Data offset 2 for the channel programmed into bits OFFSET2_CH
+          bitOffset: 0
+          bitWidth: 12
+    OFR3:
+      description: ADC offset number 3 register
+      addressOffset: 0x68
+      resetValue: 0x00000000
+      fields:
+        OFFSET3_EN:
+          description: Offset 3 Enable
+          bitOffset: 31
+          bitWidth: 1
+        OFFSET3_CH:
+          description: Channel selection for the data offset 3
+          bitOffset: 26
+          bitWidth: 5
+        SATEN:
+          description: Saturation enable
+          bitOffset: 25
+          bitWidth: 1
+        OFFSETPOS:
+          description: Positive offset
+          bitOffset: 24
+          bitWidth: 1
+        OFFSET3:
+          description: Data offset 3 for the channel programmed into bits OFFSET3_CH
+          bitOffset: 0
+          bitWidth: 12
+    OFR4:
+      description: ADC offset number 4 register
+      addressOffset: 0x6C
+      resetValue: 0x00000000
+      fields:
+        OFFSET4_EN:
+          description: Offset 4 Enable
+          bitOffset: 31
+          bitWidth: 1
+        OFFSET4_CH:
+          description: Channel selection for the data offset 4
+          bitOffset: 26
+          bitWidth: 5
+        SATEN:
+          description: Saturation enable
+          bitOffset: 25
+          bitWidth: 1
+        OFFSETPOS:
+          description: Positive offset
+          bitOffset: 24
+          bitWidth: 1
+        OFFSET4:
+          description: Data offset 4 for the channel programmed into bits OFFSET4_CH
+          bitOffset: 0
+          bitWidth: 12
+    DIFSEL:
+      description: ADC differential mode selection register
+      addressOffset: 0xB0
+      resetValue: 0x00000000
+      fields:
+        DIFSEL:
+          description: Differential mode for channels 18 to 0
+          bitOffset: 0
+          bitWidth: 18
+    CALFACT:
+      description: ADC calibration factors
+      addressOffset: 0xB4
+      resetValue: 0x00000000
+      fields:
+        CALFACT_D:
+          description: Calibration Factors in differential mode
+          bitOffset: 16
+          bitWidth: 7
+        CALFACT_S:
+          description: Calibration Factors In single-ended mode
+          bitOffset: 0
+          bitWidth: 7

--- a/devices/common_patches/adc/h7_boost_rev_v.yaml
+++ b/devices/common_patches/adc/h7_boost_rev_v.yaml
@@ -3,7 +3,7 @@
 "ADC?":
   CR:
     _modify:
-      # See RM0433 Section 24.6.3
+      # See RM0433 Rev 7 Section 25.6.3
       BOOST:
         bitOffset: 8
         bitWidth: 2

--- a/devices/stm32h735.yaml
+++ b/devices/stm32h735.yaml
@@ -23,6 +23,13 @@ _modify:
       size: 0x100
       usage: registers
 
+# ADC3 is not quite the same as ADC1
+_delete:
+  - ADC3
+_copy:
+    ADC3:
+        from: ADC1
+
 _add:
   # ADC2
   # Slave ADC, shares an interrupt with ADC2
@@ -938,6 +945,7 @@ _include:
  - common_patches/dma/h7_dmamux.yaml
  - common_patches/dma/dma2d_v2.yaml
  - common_patches/hsem/array.yaml
+ - common_patches/adc/h7_adc3.yaml
  - common_patches/adc/h7.yaml
  - common_patches/adc/h7_boost_rev_v.yaml
  - common_patches/octospi/h7.yaml

--- a/devices/stm32h735.yaml
+++ b/devices/stm32h735.yaml
@@ -966,9 +966,10 @@ _include:
  - common_patches/usart/rename_CR2_DATAINV_field.yaml
  - common_patches/usart/merge_BRR_fields.yaml
  - common_patches/tim/tim_o24ce.yaml
- - ../peripherals/adc/adc_v3_h7.yaml
+ - ../peripherals/adc/adc_v3_h7_12.yaml
  - ../peripherals/adc/adc_v3_common_h7.yaml
- - ../peripherals/adc/adc_h7_revision_v.yaml
+ - ../peripherals/adc/adc_h7_revision_v_12.yaml
+ - ../peripherals/adc/adc_h7_adc3.yaml
  - ../peripherals/axi/axi_v1.yaml
  - common_patches/crc/crc_rename_init.yaml
  - ../peripherals/crc/crc_advanced.yaml

--- a/devices/stm32h735.yaml
+++ b/devices/stm32h735.yaml
@@ -210,7 +210,7 @@ _add:
           X1_BASE:
             description: Base address of X1 buffer
             bitOffset: 0
-            bitWidth: 8  
+            bitWidth: 8
       X2BUFCFG:
         description: X2 buffer configuration register
         addressOffset: 0x04
@@ -306,7 +306,7 @@ _add:
           RIEN:
             description: Enable read interrupt
             bitOffset: 0
-            bitWidth: 1  
+            bitWidth: 1
       SR:
         description: Status register
         addressOffset: 0x14
@@ -349,7 +349,7 @@ _add:
           RES:
             description: Read data (contents of the Y output buffer at the address indicated by the READ pointer)
             bitOffset: 0
-            bitWidth: 16  
+            bitWidth: 16
     interrupts:
       FMAC:
         value: 153
@@ -887,7 +887,7 @@ RAMECC1:
 #  _add:
 #    _interrupts:
 #      I2C5_EV:
-#        value: 157 
+#        value: 157
 #        description: I2C5 event interrupt
 #      I2C5_ER:
 #        value: 158

--- a/devices/stm32h743.yaml
+++ b/devices/stm32h743.yaml
@@ -54,7 +54,7 @@ _include:
  - common_patches/sai/sai_v1.yaml
  - common_patches/dfsdm/h743.yaml
  - common_patches/ramecc/ramecc_new.yaml
- - ../peripherals/adc/adc_v3_h7.yaml
+ - ../peripherals/adc/adc_v3_h7_123.yaml
  - ../peripherals/adc/adc_v3_common_h7.yaml
  - ../peripherals/adc/adc_h7_revision_y.yaml
  - ../peripherals/axi/axi_v1.yaml

--- a/devices/stm32h743v.yaml
+++ b/devices/stm32h743v.yaml
@@ -56,7 +56,7 @@ _include:
  - common_patches/sai/sai_v1.yaml
  - common_patches/dfsdm/h743.yaml
  - common_patches/ramecc/ramecc_new.yaml
- - ../peripherals/adc/adc_v3_h7.yaml
+ - ../peripherals/adc/adc_v3_h7_123.yaml
  - ../peripherals/adc/adc_v3_common_h7.yaml
  - ../peripherals/adc/adc_h7_revision_v.yaml
  - ../peripherals/axi/axi_v1.yaml

--- a/devices/stm32h747cm4.yaml
+++ b/devices/stm32h747cm4.yaml
@@ -60,7 +60,7 @@ _include:
  - common_patches/usart/rename_CR2_DATAINV_field.yaml
  - common_patches/usart/merge_BRR_fields.yaml
  - common_patches/ramecc/ramecc_new.yaml
- - ../peripherals/adc/adc_v3_h7.yaml
+ - ../peripherals/adc/adc_v3_h7_123.yaml
  - ../peripherals/adc/adc_v3_common_h7.yaml
  - ../peripherals/adc/adc_h7_revision_v.yaml
  - common_patches/crc/crc_rename_init.yaml

--- a/devices/stm32h747cm7.yaml
+++ b/devices/stm32h747cm7.yaml
@@ -60,7 +60,7 @@ _include:
  - common_patches/usart/rename_CR2_DATAINV_field.yaml
  - common_patches/usart/merge_BRR_fields.yaml
  - common_patches/ramecc/ramecc_new.yaml
- - ../peripherals/adc/adc_v3_h7.yaml
+ - ../peripherals/adc/adc_v3_h7_123.yaml
  - ../peripherals/adc/adc_v3_common_h7.yaml
  - ../peripherals/adc/adc_h7_revision_v.yaml
  - ../peripherals/axi/axi_v1.yaml

--- a/devices/stm32h753.yaml
+++ b/devices/stm32h753.yaml
@@ -65,7 +65,7 @@ _include:
  - common_patches/sai/sai_v1.yaml
  - common_patches/dfsdm/h735_747_753.yaml
  - common_patches/ramecc/ramecc_new.yaml
- - ../peripherals/adc/adc_v3_h7.yaml
+ - ../peripherals/adc/adc_v3_h7_123.yaml
  - ../peripherals/adc/adc_v3_common_h7.yaml
  - ../peripherals/adc/adc_h7_revision_y.yaml
  - ../peripherals/axi/axi_v1.yaml

--- a/devices/stm32h753v.yaml
+++ b/devices/stm32h753v.yaml
@@ -67,7 +67,7 @@ _include:
  - common_patches/sai/sai_v1.yaml
  - common_patches/dfsdm/h735_747_753.yaml
  - common_patches/ramecc/ramecc_new.yaml
- - ../peripherals/adc/adc_v3_h7.yaml
+ - ../peripherals/adc/adc_v3_h7_123.yaml
  - ../peripherals/adc/adc_v3_common_h7.yaml
  - ../peripherals/adc/adc_h7_revision_v.yaml
  - ../peripherals/axi/axi_v1.yaml

--- a/devices/stm32h7b3.yaml
+++ b/devices/stm32h7b3.yaml
@@ -113,7 +113,7 @@ _include:
  - common_patches/usart/merge_CR2_ADDx_fields.yaml
  - common_patches/usart/rename_CR2_DATAINV_field.yaml
  - common_patches/usart/merge_BRR_fields.yaml
- - ../peripherals/adc/adc_v3_h7.yaml
+ - ../peripherals/adc/adc_v3_h7_123.yaml
  - ../peripherals/adc/adc_v3_common_h7.yaml
  - ../peripherals/adc/adc_h7_revision_v.yaml
  - ../peripherals/axi/axi_v1.yaml

--- a/peripherals/adc/adc_h7_adc3.yaml
+++ b/peripherals/adc/adc_h7_adc3.yaml
@@ -1,0 +1,12 @@
+# ADC features specific to the reduced performance ADC3 on H7 RM0468 parts
+
+_include:
+  - "adc_v3_h7_reduced.yaml"
+
+"ADC3":
+  CFGR:
+    RES:
+      TwelveBit: [0, "12-bit resolution"]
+      TenBit: [1, "10-bit resolution"]
+      EightBit: [2, "8-bit resolution"]
+      SixBit: [3, "6-bit resolution"]

--- a/peripherals/adc/adc_h7_revision_v_12.yaml
+++ b/peripherals/adc/adc_h7_revision_v_12.yaml
@@ -1,0 +1,21 @@
+# ADC features specific to H7 Rev V. For ADC1 and ADC2 only
+
+"ADC,ADC1,ADC2":
+  CFGR:
+    _modify:
+      RES:
+        bitWidth: 3
+    RES:
+      SixteenBit: [0, "16-bit resolution"]
+      FourteenBit: [1, "14-bit resolution in legacy mode (not optimized power consumption)"]
+      TwelveBit: [2, "12-bit resolution in legacy mode (not optimized power consumption)"]
+      TenBit: [3, "10-bit resolution"]
+      FourteenBitV: [5, "14-bit resolution"]
+      TwelveBitV: [6, "12-bit resolution"]
+      EightBit: [7, "8-bit resolution"]
+  CR:
+    BOOST:
+      LT6_25: [0, "Boost mode used when ADC clock ≤ 6.25 MHz"]
+      LT12_5: [1, "Boost mode used when 6.25 MHz < ADC clock ≤ 12.5 MHz"]
+      LT25: [2, "Boost mode used when 12.5 MHz < ADC clock ≤ 25.0 MHz"]
+      LT50: [3, "Boost mode used when 25.0 MHz < ADC clock ≤ 50.0 MHz"]

--- a/peripherals/adc/adc_v3_h7.yaml
+++ b/peripherals/adc/adc_v3_h7.yaml
@@ -1,8 +1,5 @@
 # ADC v3 with H7 specific fields
 
-_include:
-  - "adc_v3.yaml"
-
 "ADC,ADC?":
   CR:
     ADVREGEN:
@@ -11,12 +8,6 @@ _include:
     DEEPPWD:
       PowerUp: [0, "ADC not in deep power down"]
       PowerDown: [1, "ADC in deep power down"]
-    "LINCALRDYW?":
-      Reset: [0, "LINCALFACT Word Read"]
-      Set: [1, "LINCALFACT Word Write"]
-    ADCALLIN:
-      NoLinearity: [0, "ADC calibration without linearaity calibration"]
-      Linearity: [1, "ADC calibration with linearaity calibration"]
   CFGR:
     EXTSEL:
       TIM4_CC4: [5, "Timer 4 CC4 event"]
@@ -31,44 +22,19 @@ _include:
     JQDIS:
       Enabled: [0, "Injected Queue enabled"]
       Disabled: [1, "Injected Queue disabled"]
-    DMNGT:
-      DR: [0, "Store output data in DR only"]
-      DMA_OneShot: [1, "DMA One Shot Mode selected"]
-      DFSDM: [2, "DFSDM mode selected"]
-      DMA_Circular: [3, "DMA Circular Mode selected"]
   CFGR2:
-    LSHIFT: [0, 15]
-    OSVR: [0, 1023]
-    "RSHIFT?":
-      Disabled: [0, "Right-shifting disabled"]
-      Enabled: [1, "Data is right-shifted 1-bit"]
     ROVSM:
       Continued: [0, "Oversampling is temporary stopped and continued after injection sequence"]
       Resumed: [1, "Oversampling is aborted and resumed from start after injection sequence"]
     TROVS:
       Automatic: [0, "All oversampled conversions for a channel are run following a trigger"]
       Triggered: [1, "Each oversampled conversion for a channel needs a new trigger"]
-    OVSS: [0, 11]
     JOVSE:
       Disabled: [0, "Injected oversampling disabled"]
       Enabled: [1, "Injected oversampling enabled"]
     ROVSE:
       Disabled: [0, "Regular oversampling disabled"]
       Enabled: [1, "Regular oversampling enabled"]
-  "SMPR?":
-    "SMP*":
-      Cycles1_5: [0, "1.5 ADC clock cycles"]
-      Cycles2_5: [1, "2.5 ADC clock cycles"]
-      Cycles8_5: [2, "8.5 ADC clock cycles"]
-      Cycles16_5: [3, "16.5 ADC clock cycles"]
-      Cycles32_5: [4, "32.5 ADC clock cycles"]
-      Cycles64_5: [5, "64.5 ADC clock cycles"]
-      Cycles387_5: [6, "387.5 ADC clock cycles"]
-      Cycles810_5: [7, "810.5 ADC clock cycles"]
-  "HTR?":
-    "HTR?": [0, 0x03FF_FFFF]
-  "LTR?":
-    "LTR?": [0, 0x03FF_FFFF]
   JSQR:
     JEXTSEL:
       TIM4_TRGO: [5, "Timer 4 TRGO event"]
@@ -80,17 +46,3 @@ _include:
       LPTIM1_OUT: [18, "LPTIM1_OUT event"]
       LPTIM2_OUT: [19, "LPTIM2_OUT event"]
       LPTIM3_OUT: [20, "LPTIM3_OUT event"]
-  "OFR?":
-    SSATE:
-      Disabled: [0, "Offset is subtracted maintaining data integrity and extending result size (9-bit and 17-bit signed format)"]
-      Enabled: [1, "Offset is subtracted and result is saturated to maintain result size"]
-    "OFFSET?_CH": [0, 31]
-    "OFFSET?": [0, 0x3FFFFFF]
-  PCSEL:
-    "PCSEL*":
-      NotPreselected: [0, "Input channel x is not pre-selected"]
-      Preselected: [1, "Pre-select input channel x"]
-  CALFACT:
-    CALFACT_?: [0, 2047]
-  CALFACT2:
-    LINCALFACT: [0, 0x3FFFFFFF]

--- a/peripherals/adc/adc_v3_h7_12.yaml
+++ b/peripherals/adc/adc_v3_h7_12.yaml
@@ -1,0 +1,9 @@
+# ADC v3 with H7 specific fields. For ADC1 and ADC2 only
+
+_include:
+  - "adc_v3.yaml"
+  - "adc_v3_h7.yaml"
+
+"ADC,ADC1,ADC2":
+  _include:
+    - "adc_v3_h7_full.yaml"

--- a/peripherals/adc/adc_v3_h7_123.yaml
+++ b/peripherals/adc/adc_v3_h7_123.yaml
@@ -1,0 +1,9 @@
+# ADC v3 with H7 specific fields. For all ADCs
+
+_include:
+  - "adc_v3.yaml"
+  - "adc_v3_h7.yaml"
+
+"ADC,ADC?":
+  _include:
+    - "adc_v3_h7_full.yaml"

--- a/peripherals/adc/adc_v3_h7_full.yaml
+++ b/peripherals/adc/adc_v3_h7_full.yaml
@@ -1,0 +1,50 @@
+# ADC v3 with H7 specific fields. For full ADCs (not RM0468 ADC3)
+
+CR:
+  "LINCALRDYW?":
+    Reset: [0, "LINCALFACT Word Read"]
+    Set: [1, "LINCALFACT Word Write"]
+  ADCALLIN:
+    NoLinearity: [0, "ADC calibration without linearaity calibration"]
+    Linearity: [1, "ADC calibration with linearaity calibration"]
+CFGR:
+  DMNGT:
+    DR: [0, "Store output data in DR only"]
+    DMA_OneShot: [1, "DMA One Shot Mode selected"]
+    DFSDM: [2, "DFSDM mode selected"]
+    DMA_Circular: [3, "DMA Circular Mode selected"]
+CFGR2:
+  LSHIFT: [0, 15]
+  OSVR: [0, 1023]
+  "RSHIFT?":
+    Disabled: [0, "Right-shifting disabled"]
+    Enabled: [1, "Data is right-shifted 1-bit"]
+  OVSS: [0, 11]
+"SMPR?":
+  "SMP*":
+    Cycles1_5: [0, "1.5 ADC clock cycles"]
+    Cycles2_5: [1, "2.5 ADC clock cycles"]
+    Cycles8_5: [2, "8.5 ADC clock cycles"]
+    Cycles16_5: [3, "16.5 ADC clock cycles"]
+    Cycles32_5: [4, "32.5 ADC clock cycles"]
+    Cycles64_5: [5, "64.5 ADC clock cycles"]
+    Cycles387_5: [6, "387.5 ADC clock cycles"]
+    Cycles810_5: [7, "810.5 ADC clock cycles"]
+"HTR?":
+  "HTR?": [0, 0x03FF_FFFF]
+"LTR?":
+  "LTR?": [0, 0x03FF_FFFF]
+"OFR?":
+  SSATE:
+    Disabled: [0, "Offset is subtracted maintaining data integrity and extending result size (9-bit and 17-bit signed format)"]
+    Enabled: [1, "Offset is subtracted and result is saturated to maintain result size"]
+  "OFFSET?_CH": [0, 31]
+  "OFFSET?": [0, 0x3FFFFFF]
+PCSEL:
+  "PCSEL*":
+    NotPreselected: [0, "Input channel x is not pre-selected"]
+    Preselected: [1, "Pre-select input channel x"]
+CALFACT:
+  CALFACT_?: [0, 2047]
+CALFACT2:
+  LINCALFACT: [0, 0x3FFFFFFF]

--- a/peripherals/adc/adc_v3_h7_reduced.yaml
+++ b/peripherals/adc/adc_v3_h7_reduced.yaml
@@ -1,0 +1,35 @@
+# ADC v3 with specific fields for reduced ADC3 found on H7 RM0468 parts
+
+"ADC3":
+  CFGR2:
+    OSVR:
+      Oversample2: [0, "Oversample 2x"]
+      Oversample4: [1, "Oversample 4x"]
+      Oversample8: [2, "Oversample 8x"]
+      Oversample16: [3, "Oversample 16x"]
+      Oversample32: [4, "Oversample 32x"]
+      Oversample64: [5, "Oversample 64x"]
+      Oversample128: [6, "Oversample 128x"]
+      Oversample256: [7, "Oversample 256x"]
+    OVSS: [0, 8]
+  "SMPR?":
+    "SMP?,SMP1?":
+      Cycles2_5: [0, "2.5 ADC clock cycles"]
+      Cycles6_5: [1, "6.5 ADC clock cycles"]
+      Cycles12_5: [2, "12.5 ADC clock cycles"]
+      Cycles24_5: [3, "24.5 ADC clock cycles"]
+      Cycles47_5: [4, "47.5 ADC clock cycles"]
+      Cycles92_5: [5, "92.5 ADC clock cycles"]
+      Cycles247_5: [6, "247.5 ADC clock cycles"]
+      Cycles640_5: [7, "640.5 ADC clock cycles"]
+  "TR?":
+    "HT?": [0, 0x0FFF]
+    "LT?": [0, 0x0FFF]
+  "OFR?":
+    SATEN:
+      Disabled: [0, "No saturation control, offset result can be signed"]
+      Enabled: [1, "Saturation enabled, offset result unsigned and saturated at 0x000 and 0xFFF"]
+    "OFFSET?_CH": [0, 31]
+    "OFFSET?": [0, 0x0FFF]
+  CALFACT:
+    CALFACT_?: [0, 127]


### PR DESCRIPTION
The ADC3 on RM0468 is a 12-bit ADC with somewhat reduced functionality, compared to the 16-bit ADCs found elsewhere in H7. Here we copy ADC3 from ADC1 (previously it was derived) and modify it to match RM0468 Rev 3 Section 29