### PR TITLE
Fix `PTPPPSCR` on `stm32f4` and `stm32f7`, add variants for `PTPPPSCR:PPSFREQ` on `stm32f2`, `stm32f4`, `stm32f7`

### DIFF
--- a/devices/common_patches/ethernet/f4_f7.yaml
+++ b/devices/common_patches/ethernet/f4_f7.yaml
@@ -1,0 +1,9 @@
+Ethernet_PTP:
+  PTPPPSCR:
+    _add:
+      PPSFREQ:
+        bitWidth: 4
+        bitOffset: 0
+        access: read-write
+        description: PPS frequency selection
+    _delete: ["TSSO", "TSTTR"]

--- a/devices/stm32f217.yaml
+++ b/devices/stm32f217.yaml
@@ -94,3 +94,4 @@ _include:
  - common_patches/rtc/rtc_cr.yaml
  - common_patches/dbgmcu/dbgmcu.yaml
  - common_patches/adc/adc_common_group_name.yaml
+ - ../peripherals/eth/eth_ptp_ppsfreq.yaml

--- a/devices/stm32f405.yaml
+++ b/devices/stm32f405.yaml
@@ -140,5 +140,3 @@ _include:
  - common_patches/rtc/rtc_cr.yaml
  - ../peripherals/rtc/rtc_common.yaml
  - common_patches/adc/adc_common_group_name.yaml
- - common_patches/ethernet/f4_f7.yaml
- - ../peripherals/eth/eth_ptp_ppsfreq.yaml

--- a/devices/stm32f405.yaml
+++ b/devices/stm32f405.yaml
@@ -140,3 +140,4 @@ _include:
  - common_patches/rtc/rtc_cr.yaml
  - ../peripherals/rtc/rtc_common.yaml
  - common_patches/adc/adc_common_group_name.yaml
+ - common_patches/ethernet/f4_f7.yaml

--- a/devices/stm32f405.yaml
+++ b/devices/stm32f405.yaml
@@ -141,3 +141,4 @@ _include:
  - ../peripherals/rtc/rtc_common.yaml
  - common_patches/adc/adc_common_group_name.yaml
  - common_patches/ethernet/f4_f7.yaml
+ - ../peripherals/eth/eth_ptp_ppsfreq.yaml

--- a/devices/stm32f407.yaml
+++ b/devices/stm32f407.yaml
@@ -144,3 +144,4 @@ _include:
  - ../peripherals/rtc/rtc_common.yaml
  - ../peripherals/sdio/sdio_f4.yaml
  - common_patches/adc/adc_common_group_name.yaml
+ - common_patches/ethernet/f4_f7.yaml

--- a/devices/stm32f407.yaml
+++ b/devices/stm32f407.yaml
@@ -145,3 +145,4 @@ _include:
  - ../peripherals/sdio/sdio_f4.yaml
  - common_patches/adc/adc_common_group_name.yaml
  - common_patches/ethernet/f4_f7.yaml
+ - ../peripherals/eth/eth_ptp_ppsfreq.yaml

--- a/devices/stm32f427.yaml
+++ b/devices/stm32f427.yaml
@@ -264,3 +264,4 @@ _include:
  - ../peripherals/sdio/sdio_f4.yaml
  - ../peripherals/i2c/i2c_v1_fltr.yaml
  - common_patches/adc/adc_common_group_name.yaml
+ - common_patches/ethernet/f4_f7.yaml

--- a/devices/stm32f427.yaml
+++ b/devices/stm32f427.yaml
@@ -265,3 +265,4 @@ _include:
  - ../peripherals/i2c/i2c_v1_fltr.yaml
  - common_patches/adc/adc_common_group_name.yaml
  - common_patches/ethernet/f4_f7.yaml
+ - ../peripherals/eth/eth_ptp_ppsfreq.yaml

--- a/devices/stm32f429.yaml
+++ b/devices/stm32f429.yaml
@@ -223,3 +223,4 @@ _include:
  - ../peripherals/i2c/i2c_v1_fltr.yaml
  - common_patches/adc/adc_common_group_name.yaml
  - common_patches/ethernet/f4_f7.yaml
+ - ../peripherals/eth/eth_ptp_ppsfreq.yaml

--- a/devices/stm32f429.yaml
+++ b/devices/stm32f429.yaml
@@ -222,3 +222,4 @@ _include:
  - ../peripherals/sdio/sdio_f4.yaml
  - ../peripherals/i2c/i2c_v1_fltr.yaml
  - common_patches/adc/adc_common_group_name.yaml
+ - common_patches/ethernet/f4_f7.yaml

--- a/devices/stm32f469.yaml
+++ b/devices/stm32f469.yaml
@@ -201,3 +201,4 @@ _include:
  - ../peripherals/sdio/sdio_f4.yaml
  - ../peripherals/i2c/i2c_v1_fltr.yaml
  - common_patches/adc/adc_common_group_name.yaml
+ - common_patches/ethernet/f4_f7.yaml

--- a/devices/stm32f469.yaml
+++ b/devices/stm32f469.yaml
@@ -202,3 +202,4 @@ _include:
  - ../peripherals/i2c/i2c_v1_fltr.yaml
  - common_patches/adc/adc_common_group_name.yaml
  - common_patches/ethernet/f4_f7.yaml
+ - ../peripherals/eth/eth_ptp_ppsfreq.yaml

--- a/devices/stm32f745.yaml
+++ b/devices/stm32f745.yaml
@@ -195,3 +195,4 @@ _include:
  - common_patches/rtc/rtc_cr.yaml
  - ../peripherals/rtc/rtc_common.yaml
  - common_patches/adc/adc_common_group_name.yaml
+ - common_patches/ethernet/f4_f7.yaml

--- a/devices/stm32f745.yaml
+++ b/devices/stm32f745.yaml
@@ -196,3 +196,4 @@ _include:
  - ../peripherals/rtc/rtc_common.yaml
  - common_patches/adc/adc_common_group_name.yaml
  - common_patches/ethernet/f4_f7.yaml
+ - ../peripherals/eth/eth_ptp_ppsfreq.yaml

--- a/devices/stm32f750.yaml
+++ b/devices/stm32f750.yaml
@@ -121,3 +121,4 @@ _include:
  - common_patches/ltdc/f4_f7_ltdc_bccr.yaml
  - ../peripherals/ltdc/ltdc.yaml
  - common_patches/adc/adc_common_group_name.yaml
+ - common_patches/ethernet/f4_f7.yaml

--- a/devices/stm32f750.yaml
+++ b/devices/stm32f750.yaml
@@ -122,3 +122,4 @@ _include:
  - ../peripherals/ltdc/ltdc.yaml
  - common_patches/adc/adc_common_group_name.yaml
  - common_patches/ethernet/f4_f7.yaml
+ - ../peripherals/eth/eth_ptp_ppsfreq.yaml

--- a/devices/stm32f765.yaml
+++ b/devices/stm32f765.yaml
@@ -218,3 +218,4 @@ _include:
  - common_patches/rtc/rtc_cr.yaml
  - ../peripherals/rtc/rtc_common.yaml
  - common_patches/adc/adc_common_group_name.yaml
+ - common_patches/ethernet/f4_f7.yaml

--- a/devices/stm32f765.yaml
+++ b/devices/stm32f765.yaml
@@ -219,3 +219,4 @@ _include:
  - ../peripherals/rtc/rtc_common.yaml
  - common_patches/adc/adc_common_group_name.yaml
  - common_patches/ethernet/f4_f7.yaml
+ - ../peripherals/eth/eth_ptp_ppsfreq.yaml

--- a/devices/stm32f7x7.yaml
+++ b/devices/stm32f7x7.yaml
@@ -351,3 +351,4 @@ _include:
  - ../peripherals/dma/dma2d_v1.yaml
  - common_patches/rtc/rtc_cr.yaml
  - ../peripherals/rtc/rtc_common.yaml
+ - common_patches/ethernet/f4_f7.yaml

--- a/devices/stm32f7x7.yaml
+++ b/devices/stm32f7x7.yaml
@@ -352,3 +352,4 @@ _include:
  - common_patches/rtc/rtc_cr.yaml
  - ../peripherals/rtc/rtc_common.yaml
  - common_patches/ethernet/f4_f7.yaml
+ - ../peripherals/eth/eth_ptp_ppsfreq.yaml

--- a/devices/stm32f7x9.yaml
+++ b/devices/stm32f7x9.yaml
@@ -364,3 +364,4 @@ _include:
  - common_patches/rtc/rtc_cr.yaml
  - ../peripherals/rtc/rtc_common.yaml
  - common_patches/ethernet/f4_f7.yaml
+ - ../peripherals/eth/eth_ptp_ppsfreq.yaml

--- a/devices/stm32f7x9.yaml
+++ b/devices/stm32f7x9.yaml
@@ -363,3 +363,4 @@ _include:
  - ../peripherals/dma/dma2d_v1.yaml
  - common_patches/rtc/rtc_cr.yaml
  - ../peripherals/rtc/rtc_common.yaml
+ - common_patches/ethernet/f4_f7.yaml

--- a/peripherals/eth/eth_ptp_ppsfreq.yaml
+++ b/peripherals/eth/eth_ptp_ppsfreq.yaml
@@ -1,0 +1,19 @@
+Ethernet_PTP:
+  PTPPPSCR:
+    PPSFREQ:
+      Hz_1: [0, "1 Hz with a pulse width of 125 ms for binary rollover and of 100 ms for digital rollover"]
+      Hz_2: [1, "2 Hz with 50% duty cycle for binary rollover (digital rollover not recommended)"]
+      Hz_4: [2, "4 Hz with 50% duty cycle for binary rollover (digital rollover not recommended)"]
+      Hz_8: [3, "8 Hz with 50% duty cycle for binary rollover (digital rollover not recommended)"]
+      Hz_16: [4, "16 Hz with 50% duty cycle for binary rollover (digital rollover not recommended)"]
+      Hz_32: [5, "32 Hz with 50% duty cycle for binary rollover (digital rollover not recommended)"]
+      Hz_64: [6, "64 Hz with 50% duty cycle for binary rollover (digital rollover not recommended)"]
+      Hz_128: [7, "128 Hz with 50% duty cycle for binary rollover (digital rollover not recommended)"]
+      Hz_256: [8, "256 Hz with 50% duty cycle for binary rollover (digital rollover not recommended)"]
+      Hz_512: [9, "512 Hz with 50% duty cycle for binary rollover (digital rollover not recommended)"]
+      Hz_1024: [10, "1024 Hz with 50% duty cycle for binary rollover (digital rollover not recommended)"]
+      Hz_2048: [11, "2048 Hz with 50% duty cycle for binary rollover (digital rollover not recommended)"]
+      Hz_4096: [12, "4096 Hz with 50% duty cycle for binary rollover (digital rollover not recommended)"]
+      Hz_8192: [13, "8192 Hz with 50% duty cycle for binary rollover (digital rollover not recommended)"]
+      Hz_16384: [14, "16384 Hz with 50% duty cycle for binary rollover (digital rollover not recommended)"]
+      Hz_32768: [15, "32768 Hz with 50% duty cycle for binary rollover (digital rollover not recommended)"]


### PR DESCRIPTION
Remove the `TSSO` and `TSTTR` fields from `PTPPPSCR` on `f4` and `f7` as they don't actually exist on that register and add `PPSFREQ` field to `PTPPPSCR` on `f4` and `f7` since that field is missing from the SVDs.

Add variants for the `PPSFREQ` field for `f2`, `f4`, and `f7`

Fixes #801

Reference:
`stm32f207` and `stm32f217`, see [RM0033, page 939](https://www.st.com/resource/en/reference_manual/cd00225773-stm32f205xx-stm32f207xx-stm32f215xx-and-stm32f217xx-advanced-armbased-32bit-mcus-stmicroelectronics.pdf)
`stm32f405`, `stm32f407`, `stm32f417`, and `stm32f427`, and `stm32f429`, see [RM0090, page 1222](https://www.st.com/resource/en/reference_manual/dm00031020-stm32f405-415-stm32f407-417-stm32f427-437-and-stm32f429-439-advanced-arm-based-32-bit-mcus-stmicroelectronics.pdf) (as a sidenote: AFAICT `f405` shouldn't have ethernet at all?)
`stm32f469`, see [RM0386, page 1538](https://www.st.com/resource/en/reference_manual/rm0386-stm32f469xx-and-stm32f479xx-advanced-armbased-32bit-mcus-stmicroelectronics.pdf)
`stm32f745` and `stm32f750`, see [RM0385, page 1630](https://www.st.com/resource/en/reference_manual/rm0385-stm32f75xxx-and-stm32f74xxx-advanced-armbased-32bit-mcus-stmicroelectronics.pdf)
`stm32f765`, `stm32f7x7`, and `stm32f7x9`, see [RM0410, page 1867](https://www.st.com/resource/en/reference_manual/rm0410-stm32f76xxx-and-stm32f77xxx-advanced-armbased-32bit-mcus-stmicroelectronics.pdf)