### PR TITLE
add enum to stm32f411 adc1 smpr register

### DIFF
--- a/devices/stm32f401.yaml
+++ b/devices/stm32f401.yaml
@@ -128,9 +128,9 @@ _include:
  - ../peripherals/gpio/v2/common.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/crc/crc_idr_8bit.yaml
+ - ../peripherals/adc/adc_v2_smpr.yaml
  - ../peripherals/adc/adc_v2.yaml
  - ../peripherals/adc/adc_v2/adc_v2_extsel_b.yaml
- - ../peripherals/adc/adc_v2_smpr.yaml
  - common_patches/dma/dma_v2.yaml
  - ../peripherals/dma/dma_v2.yaml
  - ../peripherals/spi/spi_v1.yaml

--- a/devices/stm32f411.yaml
+++ b/devices/stm32f411.yaml
@@ -151,9 +151,9 @@ _include:
  - ../peripherals/gpio/v2/common.yaml
  - ../peripherals/crc/crc_basic.yaml
  - ../peripherals/crc/crc_idr_8bit.yaml
+ - ../peripherals/adc/adc_v2_smpr.yaml
  - ../peripherals/adc/adc_v2.yaml
  - ../peripherals/adc/adc_v2/adc_v2_extsel_b.yaml
- - ../peripherals/adc/adc_v2_smpr.yaml
  - common_patches/dma/dma_v2.yaml
  - ../peripherals/dma/dma_v2.yaml
  - ../peripherals/spi/spi_v1.yaml


### PR DESCRIPTION
Just changing the order of the fixes.
adc_v2_smpr.yml fix adds fields to the registers (original svd incorrectly had only one field).
adc_v2.yml adds enumeration to the smpr* fields in the adc1.smprX registers.
We need to first add fields  and then add enumeration to have enumerations on all fields. In the current order only one field has enumeration. When we change order all fields have enumerations.

This probably should be done on all other devices with the [adc fix](https://github.com/stm32-rs/stm32-rs/pull/460/commits/3f1e2e1879a8d16bb55c5c1197694f63f1da5c92).