### PR TITLE
Fixes missing CRSEN bit for L4x5 devices

### DIFF
--- a/devices/stm32l4x5.yaml
+++ b/devices/stm32l4x5.yaml
@@ -53,6 +53,11 @@ RCC:
         bitOffset: 10
         bitWidth: 1
         access: read-write
+      CRSEN:
+        description: Clock Recovery System clock enable (this bit is reserved for STM32L47x/L48x devices)
+        bitOffset: 24
+        bitWidth: 1
+        access: read-write
   APB1SMENR1:
     _add:
       RTCAPBSMEN:


### PR DESCRIPTION
For some reason https://github.com/stm32-rs/stm32-rs/issues/572 was not fixed.
This request adds the missing CRSEN bit to the L4x5 devices.