### PR TITLE
doc on `OTG_FS_GLOBAL` for STMF4

### DIFF
--- a/devices/common_patches/usb_otg/fs_f4.yaml
+++ b/devices/common_patches/usb_otg/fs_f4.yaml
@@ -1,0 +1,5 @@
+OTG_FS_GLOBAL:
+  GAHBCFG:
+    _modify:
+      GINT:
+        name: GINTMSK

--- a/devices/stm32f401.yaml
+++ b/devices/stm32f401.yaml
@@ -155,6 +155,7 @@ _include:
  - common_patches/rtc/alarm.yaml
  - common_patches/rtc/rtc_bkpr.yaml
  - common_patches/usb_otg/fs_remove_prefix.yaml
+ - common_patches/usb_otg/fs_f4.yaml
  - common_patches/usb_otg/fs_v1.yaml
  - common_patches/dbgmcu/dbgmcu.yaml
  - common_patches/fpu_interrupt.yaml

--- a/devices/stm32f405.yaml
+++ b/devices/stm32f405.yaml
@@ -167,6 +167,7 @@ _include:
  - common_patches/rtc/alarm.yaml
  - common_patches/rtc/rtc_bkpr.yaml
  - common_patches/usb_otg/fs_remove_prefix.yaml
+ - common_patches/usb_otg/fs_f4.yaml
  - common_patches/usb_otg/fs_v1ext.yaml
  - common_patches/usb_otg/fs_v1.yaml
  - common_patches/usb_otg/hs_v1.yaml

--- a/devices/stm32f407.yaml
+++ b/devices/stm32f407.yaml
@@ -132,6 +132,7 @@ _include:
  - common_patches/rtc/alarm.yaml
  - common_patches/rtc/rtc_bkpr.yaml
  - common_patches/usb_otg/fs_remove_prefix.yaml
+ - common_patches/usb_otg/fs_f4.yaml
  - common_patches/usb_otg/fs_v1ext.yaml
  - common_patches/usb_otg/fs_v1.yaml
  - common_patches/usb_otg/hs_v1.yaml

--- a/devices/stm32f411.yaml
+++ b/devices/stm32f411.yaml
@@ -178,6 +178,7 @@ _include:
  - common_patches/rtc/alarm.yaml
  - common_patches/rtc/rtc_bkpr.yaml
  - common_patches/usb_otg/fs_remove_prefix.yaml
+ - common_patches/usb_otg/fs_f4.yaml
  - common_patches/usb_otg/fs_v1.yaml
  - common_patches/dbgmcu/dbgmcu.yaml
  - common_patches/fpu_interrupt.yaml

--- a/devices/stm32f412.yaml
+++ b/devices/stm32f412.yaml
@@ -454,6 +454,7 @@ _include:
  - common_patches/rtc/alarm.yaml
  - common_patches/rtc/rtc_bkpr.yaml
  - common_patches/usb_otg/fs_remove_prefix.yaml
+ - common_patches/usb_otg/fs_f4.yaml
  - common_patches/usb_otg/fs_v1ext.yaml
  - common_patches/usb_otg/fs_v1.yaml
  - common_patches/dbgmcu/dbgmcu.yaml

--- a/devices/stm32f413.yaml
+++ b/devices/stm32f413.yaml
@@ -336,6 +336,7 @@ _include:
  - common_patches/rtc/alarm.yaml
  - common_patches/rtc/rtc_bkpr.yaml
  - common_patches/usb_otg/fs_remove_prefix.yaml
+ - common_patches/usb_otg/fs_f4.yaml
  - common_patches/usb_otg/fs_v1ext.yaml
  - common_patches/usb_otg/fs_v1.yaml
  - common_patches/dbgmcu/dbgmcu.yaml

--- a/devices/stm32f427.yaml
+++ b/devices/stm32f427.yaml
@@ -250,6 +250,7 @@ _include:
  - common_patches/rtc/alarm.yaml
  - common_patches/rtc/rtc_bkpr.yaml
  - common_patches/usb_otg/fs_remove_prefix.yaml
+ - common_patches/usb_otg/fs_f4.yaml
  - common_patches/usb_otg/fs_v1ext.yaml
  - common_patches/usb_otg/fs_v1.yaml
  - common_patches/usb_otg/hs_v1.yaml

--- a/devices/stm32f429.yaml
+++ b/devices/stm32f429.yaml
@@ -201,6 +201,7 @@ _include:
  - common_patches/rtc/alarm.yaml
  - common_patches/rtc/rtc_bkpr.yaml
  - common_patches/usb_otg/fs_remove_prefix.yaml
+ - common_patches/usb_otg/fs_f4.yaml
  - common_patches/usb_otg/fs_v1ext.yaml
  - common_patches/usb_otg/fs_v1.yaml
  - common_patches/usb_otg/hs_v1.yaml

--- a/devices/stm32f446.yaml
+++ b/devices/stm32f446.yaml
@@ -595,6 +595,7 @@ _include:
  - common_patches/rtc/alarm.yaml
  - common_patches/rtc/rtc_bkpr.yaml
  - common_patches/usb_otg/fs_remove_prefix.yaml
+ - common_patches/usb_otg/fs_f4.yaml
  - common_patches/usb_otg/fs_host_addr.yaml
  - common_patches/usb_otg/fs_v2.yaml
  - common_patches/usb_otg/fs_fixes_446_469.yaml

--- a/devices/stm32f469.yaml
+++ b/devices/stm32f469.yaml
@@ -213,6 +213,7 @@ _include:
  - common_patches/rtc/alarm.yaml
  - common_patches/rtc/rtc_bkpr.yaml
  - common_patches/usb_otg/fs_remove_prefix.yaml
+ - common_patches/usb_otg/fs_f4.yaml
  - common_patches/usb_otg/fs_host_addr.yaml
  - common_patches/usb_otg/fs_v2.yaml
  - common_patches/usb_otg/fs_fixes_446_469.yaml


### PR DESCRIPTION
for every `F4` device with `USB_OTG`:  
rename `GINT` field of `GAHBCFG` register of `OTG_FS_GLOBAL` .

doc on `FS` only device:  
include 401, 411, 405, 407, 417, 427, 437, 429, 439  
not include 412, 413, 423, 446, 469, 479