### PR TITLE
G0B1 patches for new SVD

### DIFF
--- a/devices/common_patches/dma/g0_add_dmamux_c7cr_c11cr.yaml
+++ b/devices/common_patches/dma/g0_add_dmamux_c7cr_c11cr.yaml
@@ -1,0 +1,437 @@
+DMAMUX:
+  _add:
+    C7CR:
+      displayName: C7CR
+      description: DMAMUX request line multiplexer channel 7 configuration register
+      addressOffset: 0x01C
+      size: 0x20
+      access: read-write
+      resetValue: 0x00000000
+      fields:
+        DMAREQ_ID:
+          description: DMA request identification Selects the input DMA request. See the DMAMUX table about assignments of multiplexer inputs to resources.
+          bitOffset: "0"
+          bitWidth: "6"
+          access: read-write
+        SOIE:
+          description: Synchronization overrun interrupt enable
+          bitOffset: "8"
+          bitWidth: "1"
+          access: read-write
+          enumeratedValues:
+            enumeratedValue:
+              B_0x0:
+                description: interrupt disabled
+                value: "0x0"
+              B_0x1:
+                description: interrupt enabled
+                value: "0x1"
+        EGE:
+          description: Event generation enable
+          bitOffset: "9"
+          bitWidth: "1"
+          access: read-write
+          enumeratedValues:
+            enumeratedValue:
+              B_0x0:
+                description: event generation disabled
+                value: "0x0"
+              B_0x1:
+                description: event generation enabled
+                value: "0x1"
+        SE:
+          description: Synchronization enable
+          bitOffset: "16"
+          bitWidth: "1"
+          access: read-write
+          enumeratedValues:
+            enumeratedValue:
+              B_0x0:
+                description: synchronization disabled
+                value: "0x0"
+              B_0x1:
+                description: synchronization enabled
+                value: "0x1"
+        SPOL:
+          description: Synchronization polarity Defines the edge polarity of the selected synchronization input
+          bitOffset: "17"
+          bitWidth: "2"
+          access: read-write
+          enumeratedValues:
+            enumeratedValue:
+              B_0x0:
+                description: "no event, i.e. no synchronization nor detection."
+                value: "0x0"
+              B_0x1:
+                description: rising edge
+                value: "0x1"
+              B_0x2:
+                description: falling edge
+                value: "0x2"
+              B_0x3:
+                description: rising and falling edge
+                value: "0x3"
+        NBREQ:
+          description:
+            Number of DMA requests minus 1 to forward Defines the number of DMA
+            requests to forward to the DMA controller after a synchronization event,
+            and/or the number of DMA requests before an output event is generated.
+            This field shall only be written when both SE and EGE bits are low.
+          bitOffset: "19"
+          bitWidth: "5"
+          access: read-write
+        SYNC_ID:
+          description:
+            Synchronization identification Selects the synchronization input (see
+            inputs to resources STM32G0).
+          bitOffset: "24"
+          bitWidth: "5"
+          access: read-write
+    C8CR:
+      displayName: C8CR
+      description: DMAMUX request line multiplexer channel 8 configuration register
+      addressOffset: 0x020
+      size: 0x20
+      access: read-write
+      resetValue: 0x00000000
+      fields:
+        DMAREQ_ID:
+          description: DMA request identification Selects the input DMA request. See the DMAMUX table about assignments of multiplexer inputs to resources.
+          bitOffset: "0"
+          bitWidth: "6"
+          access: read-write
+        SOIE:
+          description: Synchronization overrun interrupt enable
+          bitOffset: "8"
+          bitWidth: "1"
+          access: read-write
+          enumeratedValues:
+            enumeratedValue:
+              B_0x0:
+                description: interrupt disabled
+                value: "0x0"
+              B_0x1:
+                description: interrupt enabled
+                value: "0x1"
+        EGE:
+          description: Event generation enable
+          bitOffset: "9"
+          bitWidth: "1"
+          access: read-write
+          enumeratedValues:
+            enumeratedValue:
+              B_0x0:
+                description: event generation disabled
+                value: "0x0"
+              B_0x1:
+                description: event generation enabled
+                value: "0x1"
+        SE:
+          description: Synchronization enable
+          bitOffset: "16"
+          bitWidth: "1"
+          access: read-write
+          enumeratedValues:
+            enumeratedValue:
+              B_0x0:
+                description: synchronization disabled
+                value: "0x0"
+              B_0x1:
+                description: synchronization enabled
+                value: "0x1"
+        SPOL:
+          description: Synchronization polarity Defines the edge polarity of the selected synchronization input
+          bitOffset: "17"
+          bitWidth: "2"
+          access: read-write
+          enumeratedValues:
+            enumeratedValue:
+              B_0x0:
+                description: "no event, i.e. no synchronization nor detection."
+                value: "0x0"
+              B_0x1:
+                description: rising edge
+                value: "0x1"
+              B_0x2:
+                description: falling edge
+                value: "0x2"
+              B_0x3:
+                description: rising and falling edge
+                value: "0x3"
+        NBREQ:
+          description:
+            Number of DMA requests minus 1 to forward Defines the number of DMA
+            requests to forward to the DMA controller after a synchronization event,
+            and/or the number of DMA requests before an output event is generated.
+            This field shall only be written when both SE and EGE bits are low.
+          bitOffset: "19"
+          bitWidth: "5"
+          access: read-write
+        SYNC_ID:
+          description:
+            Synchronization identification Selects the synchronization input (see
+            inputs to resources STM32G0).
+          bitOffset: "24"
+          bitWidth: "5"
+          access: read-write
+    C9CR:
+      displayName: C9CR
+      description: DMAMUX request line multiplexer channel 9 configuration register
+      addressOffset: 0x024
+      size: 0x20
+      access: read-write
+      resetValue: 0x00000000
+      fields:
+        DMAREQ_ID:
+          description: DMA request identification Selects the input DMA request. See the DMAMUX table about assignments of multiplexer inputs to resources.
+          bitOffset: "0"
+          bitWidth: "6"
+          access: read-write
+        SOIE:
+          description: Synchronization overrun interrupt enable
+          bitOffset: "8"
+          bitWidth: "1"
+          access: read-write
+          enumeratedValues:
+            enumeratedValue:
+              B_0x0:
+                description: interrupt disabled
+                value: "0x0"
+              B_0x1:
+                description: interrupt enabled
+                value: "0x1"
+        EGE:
+          description: Event generation enable
+          bitOffset: "9"
+          bitWidth: "1"
+          access: read-write
+          enumeratedValues:
+            enumeratedValue:
+              B_0x0:
+                description: event generation disabled
+                value: "0x0"
+              B_0x1:
+                description: event generation enabled
+                value: "0x1"
+        SE:
+          description: Synchronization enable
+          bitOffset: "16"
+          bitWidth: "1"
+          access: read-write
+          enumeratedValues:
+            enumeratedValue:
+              B_0x0:
+                description: synchronization disabled
+                value: "0x0"
+              B_0x1:
+                description: synchronization enabled
+                value: "0x1"
+        SPOL:
+          description: Synchronization polarity Defines the edge polarity of the selected synchronization input
+          bitOffset: "17"
+          bitWidth: "2"
+          access: read-write
+          enumeratedValues:
+            enumeratedValue:
+              B_0x0:
+                description: "no event, i.e. no synchronization nor detection."
+                value: "0x0"
+              B_0x1:
+                description: rising edge
+                value: "0x1"
+              B_0x2:
+                description: falling edge
+                value: "0x2"
+              B_0x3:
+                description: rising and falling edge
+                value: "0x3"
+        NBREQ:
+          description:
+            Number of DMA requests minus 1 to forward Defines the number of DMA
+            requests to forward to the DMA controller after a synchronization event,
+            and/or the number of DMA requests before an output event is generated.
+            This field shall only be written when both SE and EGE bits are low.
+          bitOffset: "19"
+          bitWidth: "5"
+          access: read-write
+        SYNC_ID:
+          description:
+            Synchronization identification Selects the synchronization input (see
+            inputs to resources STM32G0).
+          bitOffset: "24"
+          bitWidth: "5"
+          access: read-write
+    C10CR:
+      displayName: C10CR
+      description: DMAMUX request line multiplexer channel 10 configuration register
+      addressOffset: 0x028
+      size: 0x20
+      access: read-write
+      resetValue: 0x00000000
+      fields:
+        DMAREQ_ID:
+          description: DMA request identification Selects the input DMA request. See the DMAMUX table about assignments of multiplexer inputs to resources.
+          bitOffset: "0"
+          bitWidth: "6"
+          access: read-write
+        SOIE:
+          description: Synchronization overrun interrupt enable
+          bitOffset: "8"
+          bitWidth: "1"
+          access: read-write
+          enumeratedValues:
+            enumeratedValue:
+              B_0x0:
+                description: interrupt disabled
+                value: "0x0"
+              B_0x1:
+                description: interrupt enabled
+                value: "0x1"
+        EGE:
+          description: Event generation enable
+          bitOffset: "9"
+          bitWidth: "1"
+          access: read-write
+          enumeratedValues:
+            enumeratedValue:
+              B_0x0:
+                description: event generation disabled
+                value: "0x0"
+              B_0x1:
+                description: event generation enabled
+                value: "0x1"
+        SE:
+          description: Synchronization enable
+          bitOffset: "16"
+          bitWidth: "1"
+          access: read-write
+          enumeratedValues:
+            enumeratedValue:
+              B_0x0:
+                description: synchronization disabled
+                value: "0x0"
+              B_0x1:
+                description: synchronization enabled
+                value: "0x1"
+        SPOL:
+          description: Synchronization polarity Defines the edge polarity of the selected synchronization input
+          bitOffset: "17"
+          bitWidth: "2"
+          access: read-write
+          enumeratedValues:
+            enumeratedValue:
+              B_0x0:
+                description: "no event, i.e. no synchronization nor detection."
+                value: "0x0"
+              B_0x1:
+                description: rising edge
+                value: "0x1"
+              B_0x2:
+                description: falling edge
+                value: "0x2"
+              B_0x3:
+                description: rising and falling edge
+                value: "0x3"
+        NBREQ:
+          description:
+            Number of DMA requests minus 1 to forward Defines the number of DMA
+            requests to forward to the DMA controller after a synchronization event,
+            and/or the number of DMA requests before an output event is generated.
+            This field shall only be written when both SE and EGE bits are low.
+          bitOffset: "19"
+          bitWidth: "5"
+          access: read-write
+        SYNC_ID:
+          description:
+            Synchronization identification Selects the synchronization input (see
+            inputs to resources STM32G0).
+          bitOffset: "24"
+          bitWidth: "5"
+          access: read-write
+    C11CR:
+      displayName: C11CR
+      description: DMAMUX request line multiplexer channel 11 configuration register
+      addressOffset: 0x02C
+      size: 0x20
+      access: read-write
+      resetValue: 0x00000000
+      fields:
+        DMAREQ_ID:
+          description: DMA request identification Selects the input DMA request. See the DMAMUX table about assignments of multiplexer inputs to resources.
+          bitOffset: "0"
+          bitWidth: "6"
+          access: read-write
+        SOIE:
+          description: Synchronization overrun interrupt enable
+          bitOffset: "8"
+          bitWidth: "1"
+          access: read-write
+          enumeratedValues:
+            enumeratedValue:
+              B_0x0:
+                description: interrupt disabled
+                value: "0x0"
+              B_0x1:
+                description: interrupt enabled
+                value: "0x1"
+        EGE:
+          description: Event generation enable
+          bitOffset: "9"
+          bitWidth: "1"
+          access: read-write
+          enumeratedValues:
+            enumeratedValue:
+              B_0x0:
+                description: event generation disabled
+                value: "0x0"
+              B_0x1:
+                description: event generation enabled
+                value: "0x1"
+        SE:
+          description: Synchronization enable
+          bitOffset: "16"
+          bitWidth: "1"
+          access: read-write
+          enumeratedValues:
+            enumeratedValue:
+              B_0x0:
+                description: synchronization disabled
+                value: "0x0"
+              B_0x1:
+                description: synchronization enabled
+                value: "0x1"
+        SPOL:
+          description: Synchronization polarity Defines the edge polarity of the selected synchronization input
+          bitOffset: "17"
+          bitWidth: "2"
+          access: read-write
+          enumeratedValues:
+            enumeratedValue:
+              B_0x0:
+                description: "no event, i.e. no synchronization nor detection."
+                value: "0x0"
+              B_0x1:
+                description: rising edge
+                value: "0x1"
+              B_0x2:
+                description: falling edge
+                value: "0x2"
+              B_0x3:
+                description: rising and falling edge
+                value: "0x3"
+        NBREQ:
+          description:
+            Number of DMA requests minus 1 to forward Defines the number of DMA
+            requests to forward to the DMA controller after a synchronization event,
+            and/or the number of DMA requests before an output event is generated.
+            This field shall only be written when both SE and EGE bits are low.
+          bitOffset: "19"
+          bitWidth: "5"
+          access: read-write
+        SYNC_ID:
+          description:
+            Synchronization identification Selects the synchronization input (see
+            inputs to resources STM32G0).
+          bitOffset: "24"
+          bitWidth: "5"
+          access: read-write

--- a/devices/common_patches/usart/g0.yaml
+++ b/devices/common_patches/usart/g0.yaml
@@ -1,4 +1,3 @@
-
 "USART?":
   CR2:
     _delete:

--- a/devices/stm32g0b1.yaml
+++ b/devices/stm32g0b1.yaml
@@ -125,6 +125,7 @@ RCC:
 
 _include:
   - ./common_patches/nvic/2_prio_bits.yaml
+  - ../peripherals/exti/exti_g0.yaml
   - ../peripherals/dma/dma_v1.yaml
   - ./common_patches/dma/g0_add_dma1_7ch.yaml
   - ./common_patches/dma/g0_add_dma2_5ch.yaml

--- a/devices/stm32g0b1.yaml
+++ b/devices/stm32g0b1.yaml
@@ -13,6 +13,11 @@ TIM1:
   _strip:
     - "TIM1_"
 
+# Disabled to have TIM2 have a 32 bit cnt always
+TIM2:
+  _delete:
+    - "CNT_ALTERNATE5"
+
 "TIM1,TIM2,TIM15,TIM16":
   CCMR1_Output:
     _modify:
@@ -144,7 +149,7 @@ _include:
   - common_patches/tim/common.yaml
   - ../peripherals/tim/tim_basic.yaml
   - ../peripherals/tim/tim6.yaml
-  - ../peripherals/tim/tim_advanced.yaml
+  - ./common_patches/tim/tim2_32bit.yaml
   - ./common_patches/flash/g0.yaml
   - common_patches/rtc/alarm.yaml
   - common_patches/rtc/tamp_bkpr.yaml

--- a/devices/stm32g0b1.yaml
+++ b/devices/stm32g0b1.yaml
@@ -47,6 +47,18 @@ TIM1:
       OC6M_bit3:
         name: OC6M_3
 
+TIM15:
+  CCMR1_Output:
+    _modify:
+      OC1M1:
+        name: OC1M
+      OC1M2:
+        name: OC1M_3
+      OC2M1:
+        name: OC2M
+      OC2M2:
+        name: OC2M_3
+
 DMAMUX:
   _strip:
     - "DMAMUX_"
@@ -54,6 +66,10 @@ DMAMUX:
 DAC:
   _strip:
     - "DAC_"
+
+I2C1:
+  _strip:
+    - "I2C_"
 
 ADC:
   _strip:
@@ -79,9 +95,7 @@ _include:
   - ../peripherals/dma/dma_v1.yaml
   - ./common_patches/dma/g0_add_dma1_7ch.yaml
   - ./common_patches/dma/g0_add_dma2_5ch.yaml
-  - ../peripherals/tim/v2/ccm.yaml
   - ../peripherals/gpio/gpio_g0_l0.yaml
-  - common_patches/i2c/g0.yaml
   - ../peripherals/i2c/i2c_v2.yaml
   - ./common_patches/spi/g0_rename_registers.yaml
   - ../peripherals/spi/spi_v2_without_UDR_CHSIDE.yaml

--- a/devices/stm32g0b1.yaml
+++ b/devices/stm32g0b1.yaml
@@ -129,6 +129,7 @@ _include:
   - ../peripherals/dma/dma_v1.yaml
   - ./common_patches/dma/g0_add_dma1_7ch.yaml
   - ./common_patches/dma/g0_add_dma2_5ch.yaml
+  - ./common_patches/dma/g0_add_dmamux_c7cr_c11cr.yaml
   - common_patches/tim/v2/g0_1.yaml
   - ../peripherals/usb/g0_enum.yaml
   - ../peripherals/tim/v2/ccm.yaml

--- a/devices/stm32g0b1.yaml
+++ b/devices/stm32g0b1.yaml
@@ -67,9 +67,13 @@ DAC:
   _strip:
     - "DAC_"
 
-I2C1:
+I2C*:
   _strip:
     - "I2C_"
+
+SPI*:
+  _strip:
+    - "SPI_"
 
 ADC:
   _strip:
@@ -99,7 +103,6 @@ _include:
   - ../peripherals/i2c/i2c_v2.yaml
   - ./common_patches/spi/g0_rename_registers.yaml
   - ../peripherals/spi/spi_v2_without_UDR_CHSIDE.yaml
-  - common_patches/usart/g0.yaml
   - ../peripherals/usart/usart_v2C.yaml
   - ../peripherals/usart/usart_wl.yaml
   - ../peripherals/iwdg/iwdg_with_WINR.yaml

--- a/devices/stm32g0b1.yaml
+++ b/devices/stm32g0b1.yaml
@@ -10,24 +10,6 @@ _delete:
   - DMA1
   - DMA2
 
-RCC:
-  AHBRSTR:
-    _delete:
-      - AESRST
-      - RNGRST
-  AHBENR:
-    _delete:
-      - AESEN
-      - RNGEN
-  AHBSMENR:
-    _delete:
-      - AESSMEN
-      - RNGSMEN
-  CCIPR:
-    _delete:
-      - RNGSEL
-      - RNGDIV
-
 EXTI:
   _delete:
     - VERR
@@ -35,6 +17,8 @@ EXTI:
     - SIDR
 
 TIM1:
+  _strip:
+    - "TIM1_"
   _modify:
     _interrupts:
       TIM1_BRK_UP_TRG_COMP:
@@ -47,18 +31,6 @@ TIM1:
       OC6M_bit3:
         name: OC6M_3
 
-TIM15:
-  CCMR1_Output:
-    _modify:
-      OC1M1:
-        name: OC1M
-      OC1M2:
-        name: OC1M_3
-      OC2M1:
-        name: OC2M
-      OC2M2:
-        name: OC2M_3
-
 DMAMUX:
   _strip:
     - "DMAMUX_"
@@ -67,13 +39,27 @@ DAC:
   _strip:
     - "DAC_"
 
+IWDG:
+  _strip:
+    - "IWDG_"
+
 I2C*:
   _strip:
     - "I2C_"
+WWDG:
+  _strip:
+    - "WWDG_"
 
 SPI*:
   _strip:
     - "SPI_"
+
+RTC:
+  _strip:
+    - "RTC_"
+TAMP:
+  _strip:
+    - "TAMP_"
 
 ADC:
   _strip:
@@ -103,15 +89,13 @@ _include:
   - ../peripherals/i2c/i2c_v2.yaml
   - ./common_patches/spi/g0_rename_registers.yaml
   - ../peripherals/spi/spi_v2_without_UDR_CHSIDE.yaml
-  - ../peripherals/usart/usart_v2C.yaml
-  - ../peripherals/usart/usart_wl.yaml
   - ../peripherals/iwdg/iwdg_with_WINR.yaml
   - ../peripherals/wwdg/wwdg_v2.yaml
   - ../peripherals/adc/adc_wl.yaml
-  - common_patches/tim/common.yaml
+  - ./common_patches/tim/common.yaml
   - ../peripherals/tim/tim_basic.yaml
   - ../peripherals/tim/tim6.yaml
   - ../peripherals/tim/tim_advanced.yaml
   - ./common_patches/flash/g0.yaml
-  - common_patches/rtc/alarm.yaml
-  - common_patches/rtc/tamp_bkpr.yaml
+  - ./common_patches/rtc/alarm.yaml
+  - ./common_patches/rtc/tamp_bkpr.yaml

--- a/devices/stm32g0b1.yaml
+++ b/devices/stm32g0b1.yaml
@@ -6,30 +6,24 @@ _modify:
 _clear_fields: ["*"]
 
 _delete:
-  - RNG
   - DMA1
   - DMA2
-
-EXTI:
-  _delete:
-    - VERR
-    - IPIDR
-    - SIDR
 
 TIM1:
   _strip:
     - "TIM1_"
-  _modify:
-    _interrupts:
-      TIM1_BRK_UP_TRG_COMP:
-        name: TIM1_BRK_UP_TRG_COM
-        description: TIM1 break, update, trigger and commutation interrupts
-  CCMR3_Output:
+
+"TIM1,TIM2,TIM15,TIM16":
+  CCMR1_Output:
     _modify:
-      OC5M_bit3:
-        name: OC5M_3
-      OC6M_bit3:
-        name: OC6M_3
+      OC1M1:
+        name: OC1M
+      OC1M2:
+        name: OC1M_3
+      OC2M1:
+        name: OC2M
+      OC2M2:
+        name: OC2M_3
 
 DMAMUX:
   _strip:
@@ -60,6 +54,9 @@ RTC:
 TAMP:
   _strip:
     - "TAMP_"
+USB:
+  _strip:
+    - "USB_"
 
 ADC:
   _strip:
@@ -78,24 +75,73 @@ ADC:
       regularDATA:
         name: DATA
 
+CRC:
+  _strip:
+    - "CRC_"
+
+DBG:
+  _strip:
+    - "DBG_"
+
+VREFBUF:
+  _strip:
+    - "VREFBUF_"
+
+"FDCAN?":
+  _strip:
+    - FDCAN_
+
+LPTIM*:
+  _strip:
+    - "LPTIM_"
+
+LPUART*:
+  _strip:
+    - "LPUART_"
+
+UCPD*:
+  _strip:
+    - "UCPD_"
+
+SPI1:
+  _modify:
+    "*":
+      size: 32
+
+RCC:
+  _modify:
+    PLLCFGR:
+      name: PLLSYSCFGR
+
+# Enabling FIFO by default for CR1 and ISR
+"USART?":
+  _delete:
+    - CR1_FIFO_DISABLED
+  _modify:
+    CR1_FIFO_ENABLED:
+      name: CR1
+    ISR_FIFO_ENABLED:
+      name: ISR
+
 _include:
   - ./common_patches/nvic/2_prio_bits.yaml
-  - ../peripherals/exti/exti_g0.yaml
-  - ./common_patches/adc/g0_typo.yaml
   - ../peripherals/dma/dma_v1.yaml
   - ./common_patches/dma/g0_add_dma1_7ch.yaml
   - ./common_patches/dma/g0_add_dma2_5ch.yaml
+  - common_patches/tim/v2/g0_1.yaml
+  - ../peripherals/usb/g0_enum.yaml
+  - ../peripherals/tim/v2/ccm.yaml
   - ../peripherals/gpio/gpio_g0_l0.yaml
   - ../peripherals/i2c/i2c_v2.yaml
-  - ./common_patches/spi/g0_rename_registers.yaml
   - ../peripherals/spi/spi_v2_without_UDR_CHSIDE.yaml
+  - ../peripherals/spi/spi_I2S_ASTRTEN.yaml
   - ../peripherals/iwdg/iwdg_with_WINR.yaml
   - ../peripherals/wwdg/wwdg_v2.yaml
   - ../peripherals/adc/adc_wl.yaml
-  - ./common_patches/tim/common.yaml
+  - common_patches/tim/common.yaml
   - ../peripherals/tim/tim_basic.yaml
   - ../peripherals/tim/tim6.yaml
   - ../peripherals/tim/tim_advanced.yaml
   - ./common_patches/flash/g0.yaml
-  - ./common_patches/rtc/alarm.yaml
-  - ./common_patches/rtc/tamp_bkpr.yaml
+  - common_patches/rtc/alarm.yaml
+  - common_patches/rtc/tamp_bkpr.yaml

--- a/devices/stm32g0b1.yaml
+++ b/devices/stm32g0b1.yaml
@@ -113,14 +113,15 @@ RCC:
     PLLCFGR:
       name: PLLSYSCFGR
 
-# Enabling FIFO by default for CR1 and ISR
+# Disabling FIFO by default for CR1 and ISR
 "USART?":
   _delete:
-    - CR1_FIFO_DISABLED
+    - CR1_FIFO_ENABLED
+    - ISR_FIFO_ENABLED
   _modify:
-    CR1_FIFO_ENABLED:
+    CR1_FIFO_DISABLED:
       name: CR1
-    ISR_FIFO_ENABLED:
+    ISR_FIFO_DISABLED:
       name: ISR
 
 _include:

--- a/devices/stm32g0b1.yaml
+++ b/devices/stm32g0b1.yaml
@@ -6,22 +6,46 @@ _modify:
 _clear_fields: ["*"]
 
 _delete:
+  - RNG
   - DMA1
   - DMA2
+
+RCC:
+  AHBRSTR:
+    _delete:
+      - AESRST
+      - RNGRST
+  AHBENR:
+    _delete:
+      - AESEN
+      - RNGEN
+  AHBSMENR:
+    _delete:
+      - AESSMEN
+      - RNGSMEN
+  CCIPR:
+    _delete:
+      - RNGSEL
+      - RNGDIV
+
+EXTI:
+  _delete:
+    - VERR
+    - IPIDR
+    - SIDR
 
 TIM1:
   _modify:
     _interrupts:
-      TIM1_BRK_UP_TRG_COM:
+      TIM1_BRK_UP_TRG_COMP:
+        name: TIM1_BRK_UP_TRG_COM
         description: TIM1 break, update, trigger and commutation interrupts
-  _strip:
-    - "TIM1_"
-
-"TIM1,TIM2":
-  CCMR1_Output:
+  CCMR3_Output:
     _modify:
-      OC1M1:
-        name: OC1M
+      OC5M_bit3:
+        name: OC5M_3
+      OC6M_bit3:
+        name: OC6M_3
 
 DMAMUX:
   _strip:
@@ -31,30 +55,6 @@ DAC:
   _strip:
     - "DAC_"
 
-CRC:
-  _strip:
-    - "CRC_"
-
-DBG:
-  _strip:
-    - "DBG_"
-
-IWDG:
-  _strip:
-    - "IWDG_"
-
-WWDG:
-  _strip:
-    - "WWDG_"
-
-VREFBUF:
-  _strip:
-    - "VREFBUF_"
-
-USB:
-  _strip:
-    - "USB_"
-
 ADC:
   _strip:
     - "ADC_"
@@ -63,65 +63,38 @@ ADC:
       name: CHSELR0
     CHSELR_1:
       name: CHSELR1
-
-"FDCAN?":
-  _strip:
-    - FDCAN_
-
-I2C*:
-  _strip:
-    - "I2C_"
-
-LPTIM*:
-  _strip:
-    - "LPTIM_"
-
-LPUART*:
-  _strip:
-    - "LPUART_"
-
-RTC:
-  _strip:
-    - "RTC_"
-
-SPI*:
-  _strip:
-    - "SPI_"
-
-TAMP:
-  _strip:
-    - "TAMP_"
-
-UCPD*:
-  _strip:
-    - "UCPD_"
-
-SPI1:
-  _modify:
-    "*":
-      size: 32
+  CFGR1:
+    _modify:
+      AWDCH1CH:
+        name: AWD1CH
+  DR:
+    _modify:
+      regularDATA:
+        name: DATA
 
 _include:
- - ./common_patches/nvic/2_prio_bits.yaml
- - ../peripherals/dma/dma_v1.yaml
- - ./common_patches/dma/g0_add_dma1_7ch.yaml
- - ./common_patches/dma/g0_add_dma2_5ch.yaml
- - common_patches/tim/v2/g0_1.yaml
- - ../peripherals/usb/g0_enum.yaml
- - ../peripherals/exti/exti_g0.yaml
- - ../peripherals/tim/v2/ccm.yaml
- - ../peripherals/gpio/gpio_g0_l0.yaml
- - ../peripherals/i2c/i2c_v2.yaml
- - ../peripherals/spi/spi_v2_without_UDR_CHSIDE.yaml
- - ../peripherals/spi/spi_I2S_ASTRTEN.yaml
-# TODO: usart CR1
- - ../peripherals/iwdg/iwdg_with_WINR.yaml
- - ../peripherals/wwdg/wwdg_v2.yaml
- - ../peripherals/adc/adc_wl.yaml
- - common_patches/tim/common.yaml
- - ../peripherals/tim/tim_basic.yaml
- - ../peripherals/tim/tim6.yaml
- - ../peripherals/tim/tim_advanced.yaml
- - ./common_patches/flash/g0.yaml
- - common_patches/rtc/alarm.yaml
- - common_patches/rtc/tamp_bkpr.yaml
+  - ./common_patches/nvic/2_prio_bits.yaml
+  - ../peripherals/exti/exti_g0.yaml
+  - ./common_patches/adc/g0_typo.yaml
+  - ../peripherals/dma/dma_v1.yaml
+  - ./common_patches/dma/g0_add_dma1_7ch.yaml
+  - ./common_patches/dma/g0_add_dma2_5ch.yaml
+  - ../peripherals/tim/v2/ccm.yaml
+  - ../peripherals/gpio/gpio_g0_l0.yaml
+  - common_patches/i2c/g0.yaml
+  - ../peripherals/i2c/i2c_v2.yaml
+  - ./common_patches/spi/g0_rename_registers.yaml
+  - ../peripherals/spi/spi_v2_without_UDR_CHSIDE.yaml
+  - common_patches/usart/g0.yaml
+  - ../peripherals/usart/usart_v2C.yaml
+  - ../peripherals/usart/usart_wl.yaml
+  - ../peripherals/iwdg/iwdg_with_WINR.yaml
+  - ../peripherals/wwdg/wwdg_v2.yaml
+  - ../peripherals/adc/adc_wl.yaml
+  - common_patches/tim/common.yaml
+  - ../peripherals/tim/tim_basic.yaml
+  - ../peripherals/tim/tim6.yaml
+  - ../peripherals/tim/tim_advanced.yaml
+  - ./common_patches/flash/g0.yaml
+  - common_patches/rtc/alarm.yaml
+  - common_patches/rtc/tamp_bkpr.yaml


### PR DESCRIPTION
I tried adding new patches for the g0b1 board with the updated SVD now. 

- Added USART CR1
- Removed EXTI for now since the SVD still doesnt mention it
- Applied some timer patches
- Renamed PLLCFGR register so it fits with the rest of the G0 family

Pointers appreciated, I am new to embedded