### PR TITLE
add missing I2S*ext peripherals on f413

### DIFF
--- a/devices/stm32f413.yaml
+++ b/devices/stm32f413.yaml
@@ -32,6 +32,15 @@ _modify:
       TIFRFE:
         name: "FRE"
 
+_add:
+    # I2S*ext are missing
+    I2S2ext:
+        derivedFrom: SPI1
+        baseAddress: "0x40003400"
+    I2S3ext:
+        derivedFrom: SPI1
+        baseAddress: "0x40004000"
+
 FLASH:
   ACR:
     _modify:


### PR DESCRIPTION
Hi, I2S*ext were missing from f413 pac, so i added them by deriving it from SPI1. I didn't add their interrput because they are already defined by SPI peripheral. 
Is it relevant to have the interrupt definition on the right peripheral ? When running `svdtools interrupts ../svd/stm32f413.svd.patched` I see many interrupt with the right description, but defined on the wrong peripheral