### PR TITLE
makehtml: improve expand_cluster ValueError

### DIFF
--- a/scripts/makehtml.py
+++ b/scripts/makehtml.py
@@ -137,7 +137,9 @@ def expand_cluster(node):
     The returned register nodes are as though they were never in a cluster.
     """
     if node.attrib.get("dim_index") is None:
-        raise ValueError("Can't process cluster without dim_index")
+        raise ValueError("Can't process cluster '{}' without dim_index".format(
+            get_string(node, "name")
+        ))
     cluster_idx = node.attrib["dim_index"]
     cluster_addr = get_int(node, "addressOffset")
     nodes = []


### PR DESCRIPTION
The differences between `{DIEP,DOEP}0` and `{DIEP,DOEP}%s` in #768 resulted in makehtml returning a `ValueError` for DIEP0.  The contents of this PR doesn't fix it, just makes it easier to debug for the future.

CC @burrbull

---

The simple hack-fix is to do this:

```python
if get_string(node, "name") in ("DIEP0", "DOEP0"):
    return []
else:
    raise ValueError("Can't process cluster '{}' without dim_index".format(
        get_string(node, "name")
    ))
```

Perhaps the ValueError should be removed and replaced with `return []` as a long-term fix?  This makes it so DIEP0/DOEP0 get handled separately in the HTML output.  Can change this PR or open another if that is a desirable solution.

