### PR TITLE
ci: fix node 12 deprecation warnings

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,11 +47,8 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          profile: minimal
-          override: true
           components: rustfmt
 
       - name: Install xmllint

--- a/.github/workflows/nightlies.yaml
+++ b/.github/workflows/nightlies.yaml
@@ -20,12 +20,9 @@ jobs:
           path: stm32-rs
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          profile: minimal
           components: rustfmt
-          override: true
 
       - name: Add fictive crate
         run: |


### PR DESCRIPTION
`actions-rs` appears to be unmaintained: https://github.com/actions-rs/toolchain/issues/216