### PR TITLE
Add .gitattributes file to fix script line endings.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# linux script files 
+*.sh text eol=lf
+


### PR DESCRIPTION
On cygwin you get errors because the scripts have mixed line endings, e.g.

```
Hydra on DESKTOP-H1JUK44 in /cygdrive/d/Users/Hydra/Documents/dev/projects/stm32-rs/stm32-rs/svd (master)
$ ./extract.sh
./extract.sh: line 2: syntax error near unexpected token `$'do\r''
'/extract.sh: line 2: `for f in vendor/*.zip; do
```

See also:

https://git-scm.com/docs/gitattributes
https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings?platform=windows

For this repo, I use `autocrlf=auto`, as per the recommendations.

This PR will prevent future accidental line endings making their way into the repo for all .sh files.
