### PR TITLE
Apply TIM2 32-bit patch to STM32WB55

### DIFF
--- a/devices/stm32wb55.yaml
+++ b/devices/stm32wb55.yaml
@@ -108,16 +108,6 @@ SYSCFG:
     SIPCR:
       addressOffset: 0x110
 
-TIM2:
-  CNT:
-    _delete:
-      - CNT_H
-    _modify:
-      CNT_L:
-        name: CNT
-        description: Counter value
-        bitWidth: 32
-
 TIM16:
   _add:
     TISEL:
@@ -299,3 +289,4 @@ _include:
  - ./common_patches/adc/wb_adc_common.yaml
  - ./common_patches/adc/l4_smpr.yaml
  - common_patches/hsem/array.yaml
+ - common_patches/tim/tim2_32bit.yaml

--- a/devices/stm32wb55.yaml
+++ b/devices/stm32wb55.yaml
@@ -108,6 +108,23 @@ SYSCFG:
     SIPCR:
       addressOffset: 0x110
 
+
+TIM2:
+  CNT:
+    _add:
+      UIFREMAP_CNT:
+        description: Counter value when CR1.UIFREMAP=1
+        bitOffset: 0
+        bitWidth: 31
+    _modify:
+      UIFCPY:
+        description: Copy of ISR.UIF when CR1.UIFREMAP=1
+      CNT_H:
+        bitWidth: 16
+        bitOffset: 16
+      CNT_L:
+        bitOffset: 0
+
 TIM16:
   _add:
     TISEL:


### PR DESCRIPTION
Seems like TIM2 could've benefited from the `tim2_32bit` patch, looks like someone started it but never quite finished (or maybe the `tim2_32bit` patch didn't exist back then?)

Either way, this PR does exactly what the name suggests