### PR TITLE
doc on `OTG_FS_*` for STM32F4 with standalone `OTG_FS_*` section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 Family-specific:
 
+* F4:
+* doc on `OTG_FS_*` with standalone `OTG_FS_*` section ([#855])
+
+
 * G4:
   * UART: remove missing fields, derive UART/LPUART from USART (#1247)
 
@@ -23,6 +27,8 @@ Family-specific:
 * WBA:
   * Initial support (#1229)
   * Apply exisiting patches
+
+[#855]: https://github.com/stm32-rs/stm32-rs/pull/855
 
 ## [v0.16.0] 2025-05-13
 

--- a/devices/fields/usb_otg/otg_fs_device_f4.yaml
+++ b/devices/fields/usb_otg/otg_fs_device_f4.yaml
@@ -1,0 +1,367 @@
+# Note: if you want to include `OTG_FS_GLOBAL`, `OTG_FS_DEVICE`, `OTG_FS_HOST` and `OTG_FS_PWRCLK`,
+# then try include `../peripherals/otg_fs_f4.yaml` into device yaml file instead.
+#
+# the main frame of this file was generated from stm32f429.svd.patched
+
+DCFG:
+  PFIVL:
+    Interval80: [0, "80% of the frame interval"]
+    Interval85: [1, "85% of the frame interval"]
+    Interval90: [2, "90% of the frame interval"]
+    Interval95: [3, "95% of the frame interval"]
+  DAD:
+    SendStallDirectly:
+      [
+        0,
+        "Send a STALL handshake on a nonzero-length status OUT transaction and do not send the received OUT packet to the application",
+      ]
+    SendStallByCondition:
+      [
+        1,
+        "Send the received OUT packet to the application (zero-length or nonzero-length) and send a handshake based on the NAK and STALL bits for the endpoint in the Device endpoint control register",
+      ]
+  NZLSOHSK:
+    ByCondition: [0, ""]
+    SendStall: [1, ""]
+  DSPD:
+    FullSpeed: [3, "Full speed (USB 1.1 transceiver clock is 48 MHz)"]
+
+DCTL:
+  POPRGDNE:
+    NotDone: [0, ""]
+    Done: [1, ""]
+  CGONAK:
+    Clear: [1, ""]
+  SGONAK:
+    Clear: [1, ""]
+  CGINAK:
+    Clear: [1, ""]
+  SGINAK:
+    Clear: [1, ""]
+  TCTL:
+    Disabled: [0, "Test mode disabled"]
+    JMode: [1, "Test_J mode"]
+    KMode: [2, "Test_K mode"]
+    SE0NAK: [3, "Test_SE0_NAK mode"]
+    Packet: [4, "Test_Packet mode"]
+    ForceEnable: [5, "Test_Force_Enable"]
+  GONSTS:
+    ByCondition: [0, "A handshake is sent based on the FIFO Status and the NAK and STALL bit settings"]
+    AllNAK:
+      [
+        1,
+        "No data is written to the RxFIFO, irrespective of space availability. Sends a NAK handshake on all packets, except on SETUP transactions. All isochronous OUT packets are dropped",
+      ]
+  GINSTS:
+    ByCondition: [0, "A handshake is sent out based on the data availability in the transmit FIFO"]
+    AllNAK:
+      [
+        1,
+        "A NAK handshake is sent out on all non-periodic IN endpoints, irrespective of the data availability in the transmit FIFO",
+      ]
+  SDIS:
+    Normal:
+      [
+        0,
+        "Normal operation. When this bit is cleared after a soft disconnect, the core generates a device connect event to the USB host. When the device is reconnected, the USB host restarts device enumeration",
+      ]
+    Disconnect: [1, "The core generates a device disconnect event to the USB host"]
+  RWUSIG:
+    Clear: [0, ""]
+    WakeUp: [1, ""]
+
+DSTS:
+  FNSOF: [0, 0x3fff]
+  EERR:
+    Clear: [0, ""]
+    Error: [1, ""]
+  ENUMSPD:
+    FullSpeed: [3, "Full speed (PHY clock is running at 48 MHz)"]
+  SUSPSTS:
+    Clear: [0, ""]
+    Suspended: [1, ""]
+
+DIEPMSK:
+  NAKM:
+    Masked: [0, "Masked interrupt"]
+    Unmasked: [1, "Unmasked interrupt"]
+  INEPNEM:
+    Masked: [0, "Masked interrupt"]
+    Unmasked: [1, "Unmasked interrupt"]
+  INEPNMM:
+    Masked: [0, "Masked interrupt"]
+    Unmasked: [1, "Unmasked interrupt"]
+  ITTXFEMSK:
+    Masked: [0, "Masked interrupt"]
+    Unmasked: [1, "Unmasked interrupt"]
+  TOM:
+    Masked: [0, "Masked interrupt"]
+    Unmasked: [1, "Unmasked interrupt"]
+  EPDM:
+    Masked: [0, "Masked interrupt"]
+    Unmasked: [1, "Unmasked interrupt"]
+  XFRCM:
+    Masked: [0, "Masked interrupt"]
+    Unmasked: [1, "Unmasked interrupt"]
+
+DOEPMSK:
+  NAKMSK:
+    Masked: [0, "Masked interrupt"]
+    Unmasked: [1, "Unmasked interrupt"]
+  BERRM:
+    Masked: [0, "Masked interrupt"]
+    Unmasked: [1, "Unmasked interrupt"]
+  OUTPKTERRM:
+    Masked: [0, "Masked interrupt"]
+    Unmasked: [1, "Unmasked interrupt"]
+  STSPHSRXM:
+    Masked: [0, "Masked interrupt"]
+    Unmasked: [1, "Unmasked interrupt"]
+  OTEPDM:
+    Masked: [0, "Masked interrupt"]
+    Unmasked: [1, "Unmasked interrupt"]
+  STUPM:
+    Masked: [0, "Masked interrupt"]
+    Unmasked: [1, "Unmasked interrupt"]
+  EPDM:
+    Masked: [0, "Masked interrupt"]
+    Unmasked: [1, "Unmasked interrupt"]
+  XFRCM:
+    Masked: [0, "Masked interrupt"]
+    Unmasked: [1, "Unmasked interrupt"]
+
+DAINT:
+  OEPINT: [0, 0xF]
+  IEPINT: [0, 0xF]
+
+DAINTMSK:
+  OEPM: [0, 0xF]
+  IEPM: [0, 0xF]
+
+DVBUSDIS:
+  VBUSDT: [0, 0xFFFF]
+
+DVBUSPULSE:
+  DVBUSP: [0, 0xFFF]
+
+DIEPEMPMSK:
+  INEPTXFEM: [0, 0xF]
+
+DIEPCTL0:
+  EPENA:
+    Disabled: [0, ""]
+    Enabled: [1, "Start transmitting data on the endpoint 0"]
+  EPDIS:
+    Clear: [0, ""]
+    Stop: [1, "Stop transmitting data on an endpoint"]
+  SNAK:
+    Clear: [0, ""]
+    Set: [1, ""]
+  CNAK:
+    Set: [1, "A write to this bit clears the NAK bit for the endpoint"]
+  TXFNUM: [0, 0xF]
+  STALL:
+    Clear: [0, "the core clears it when a SETUP token is received for this endpoint"]
+    Set: [1, ""]
+  EPTYP: [0, 0]
+  NAKSTS:
+    ByCondition: [0, "The core is transmitting non-NAK handshakes based on the FIFO status"]
+    AllNAK: [1, "The core is transmitting NAK handshakes on this endpoint"]
+  USBAEP: [1, 1]
+  MPSIZ:
+    Byte64: [0, "64 bytes"]
+    Byte32: [1, "32 bytes"]
+    Byte16: [2, "16 bytes"]
+    Byte8: [3, "8 bytes"]
+
+DIEPCTL[1-3]:
+  EPENA:
+    Disabled: [0, ""]
+    Enabled: [1, "Start transmitting data on the endpoint 0"]
+  EPDIS:
+    Clear: [0, ""]
+    Stop: [1, "Stop transmitting data on an endpoint"]
+  SODDFRM:
+    OddFrame: [1, "Sets the Even/Odd frame (EONUM) field to Odd frame"]
+  SD0PID:
+    Set: [1, "sets the endpoint data PID (DPID) field in this register to DATA0"]
+  SEVNFRM:
+    EvenFrame: [1, "Sets the Even/Odd frame (EONUM) field to even frame"]
+  SNAK:
+    Set: [1, "sets the NAK bit for the endpoint"]
+  CNAK:
+    Set: [1, "A write to this bit clears the NAK bit for the endpoint"]
+  TXFNUM: [0, 0xF]
+  STALL:
+    Clear: [0, ""]
+    Stall: [1, "Stall all tokens from the USB host to this endpoint"]
+  EPTYP:
+    Control: [0, ""]
+    Isochronous: [1, ""]
+    Bulk: [2, ""]
+    Interrupt: [3, ""]
+  NAKSTS:
+    ByCondition: [0, "The core is transmitting non-NAK handshakes based on the FIFO status"]
+    AllNAK: [1, "The core is transmitting NAK handshakes on this endpoint"]
+  EONUM:
+    Even: [0, "Even frame"]
+    Odd: [1, "Odd frame"]
+  DPID:
+    Data0: [0, "DATA0"]
+    Data1: [1, "DATA1"]
+  USBAEP:
+    Inactive: [0, "Endpoint is inactive"]
+    Active: [1, "Endpoint is active"]
+  MPSIZ: [0, 3]
+
+DOEPCTL0:
+  EPENA:
+    Disabled: [0, ""]
+    Enabled: [1, "Start transmitting data on the endpoint 0"]
+  EPDIS: [0, 0]
+  SNAK:
+    Clear: [0, ""]
+    Set: [1, ""]
+  CNAK:
+    Set: [1, "A write to this bit clears the NAK bit for the endpoint"]
+  STALL:
+    Clear: [0, ""]
+    Set: [1, ""]
+  SNPM:
+    Clear: [0, ""]
+    Set: [1, ""]
+  EPTYP: [1, 1]
+  NAKSTS:
+    ByCondition: [0, "The core is transmitting non-NAK handshakes based on the FIFO status"]
+    AllNAK: [1, "The core is transmitting NAK handshakes on this endpoint"]
+  USBAEP: [1, 1]
+  MPSIZ:
+    Byte64: [0, "64 bytes"]
+    Byte32: [1, "32 bytes"]
+    Byte16: [2, "16 bytes"]
+    Byte8: [3, "8 bytes"]
+
+DOEPCTL[1-3]:
+  EPENA:
+    Disabled: [0, ""]
+    Enabled: [1, "Start transmitting data on an endpoint"]
+  EPDIS:
+    Clear: [0, ""]
+    Stop: [1, "Stop transmitting data on an endpoint"]
+  SD1PID:
+    Set: [1, "sets the endpoint data PID (DPID) field in this register to DATA1"]
+  SODDFRM:
+    OddFrame: [1, "Sets the Even/Odd frame (EONUM) field to Odd frame"]
+  SD0PID:
+    Set: [1, "sets the endpoint data PID (DPID) field in this register to DATA0"]
+  SEVNFRM:
+    EvenFrame: [1, "Sets the Even/Odd frame (EONUM) field to even frame"]
+  SNAK:
+    Set: [1, "sets the NAK bit for the endpoint"]
+  CNAK:
+    Set: [1, "A write to this bit clears the NAK bit for the endpoint"]
+  STALL:
+    Clear: [0, ""]
+    Stall: [1, "Stall all tokens from the USB host to this endpoint"]
+  SNPM:
+    Clear: [0, ""]
+    Set: [1, ""]
+  EPTYP:
+    Control: [0, ""]
+    Isochronous: [1, ""]
+    Bulk: [2, ""]
+    Interrupt: [3, ""]
+  NAKSTS:
+    ByCondition: [0, "The core is transmitting non-NAK handshakes based on the FIFO status"]
+    AllNAK: [1, "The core is transmitting NAK handshakes on this endpoint"]
+  EONUM:
+    Even: [0, "Even frame"]
+    Odd: [1, "Odd frame"]
+  DPID:
+    Data0: [0, "DATA0"]
+    Data1: [1, "DATA1"]
+  USBAEP:
+    Inactive: [0, "Endpoint is inactive"]
+    Active: [1, "Endpoint is active"]
+  MPSIZ: [0, 0x7FF]
+
+DIEPINT[0-3]:
+  NAK:
+    NotNAK: [0, ""]
+    NAK: [1, ""]
+  PKTDRPSTS:
+    NotDropped: [0, ""]
+    Dropped: [1, ""]
+  TXFE:
+    NotEmpty: [0, ""]
+    Empty: [1, ""]
+  INEPNE: [0, 1]
+  INEPNM: [0, 1]
+  ITTXFE: [0, 1]
+  TOC:
+    NotTimeout: [0, ""]
+    Timeout: [1, ""]
+  EPDISD:
+    NotDisabled: [0, ""]
+    Disabled: [1, ""]
+  XFRC:
+    NotCompleted: [0, ""]
+    Completed: [1, ""]
+
+DOEPINT[0-3]:
+  NAK:
+    NotNAK: [0, ""]
+    NAK: [1, ""]
+  BERR:
+    NotBabbled: [0, ""]
+    Babbled: [1, ""]
+  OUTPKTERR:
+    NoError: [0, ""]
+    Error: [1, ""]
+  STSPHSRX:
+    NotReceived: [0, ""]
+    Received: [1, ""]
+  OTEPDIS:
+    NotReceived: [0, ""]
+    Received: [1, ""]
+  STUP:
+    NotCompleted: [0, ""]
+    Completed: [1, ""]
+  EPDISD:
+    NotDisabled: [0, ""]
+    Disabled: [1, ""]
+  XFRC:
+    NotCompleted: [0, ""]
+    Completed: [1, ""]
+
+DIEPTSIZ0:
+  PKTCNT: [0, 3]
+  XFRSIZ: [0, 0x7F]
+
+DOEPTSIZ0:
+  STUPCNT:
+    Packet1: [1, "1 packet"]
+    Packet2: [2, "2 packets"]
+    Packet3: [3, "3 packets"]
+  PKTCNT: [0, 1]
+  XFRSIZ: [0, 0x7F]
+
+DIEPTSIZ[1-3]:
+  PKTCNT: [0, 0x3FF]
+  XFRSIZ: [0, 0x1FFF_FFFF]
+
+DTXFSTS[0-3]:
+  INEPTFSAV: [0, 0xFFFF]
+
+DOEPTSIZ[1-3]:
+  RXDPID:
+    Data0: [0, ""]
+    Data1: [2, ""]
+    Data2: [1, ""]
+    MData: [3, ""]
+  STUPCNT:
+    Packet1: [1, "1 packet"]
+    Packet2: [2, "2 packets"]
+    Packet3: [3, "3 packets"]
+  PKTCNT: [0, 0x3FF]
+  XFRSIZ: [0, 0x7_FFFF]

--- a/devices/fields/usb_otg/otg_fs_global_f4.yaml
+++ b/devices/fields/usb_otg/otg_fs_global_f4.yaml
@@ -1,0 +1,389 @@
+# Note: if you want to include `OTG_FS_GLOBAL`, `OTG_FS_DEVICE`, `OTG_FS_HOST` and `OTG_FS_PWRCLK`,
+# then try include `../peripherals/otg_fs_f4.yaml` into device yaml file instead.
+#
+# the main frame of this file was generated from stm32f429.svd.patched
+
+GOTGCTL:
+  BSVLD:
+    NotValid: [0, "B-session is not valid"]
+    Valid: [1, "B-session is valid"]
+  ASVLD:
+    NotValid: [0, "A-session is not valid"]
+    Valid: [1, "A-session is valid"]
+  DBCT:
+    Long: [0, "Long debounce time, used for physical connections (100 ms + 2.5 us)"]
+    Short: [1, "Short debounce time, used for soft connections (2.5 us)"]
+  CIDSTS:
+    ADeviceMode: [0, "The OTG_FS controller is in A-device mode"]
+    BDeviceMode: [1, "The OTG_FS controller is in B-device mode"]
+  DHNPEN:
+    NotEnabled: [0, "HNP is not enabled in the application"]
+    Enabled: [1, "HNP is enabled in the application"]
+  HSHNPEN:
+    NotEnabled: [0, "Host Set HNP is not enabled"]
+    Enabled: [1, "Host Set HNP is enabled"]
+  HNPRQ:
+    NotRequested: [0, "No HNP request"]
+    Requested: [1, "HNP request"]
+  HNGSCS:
+    Failure: [0, "Host negotiation failure"]
+    Succeed: [1, "Host negotiation success"]
+  SRQ:
+    NotRequested: [0, "No session request"]
+    Requested: [1, "Session request"]
+  SRQSCS:
+    Failure: [0, "Session request failure"]
+    Succeed: [1, "Session request success"]
+
+GOTGINT:
+  DBCDNE:
+    NotDone: [0, ""]
+    Done: [1, ""]
+  ADTOCHG:
+    NotTimeOut: [0, ""]
+    TimeOut: [1, ""]
+  HNGDET:
+    NotDetected: [0, ""]
+    Detected: [1, ""]
+  HNSSCHG:
+    Unchanged: [0, ""]
+    Changed: [1, ""]
+  SRSSCHG:
+    Unchanged: [0, ""]
+    Changed: [1, ""]
+  SEDET:
+    NotEnd: [0, ""]
+    Ended: [1, ""]
+
+GAHBCFG:
+  PTXFELVL:
+    HalfEmpty: [0, "PTXFE (in OTG_FS_GINTSTS) interrupt indicates that the Periodic TxFIFO is half empty"]
+    CompletelyEmpty: [1, "PTXFE (in OTG_FS_GINTSTS) interrupt indicates that the Periodic TxFIFO is completely empty"]
+  TXFELVL:
+    HalfEmpty:
+      [
+        0,
+        "In device mode, the TXFE (in OTG_FS_DIEPINTx) interrupt indicates that the IN Endpoint TxFIFO is half empty; In host mode, the NPTXFE (in OTG_FS_GINTSTS) interrupt indicates that the nonperiodic Tx FIFO is half empty",
+      ]
+    CompletelyEmpty:
+      [
+        1,
+        "In device mode, the TXFE (in OTG_FS_DIEPINTx) interrupt indicates that the IN Endpoint TxFIFO is completely empty; In host mode, the NPTXFE (in OTG_FS_GINTSTS) interrupt indicates that the nonperiodic Tx FIFO is completely empty",
+      ]
+  GINTMSK:
+    Masked: [0, "Mask the interrupt assertion to the application"]
+    Unmasked: [1, "Unmask the interrupt assertion to the application"]
+
+GUSBCFG:
+  CTXPKT:
+    KeepAtZero: [0, "Always keep at this variant"]
+    NeverSetToThis: [1, "WARNING: NEVER SET TO THIS VARIANT"]
+  FDMOD:
+    Normal: [0, "Normal mode"]
+    ForceDevice: [1, "Force device mode"]
+  FHMOD:
+    Normal: [0, "Normal mode"]
+    ForceHost: [1, "Force host mode"]
+  TRDT: [0x6, 0xF]
+  HNPCAP:
+    NotEnabled: [0, "HNP capability is not enabled"]
+    Enabled: [1, "HNP capability is enabled"]
+  SRPCAP:
+    NotEnabled: [0, "SRP capability is not enabled"]
+    Enabled: [1, "SRP capability is enabled"]
+  PHYSEL:
+    Impossible: [0, "This variant is NOT POSSIBLE"]
+    Selected: [1, "This variant is always used"]
+  TOCAL: [0, 7]
+
+GRSTCTL:
+  AHBIDL:
+    NotIdle: [0, ""]
+    Idle: [1, ""]
+  TXFNUM:
+    FIFO0_NonPeriodic: [0, ""]
+    FIFO1_Periodic: [1, ""]
+    FIFO2: [2, ""]
+    FIFO3: [3, ""]
+    FIFO4: [4, ""]
+    # There might be a bug in STM32F429's Reference Manual
+    # This vaiant mark as TXFIFO 15, but the value is only 5
+    FIFO5: [5, ""]
+    FIFOAll: [16, ""]
+  TXFFLSH:
+    NotFlush: [0, ""]
+    Flush: [1, ""]
+  RXFFLSH:
+    NotFlush: [0, ""]
+    Flush: [1, ""]
+  FCRST:
+    NotReset: [0, ""]
+    Reset: [1, ""]
+  HSRST:
+    NotReset: [0, ""]
+    Reset: [1, ""]
+  CSRST:
+    NotReset: [0, ""]
+    Reset: [1, ""]
+
+GINTSTS:
+  WKUPINT:
+    NotDetected: [0, ""]
+    Detected: [1, ""]
+  SRQINT:
+    NotDetected: [0, ""]
+    Detected: [1, ""]
+  DISCINT:
+    NotDetected: [0, ""]
+    Detected: [1, ""]
+  CIDSCHG:
+    Unchanged: [0, ""]
+    Changed: [1, ""]
+  PTXFE:
+    NotEmpty: [0, ""]
+    Empty: [1, ""]
+  HCINT:
+    NotPending: [0, ""]
+    Pending: [1, ""]
+  HPRTINT:
+    Unchanged: [0, ""]
+    Changed: [1, ""]
+  IPXFR:
+    Completed: [0, ""]
+    Incompleted: [1, ""]
+  INCOMPISOOUT:
+    Completed: [0, ""]
+    Incompleted: [1, ""]
+  IISOIXFR:
+    Completed: [0, ""]
+    Incompleted: [1, ""]
+  OEPINT:
+    NotPending: [0, ""]
+    Pending: [1, ""]
+  IEPINT:
+    NotPending: [0, ""]
+    Pending: [1, ""]
+  EOPF:
+    NotEnd: [0, ""]
+    Ended: [1, ""]
+  ISOODRP:
+    NotDropped: [0, ""]
+    Dropped: [1, ""]
+  ENUMDNE:
+    NotCompleted: [0, ""]
+    Completed: [1, ""]
+  USBRST:
+    NotDetected: [0, ""]
+    Detected: [1, ""]
+  USBSUSP:
+    NotDetected: [0, ""]
+    Detected: [1, ""]
+  ESUSP:
+    NotDetected: [0, ""]
+    Detected: [1, ""]
+  GOUTNAKEFF:
+    NotEffective: [0, ""]
+    Effective: [1, ""]
+  GINAKEFF:
+    NotEffective: [0, ""]
+    Effective: [1, ""]
+  NPTXFE:
+    NotEmpty: [0, ""]
+    Empty: [1, ""]
+  RXFLVL:
+    Empty: [0, ""]
+    NotEmpty: [1, ""]
+  SOF:
+    NotTransmitted: [0, ""]
+    Transmitted: [1, ""]
+  OTGINT:
+    NotOccurred: [0, ""]
+    Occurred: [1, ""]
+  MMIS:
+    Matched: [0, ""]
+    Mismatched: [1, ""]
+  CMOD:
+    DeviceMode: [0, ""]
+    HostMode: [1, ""]
+
+GINTMSK:
+  WUIM:
+    Masked: [0, "Masked interrupt"]
+    Unmasked: [1, "Unmasked interrupt"]
+  SRQIM:
+    Masked: [0, "Masked interrupt"]
+    Unmasked: [1, "Unmasked interrupt"]
+  DISCINT:
+    Masked: [0, "Masked interrupt"]
+    Unmasked: [1, "Unmasked interrupt"]
+  CIDSCHGM:
+    Masked: [0, "Masked interrupt"]
+    Unmasked: [1, "Unmasked interrupt"]
+  PTXFEM:
+    Masked: [0, "Masked interrupt"]
+    Unmasked: [1, "Unmasked interrupt"]
+  HCIM:
+    Masked: [0, "Masked interrupt"]
+    Unmasked: [1, "Unmasked interrupt"]
+  PRTIM:
+    Masked: [0, "Masked interrupt"]
+    Unmasked: [1, "Unmasked interrupt"]
+  IPXFRM:
+    Masked: [0, "Masked interrupt"]
+    Unmasked: [1, "Unmasked interrupt"]
+  IISOOXFRM:
+    Masked: [0, "Masked interrupt"]
+    Unmasked: [1, "Unmasked interrupt"]
+  IISOIXFRM:
+    Masked: [0, "Masked interrupt"]
+    Unmasked: [1, "Unmasked interrupt"]
+  OEPINT:
+    Masked: [0, "Masked interrupt"]
+    Unmasked: [1, "Unmasked interrupt"]
+  IEPINT:
+    Masked: [0, "Masked interrupt"]
+    Unmasked: [1, "Unmasked interrupt"]
+  EPMISM:
+    Masked: [0, "Masked interrupt"]
+    Unmasked: [1, "Unmasked interrupt"]
+  EOPFM:
+    Masked: [0, "Masked interrupt"]
+    Unmasked: [1, "Unmasked interrupt"]
+  ISOODRPM:
+    Masked: [0, "Masked interrupt"]
+    Unmasked: [1, "Unmasked interrupt"]
+  ENUMDNEM:
+    Masked: [0, "Masked interrupt"]
+    Unmasked: [1, "Unmasked interrupt"]
+  USBRST:
+    Masked: [0, "Masked interrupt"]
+    Unmasked: [1, "Unmasked interrupt"]
+  USBSUSPM:
+    Masked: [0, "Masked interrupt"]
+    Unmasked: [1, "Unmasked interrupt"]
+  ESUSPM:
+    Masked: [0, "Masked interrupt"]
+    Unmasked: [1, "Unmasked interrupt"]
+  GONAKEFFM:
+    Masked: [0, "Masked interrupt"]
+    Unmasked: [1, "Unmasked interrupt"]
+  GINAKEFFM:
+    Masked: [0, "Masked interrupt"]
+    Unmasked: [1, "Unmasked interrupt"]
+  NPTXFEM:
+    Masked: [0, "Masked interrupt"]
+    Unmasked: [1, "Unmasked interrupt"]
+  RXFLVLM:
+    Masked: [0, "Masked interrupt"]
+    Unmasked: [1, "Unmasked interrupt"]
+  SOFM:
+    Masked: [0, "Masked interrupt"]
+    Unmasked: [1, "Unmasked interrupt"]
+  OTGINT:
+    Masked: [0, "Masked interrupt"]
+    Unmasked: [1, "Unmasked interrupt"]
+  MMISM:
+    Masked: [0, "Masked interrupt"]
+    Unmasked: [1, "Unmasked interrupt"]
+
+GRXSTSR_Host:
+  PKTSTS:
+    InDataReceived: [2, "IN data packet received"]
+    InTransferCompleted: [3, "IN transfer completed (triggers an interrupt)"]
+    DataToggleError: [5, "Data toggle error (triggers an interrupt)"]
+    ChannelHalted: [7, "Channel halted (triggers an interrupt)"]
+  DPID:
+    Data0: [0, ""]
+    Data1: [2, ""]
+    Data2: [1, ""]
+    MData: [3, ""]
+  BCNT: [0, 0x7FF]
+  CHNUM: [0, 0xF]
+
+GRXSTSR_Device:
+  FRMNUM: [0, 0xF]
+  PKTSTS:
+    InDataReceived: [2, "IN data packet received"]
+    InTransferCompleted: [3, "IN transfer completed (triggers an interrupt)"]
+    DataToggleError: [5, "Data toggle error (triggers an interrupt)"]
+    ChannelHalted: [7, "Channel halted (triggers an interrupt)"]
+  DPID:
+    Data0: [0, ""]
+    Data1: [2, ""]
+    Data2: [1, ""]
+    MData: [3, ""]
+  BCNT: [0, 0x7FF]
+  EPNUM: [0, 0xF]
+
+GRXSTSP_Host:
+  PKTSTS:
+    InDataReceived: [2, "IN data packet received"]
+    InTransferCompleted: [3, "IN transfer completed (triggers an interrupt)"]
+    DataToggleError: [5, "Data toggle error (triggers an interrupt)"]
+    ChannelHalted: [7, "Channel halted (triggers an interrupt)"]
+  DPID:
+    Data0: [0, ""]
+    Data1: [2, ""]
+    Data2: [1, ""]
+    MData: [3, ""]
+  BCNT: [0, 0x7FF]
+  CHNUM: [0, 0xF]
+
+GRXSTSP_Device:
+  FRMNUM: [0, 0xF]
+  PKTSTS:
+    InDataReceived: [2, "IN data packet received"]
+    InTransferCompleted: [3, "IN transfer completed (triggers an interrupt)"]
+    DataToggleError: [5, "Data toggle error (triggers an interrupt)"]
+    ChannelHalted: [7, "Channel halted (triggers an interrupt)"]
+  DPID:
+    Data0: [0, ""]
+    Data1: [2, ""]
+    Data2: [1, ""]
+    MData: [3, ""]
+  BCNT: [0, 0x7FF]
+  EPNUM: [0, 0xF]
+
+GRXFSIZ:
+  RXFD: [16, 256]
+
+HNPTXFSIZ:
+  NPTXFD: [16, 256]
+  NPTXFSA: [0, 0xFFFF]
+
+DIEPTXF0:
+  TX0FD: [16, 256]
+  TX0FSA: [0, 0xFFFF]
+
+HNPTXSTS:
+  NPTXQTOP: [0, 0x7F]
+  NPTQXSAV: [0, 0xFF]
+  NPTXFSAV: [0, 0xFFFF]
+
+GCCFG:
+  NOVBUSSENS:
+    Avaliable: [0, "Vbus sensing available by hardware"]
+    NotAvaliable: [1, "Vbus sensing not available by hardware"]
+  SOFOUTEN:
+    Avaliable: [0, "SOF pulse not available on PAD (OTG_FS_SOF)"]
+    NotAvaliable: [1, "SOF pulse available on PAD (OTG_FS_SOF)"]
+  VBUSBSEN:
+    Disabled: [0, 'Vbus sensing "B" disabled']
+    Enabled: [1, 'Vbus sensing "B" enabled']
+  VBUSASEN:
+    Disabled: [0, 'Vbus sensing "A" disabled']
+    Enabled: [1, 'Vbus sensing "A" enabled']
+  PWRDWN:
+    PowerDown: [0, "Power down active"]
+    TransceiverActive: [1, 'Power down deactivated ("Transceiver active")']
+
+CID:
+  PRODUCT_ID: [0, 0xFFFF_FFFF]
+
+HPTXFSIZ:
+  PTXFD: [16, 0xFFFF]
+  PTXSA: [0, 0xFFFF]
+
+DIEPTXF[1-3]:
+  INEPTXFD: [16, 0xFFFF]
+  INEPTXSA: [0, 0xFFFF]

--- a/devices/fields/usb_otg/otg_fs_host_f4.yaml
+++ b/devices/fields/usb_otg/otg_fs_host_f4.yaml
@@ -1,0 +1,161 @@
+# Note: if you want to include `OTG_FS_GLOBAL`, `OTG_FS_DEVICE`, `OTG_FS_HOST` and `OTG_FS_PWRCLK`,
+# then try include `../peripherals/otg_fs_f4.yaml` into device yaml file instead.
+#
+# the main frame of this file was generated from stm32f429.svd.patched
+
+HCFG:
+  FSLSS:
+    FSLSOnly: [1, "FS/LS-only, even if the connected device can support HS (read-only)"]
+  FSLSPCS:
+    Clock48MHz: [1, "Select 48 MHz PHY clock frequency"]
+    Clock6MHz: [2, "Select 6 MHz PHY clock frequency"]
+
+HFIR:
+  FRIVL: [0, 0xFFFF]
+
+HFNUM:
+  FTREM: [0, 0xFFFF]
+  FRNUM: [0, 0x3FFF]
+
+HPTXSTS:
+  PTXQTOP: [0, 0xFF]
+  PTXQSAV: [0, 0xFF]
+  PTXFSAVL: [0, 0xFFFF]
+
+HAINT:
+  HAINT: [0, 0xFFFF]
+
+HAINTMSK:
+  HAINTM: [0, 0xFFFF]
+
+HPRT:
+  PSPD:
+    FullSpeed: [1, "Full speed"]
+    LowSpeed: [2, "Low speed"]
+  PTCTL:
+    Disabled: [0, "Test mode disabled"]
+    JMode: [1, "Test_J mode"]
+    KMode: [2, "Test_K mode"]
+    SE0NAK: [3, "Test_SE0_NAK mode"]
+    Packet: [4, "Test_Packet mode"]
+    ForceEnable: [5, "Test_Force_Enable"]
+  PPWR:
+    Off: [0, "Power Off"]
+    On: [1, "Power On"]
+  PLSTS: [0, 3]
+  PRST:
+    NotReset: [0, "Port not in reset"]
+    Reset: [1, "Port in reset"]
+  PSUSP:
+    NotSuspended: [0, "Port not in Suspend mode"]
+    Suspended: [1, "Port in Suspend mode"]
+  PRES:
+    NotDriven: [0, "No resume driven"]
+    Driven: [1, "Resume driven"]
+  POCCHNG: [0, 1]
+  POCA:
+    NoOvercurrent: [0, "No overcurrent condition"]
+    Overcurrent: [1, "Overcurrent condition"]
+  PENCHNG: [0, 1]
+  PENA:
+    Disabled: [0, "Port disabled"]
+    Enabled: [1, "Port enabled"]
+  PCDET: [0, 1]
+  PCSTS:
+    NotAttached: [0, "No device is attached to the port"]
+    Attached: [1, "A device is attached to the port"]
+
+HCCHAR[0-7]:
+  CHENA:
+    Disabled: [0, "Channel disabled"]
+    Enabled: [1, "Channel enabled"]
+  CHDIS: [0, 1]
+  ODDFRM:
+    Even: [0, "Even frame"]
+    Odd: [1, "Odd frame"]
+  DAD: [0, 0x7F]
+  MCNT:
+    One: [1, "1 transaction"]
+    Two: [2, "2 transactions per frame to be issued for this endpoint"]
+    Three: [3, "3 transactions per frame to be issued for this endpoint"]
+  EPTYP:
+    Bulk: [0, "Bulk endpoint"]
+    Control: [1, "Control endpoint"]
+    Iso: [2, "Iso endpoint"]
+    Interrupt: [3, "Interrupt endpoint"]
+  LSDEV: [0, 1]
+  EPDIR:
+    Out: [0, "OUT"]
+    In: [1, "IN"]
+  EPNUM: [0, 0xF]
+  MPSIZ: [0, 0x7FF]
+
+HCINT[0-7]:
+  DTERR:
+    NoError: [0, ""]
+    Error: [1, ""]
+  FRMOR:
+    NoOverrun: [0, ""]
+    Overrun: [1, ""]
+  BBERR:
+    NoError: [0, ""]
+    Error: [1, ""]
+  TXERR:
+    NoError: [0, ""]
+    Error: [1, ""]
+  ACK:
+    NotACK: [0, ""]
+    ACK: [1, ""]
+  NAK:
+    NotNAK: [0, ""]
+    NAK: [1, ""]
+  STALL:
+    NotStall: [0, ""]
+    Stall: [1, ""]
+  CHH:
+    NotHalt: [0, ""]
+    Halt: [1, ""]
+  XFRC:
+    NotCompleted: [0, ""]
+    Completed: [1, ""]
+
+HCINTMSK[0-7]:
+  DTERRM:
+    Masked: [0, "Masked interrupt"]
+    Unmasked: [1, "Unmasked interrupt"]
+  FRMORM:
+    Masked: [0, "Masked interrupt"]
+    Unmasked: [1, "Unmasked interrupt"]
+  BBERRM:
+    Masked: [0, "Masked interrupt"]
+    Unmasked: [1, "Unmasked interrupt"]
+  TXERRM:
+    Masked: [0, "Masked interrupt"]
+    Unmasked: [1, "Unmasked interrupt"]
+  NYET:
+    Masked: [0, "Masked interrupt"]
+    Unmasked: [1, "Unmasked interrupt"]
+  ACKM:
+    Masked: [0, "Masked interrupt"]
+    Unmasked: [1, "Unmasked interrupt"]
+  NAKM:
+    Masked: [0, "Masked interrupt"]
+    Unmasked: [1, "Unmasked interrupt"]
+  STALLM:
+    Masked: [0, "Masked interrupt"]
+    Unmasked: [1, "Unmasked interrupt"]
+  CHHM:
+    Masked: [0, "Masked interrupt"]
+    Unmasked: [1, "Unmasked interrupt"]
+  XFRCM:
+    Masked: [0, "Masked interrupt"]
+    Unmasked: [1, "Unmasked interrupt"]
+
+HCTSIZ[0-7]:
+  DPID:
+    Data0: [0, ""]
+    Data1: [2, ""]
+    Data2: [1, ""]
+    MData: [3, ""]
+  PKTCNT: [0, 0x3FF]
+  XFRSIZ: [0, 0x7_FFFF]

--- a/devices/fields/usb_otg/otg_fs_pwrclk_f4.yaml
+++ b/devices/fields/usb_otg/otg_fs_pwrclk_f4.yaml
@@ -1,0 +1,11 @@
+# Note: if you want to include `OTG_FS_GLOBAL`, `OTG_FS_DEVICE`, `OTG_FS_HOST` and `OTG_FS_PWRCLK`,
+# then try include `../peripherals/otg_fs_f4.yaml` into device yaml file instead.
+#
+# the main frame of this file was generated from stm32f429.svd.patched
+
+PCGCCTL:
+  PHYSUSP:
+    NotSuspended: [0, ""]
+    Suspended: [1, ""]
+  GATEHCLK: [0, 1]
+  STPPCLK: [0, 1]

--- a/devices/patches/usb_otg/fs_f4_device.yaml
+++ b/devices/patches/usb_otg/fs_f4_device.yaml
@@ -1,0 +1,153 @@
+# this file is for STM32F401, F411, F405, F407, F427, F429
+# and can be included into (currently non-exist) F417, F437, F439 yaml in future
+#
+# for maintainer of F412, F413, F423, F446, F469, F479:
+# this file might not be suitable for these devices,
+# double check if you want to include
+
+DIEPMSK:
+  _add:
+    NAKM:
+      description: NAK interrupt mask
+      bitOffset: 13
+      bitWidth: 1
+DOEPMSK:
+  _add:
+    NAKMSK:
+      description: NAK interrupt mask
+      bitOffset: 13
+      bitWidth: 1
+    BERRM:
+      description: NAK interrupt mask
+      bitOffset: 12
+      bitWidth: 1
+    OUTPKTERRM:
+      description: Out packet error mask
+      bitOffset: 8
+      bitWidth: 1
+    STSPHSRXM:
+      description: Status phase received for control write mask
+      bitOffset: 5
+      bitWidth: 1
+DIEPCTL0:
+  _modify:
+    EPTYP:
+      description: "Endpoint type\nHardcoded to '00' for control"
+    USBAEP:
+      description: "USB active endpoint\nThis bit is always set to 1, indicating that control endpoint 0 is always active in all configurations and interfaces"
+DIEPCTL1:
+  _add:
+    SODDFRM:
+      description: Set odd frame
+      bitOffset: 29
+      bitWidth: 1
+DIEPCTL[1-3]:
+  _modify:
+    SD0PID_SEVNFRM: # 2 flags are occupied same bit field, "split" them
+      name: SD0PID
+      description: "Set DATA0 PID"
+    EONUM_DPID: # 2 flags are occupied same bit field, "split" them
+      name: EONUM
+      description: "Even/odd frame"
+  _add:
+    SEVNFRM: # this flag is "split" from `SD0PID_SEVNFRM` field
+      description: Set even frame
+      bitOffset: 28
+      bitWidth: 1
+      access: write-only
+    DPID: # this flag is "split" from `EONUM_DPID` field
+      description: Endpoint data PID
+      bitOffset: 16
+      bitWidth: 1
+      access: read-only
+  _delete:
+    - "SODDFRM_SD1PID"
+DOEPCTL0:
+  _modify:
+    EPDIS:
+      description: "Endpoint disable\nThe application CANNOT disable control OUT endpoint 0.\nEndpoint disable"
+    EPTYP:
+      description: "Endpoint type\nHardcoded to '00' for control"
+    USBAEP:
+      description: "USB active endpoint\nThis bit is always set to 1, indicating that control endpoint 0 is always active in all configurations and interfaces"
+DOEPCTL[1-3]:
+  _modify:
+    SD0PID_SEVNFRM: # 2 flags are occupied same bit field, "split" them
+      name: SD0PID
+      description: Set DATA0 PID
+    EONUM_DPID: # 2 flags are occupied same bit field, "split" them
+      name: EONUM
+      description: Even/odd frame
+  _add:
+    # some other file has remove SODDFRM_SD1PID and create SODDFRM
+    # we need to create SD1PID itself
+    SD1PID:
+      description: Set DATA1 PID
+      bitOffset: 29
+      bitWidth: 1
+      access: write-only
+    SEVNFRM: # this flag is "split" from `SD0PID_SEVNFRM` field
+      description: Set odd frame
+      bitOffset: 28
+      bitWidth: 1
+      access: write-only
+    DPID: # this flag is "split" from `EONUM_DPID` field
+      description: Endpoint data PID
+      bitOffset: 16
+      bitWidth: 1
+      access: read-only
+DIEPINT[0-3]:
+  _add:
+    NAK:
+      description: NAK input
+      bitOffset: 13
+      bitWidth: 1
+      access: read-write
+    PKTDRPSTS:
+      description: Packet dropped status
+      bitOffset: 11
+      bitWidth: 1
+      access: read-write
+    INEPNM:
+      description: IN token received with EP mismatch
+      bitOffset: 5
+      bitWidth: 1
+      access: read-write
+DOEPINT[0-3]:
+  _delete:
+    - B2BSTUP
+  _add:
+    NAK:
+      description: NAK input
+      bitOffset: 13
+      bitWidth: 1
+      access: read-write
+    BERR:
+      description: Babble error interrupt
+      bitOffset: 12
+      bitWidth: 1
+      access: read-write
+    OUTPKTERR:
+      description: OUT packet error
+      bitOffset: 8
+      bitWidth: 1
+      access: read-write
+    STSPHSRX:
+      description: Status phase received for control write
+      bitOffset: 5
+      bitWidth: 1
+      access: read-write
+DIEPTSIZ[1-3]:
+  _delete:
+    - MCNT
+DOEPTSIZ[1-3]:
+  _modify:
+    RXDPID_STUPCNT:
+      name: RXDPID
+      description: Received data PID
+  _add:
+    STUPCNT:
+      description: SETUP packet count
+      bitOffset: 29
+      bitWidth: 2
+      access: read-write

--- a/devices/patches/usb_otg/fs_f4_global.yaml
+++ b/devices/patches/usb_otg/fs_f4_global.yaml
@@ -1,0 +1,46 @@
+# this file is for STM32F401, F411, F405, F407, F427, F429
+# and can be included into (currently non-exist) F417, F437, F439 yaml in future
+#
+# for maintainer of F412, F413, F423, F446, F469, F479:
+# this file might not be suitable for these devices,
+# double check if you want to include
+
+_modify:
+  GNPTXSTS:
+    name: HNPTXSTS
+GAHBCFG:
+  _modify:
+    GINT:
+      name: GINTMSK
+GUSBCFG:
+  _modify:
+    CTXPKT:
+      description: "Corrupt Tx packet\nNever set this bit to 1. This bit is for debug purposes only"
+    PHYSEL:
+      access: read-only
+GINTSTS:
+  _modify:
+    IPXFR_INCOMPISOOUT: # 2 state flags are occupied same bit field, "split" them
+      name: IPXFR
+      description: "Incomplete periodic transfer"
+  _add:
+    INCOMPISOOUT: # this flag is "split" from `IPXFR_INCOMPISOOUT` field
+      description: "Incomplete isochronous OUT transfer"
+      bitOffset: 21
+      bitWidth: 1
+      access: read-write
+GINTMSK:
+  _modify:
+    IPXFRM_IISOOXFRM: # 2 state flags are occupied same bit field, "split" them
+      name: IPXFRM
+      description: Incomplete periodic transfer mask
+  _add:
+    IISOOXFRM:
+      description: "Incomplete isochronous OUT transfer mask"
+      bitOffset: 21
+      bitWidth: 1
+      access: read-write
+HPTXFSIZ:
+  _modify:
+    PTXFSIZ:
+      name: PTXFD

--- a/devices/stm32f401.yaml
+++ b/devices/stm32f401.yaml
@@ -110,17 +110,24 @@ OTG_FS_*:
 OTG_FS_DEVICE:
   _include:
     - patches/usb_otg/fs_v1_device.yaml
+    - patches/usb_otg/fs_f4_device.yaml
+    - fields/usb_otg/otg_fs_device_f4.yaml
     - collect/usb_otg/fs_device.yaml
 OTG_FS_GLOBAL:
   _include:
     - patches/usb_otg/fs_v1_global.yaml
     - patches/usb_otg/fs_v1_novbussens.yaml
+    - patches/usb_otg/fs_f4_global.yaml
+    - fields/usb_otg/otg_fs_global_f4.yaml
     - collect/usb_otg/fs_global.yaml
 OTG_FS_HOST:
   _include:
     - patches/usb_otg/fs_v1_host.yaml
+    - fields/usb_otg/otg_fs_host_f4.yaml
     - collect/usb_otg/fs_host.yaml
-OTG_FS_PWRCLK: {}
+OTG_FS_PWRCLK:
+  _include:
+    - fields/usb_otg/otg_fs_pwrclk_f4.yaml
 
 PWR:
   CR:

--- a/devices/stm32f405.yaml
+++ b/devices/stm32f405.yaml
@@ -154,21 +154,31 @@ OTG_FS_*:
 
 OTG_FS_DEVICE:
   _include:
-    - patches/usb_otg/fs_v1_device_ext.yaml
+    # the file below create DIEP*[4-5] and DOEP*[4-5], which is not exist for this device
+    # but there are some other registers created in the same file
+    # I will just comment it out for now, until we can safely remove it
+    #- patches/usb_otg/fs_v1_device_ext.yaml
     - patches/usb_otg/fs_v1_device.yaml
+    - patches/usb_otg/fs_f4_device.yaml
+    - fields/usb_otg/otg_fs_device_f4.yaml
     - collect/usb_otg/fs_device.yaml
 OTG_FS_GLOBAL:
   _include:
-    - patches/usb_otg/fs_v1_global_ext.yaml
+    #- patches/usb_otg/fs_v1_global_ext.yaml
     - patches/usb_otg/fs_v1_global.yaml
     - patches/usb_otg/fs_v1_novbussens.yaml
+    - patches/usb_otg/fs_f4_global.yaml
+    - fields/usb_otg/otg_fs_global_f4.yaml
     - collect/usb_otg/fs_global.yaml
 OTG_FS_HOST:
   _include:
-    - patches/usb_otg/fs_v1_host_ext.yaml
+    #- patches/usb_otg/fs_v1_host_ext.yaml
     - patches/usb_otg/fs_v1_host.yaml
+    - fields/usb_otg/otg_fs_host_f4.yaml
     - collect/usb_otg/fs_host.yaml
-OTG_FS_PWRCLK: {}
+OTG_FS_PWRCLK:
+  _include:
+    - fields/usb_otg/otg_fs_pwrclk_f4.yaml
 
 OTG_HS_*:
   _strip: OTG_HS_

--- a/devices/stm32f407.yaml
+++ b/devices/stm32f407.yaml
@@ -152,21 +152,31 @@ OTG_FS_*:
 
 OTG_FS_DEVICE:
   _include:
-    - patches/usb_otg/fs_v1_device_ext.yaml
+    # the file below create DIEP*[4-5] and DOEP*[4-5], which is not exist for this device
+    # but there are some other registers created in the same file
+    # I will just comment it out for now, until we can safely remove it
+    #- patches/usb_otg/fs_v1_device_ext.yaml
     - patches/usb_otg/fs_v1_device.yaml
+    - patches/usb_otg/fs_f4_device.yaml
+    - fields/usb_otg/otg_fs_device_f4.yaml
     - collect/usb_otg/fs_device.yaml
 OTG_FS_GLOBAL:
   _include:
-    - patches/usb_otg/fs_v1_global_ext.yaml
+    #- patches/usb_otg/fs_v1_global_ext.yaml
     - patches/usb_otg/fs_v1_global.yaml
     - patches/usb_otg/fs_v1_novbussens.yaml
+    - patches/usb_otg/fs_f4_global.yaml
+    - fields/usb_otg/otg_fs_global_f4.yaml
     - collect/usb_otg/fs_global.yaml
 OTG_FS_HOST:
   _include:
-    - patches/usb_otg/fs_v1_host_ext.yaml
+    #- patches/usb_otg/fs_v1_host_ext.yaml
     - patches/usb_otg/fs_v1_host.yaml
+    - fields/usb_otg/otg_fs_host_f4.yaml
     - collect/usb_otg/fs_host.yaml
-OTG_FS_PWRCLK: {}
+OTG_FS_PWRCLK:
+  _include:
+    - fields/usb_otg/otg_fs_pwrclk_f4.yaml
 
 OTG_HS_*:
   _strip: OTG_HS_

--- a/devices/stm32f411.yaml
+++ b/devices/stm32f411.yaml
@@ -105,17 +105,24 @@ OTG_FS_*:
 OTG_FS_DEVICE:
   _include:
     - patches/usb_otg/fs_v1_device.yaml
+    - patches/usb_otg/fs_f4_device.yaml
+    - fields/usb_otg/otg_fs_device_f4.yaml
     - collect/usb_otg/fs_device.yaml
 OTG_FS_GLOBAL:
   _include:
     - patches/usb_otg/fs_v1_global.yaml
     - patches/usb_otg/fs_v1_novbussens.yaml
+    - patches/usb_otg/fs_f4_global.yaml
+    - fields/usb_otg/otg_fs_global_f4.yaml
     - collect/usb_otg/fs_global.yaml
 OTG_FS_HOST:
   _include:
     - patches/usb_otg/fs_v1_host.yaml
+    - fields/usb_otg/otg_fs_host_f4.yaml
     - collect/usb_otg/fs_host.yaml
-OTG_FS_PWRCLK: {}
+OTG_FS_PWRCLK:
+  _include:
+    - fields/usb_otg/otg_fs_pwrclk_f4.yaml
 
 PWR:
   _include:

--- a/devices/stm32f412.yaml
+++ b/devices/stm32f412.yaml
@@ -209,11 +209,13 @@ OTG_FS_DEVICE:
   _include:
     - patches/usb_otg/fs_v1_device_ext.yaml
     - patches/usb_otg/fs_v1_device.yaml
+    #- patches/usb_otg/fs_f4_device.yaml # read fs_f4.yaml before activate this
     - collect/usb_otg/fs_device.yaml
 OTG_FS_GLOBAL:
   _include:
     - patches/usb_otg/fs_v1_global_ext.yaml
     - patches/usb_otg/fs_v1_global.yaml
+    #- fields/usb_otg/otg_fs_global_f4.yaml # read fs_f4.yaml before activate this
     - collect/usb_otg/fs_global.yaml
 OTG_FS_HOST:
   _include:

--- a/devices/stm32f413.yaml
+++ b/devices/stm32f413.yaml
@@ -207,6 +207,7 @@ OTG_FS_DEVICE:
   _include:
     - patches/usb_otg/fs_v1_device_ext.yaml
     - patches/usb_otg/fs_v1_device.yaml
+    #- patches/usb_otg/fs_f4_device.yaml # read fs_f4.yaml before activate this
     - collect/usb_otg/fs_device.yaml
 
 # Fix invalid formatting on this alternateRegister field
@@ -219,6 +220,7 @@ OTG_FS_GLOBAL:
   _include:
     - patches/usb_otg/fs_v1_global_ext.yaml
     - patches/usb_otg/fs_v1_global.yaml
+    #- fields/usb_otg/otg_fs_global_f4.yaml # read fs_f4.yaml before activate this
     - collect/usb_otg/fs_global.yaml
 
 OTG_FS_HOST:

--- a/devices/stm32f427.yaml
+++ b/devices/stm32f427.yaml
@@ -184,21 +184,31 @@ OTG_FS_*:
 
 OTG_FS_DEVICE:
   _include:
-    - patches/usb_otg/fs_v1_device_ext.yaml
+    # the file below create DIEP*[4-5] and DOEP*[4-5], which is not exist for this device
+    # but there are some other registers created in the same file
+    # I will just comment it out for now, until we can safely remove it
+    #- patches/usb_otg/fs_v1_device_ext.yaml
     - patches/usb_otg/fs_v1_device.yaml
+    - patches/usb_otg/fs_f4_device.yaml
+    - fields/usb_otg/otg_fs_device_f4.yaml
     - collect/usb_otg/fs_device.yaml
 OTG_FS_GLOBAL:
   _include:
-    - patches/usb_otg/fs_v1_global_ext.yaml
+    #- patches/usb_otg/fs_v1_global_ext.yaml
     - patches/usb_otg/fs_v1_global.yaml
     - patches/usb_otg/fs_v1_novbussens.yaml
+    - patches/usb_otg/fs_f4_global.yaml
+    - fields/usb_otg/otg_fs_global_f4.yaml
     - collect/usb_otg/fs_global.yaml
 OTG_FS_HOST:
   _include:
-    - patches/usb_otg/fs_v1_host_ext.yaml
+    #- patches/usb_otg/fs_v1_host_ext.yaml
     - patches/usb_otg/fs_v1_host.yaml
+    - fields/usb_otg/otg_fs_host_f4.yaml
     - collect/usb_otg/fs_host.yaml
-OTG_FS_PWRCLK: {}
+OTG_FS_PWRCLK:
+  _include:
+    - fields/usb_otg/otg_fs_pwrclk_f4.yaml
 
 OTG_HS_*:
   _strip: OTG_HS_

--- a/devices/stm32f429.yaml
+++ b/devices/stm32f429.yaml
@@ -175,21 +175,31 @@ OTG_FS_*:
 
 OTG_FS_DEVICE:
   _include:
-    - patches/usb_otg/fs_v1_device_ext.yaml
+    # the file below create DIEP*[4-5] and DOEP*[4-5], which is not exist for this device
+    # but there are some other registers created in the same file
+    # I will just comment it out for now, until we can safely remove it
+    #- patches/usb_otg/fs_v1_device_ext.yaml
     - patches/usb_otg/fs_v1_device.yaml
+    - patches/usb_otg/fs_f4_device.yaml
+    - fields/usb_otg/otg_fs_device_f4.yaml
     - collect/usb_otg/fs_device.yaml
 OTG_FS_GLOBAL:
   _include:
-    - patches/usb_otg/fs_v1_global_ext.yaml
+    #- patches/usb_otg/fs_v1_global_ext.yaml
     - patches/usb_otg/fs_v1_global.yaml
     - patches/usb_otg/fs_v1_novbussens.yaml
+    - patches/usb_otg/fs_f4_global.yaml
+    - fields/usb_otg/otg_fs_global_f4.yaml
     - collect/usb_otg/fs_global.yaml
 OTG_FS_HOST:
   _include:
-    - patches/usb_otg/fs_v1_host_ext.yaml
+    #- patches/usb_otg/fs_v1_host_ext.yaml
     - patches/usb_otg/fs_v1_host.yaml
+    - fields/usb_otg/otg_fs_host_f4.yaml
     - collect/usb_otg/fs_host.yaml
-OTG_FS_PWRCLK: {}
+OTG_FS_PWRCLK:
+  _include:
+    - fields/usb_otg/otg_fs_pwrclk_f4.yaml
 
 OTG_HS_*:
   _strip: OTG_HS_

--- a/devices/stm32f446.yaml
+++ b/devices/stm32f446.yaml
@@ -185,6 +185,7 @@ OTG_FS_DEVICE:
   _strip: OTG_FS_
   _include:
     - patches/usb_otg/fs_v2_device.yaml
+    #- patches/usb_otg/fs_f4_device.yaml # read fs_f4.yaml before activate this
     - collect/usb_otg/fs_device.yaml
 OTG_FS_GLOBAL:
   _strip: OTG_FS_
@@ -197,6 +198,7 @@ OTG_FS_HOST:
   _include:
     - patches/usb_otg/fs_host_addr.yaml
     - patches/usb_otg/fs_v2_host.yaml
+    #- fields/usb_otg/otg_fs_global_f4.yaml # read fs_f4.yaml before activate this
     - collect/usb_otg/fs_host.yaml
 OTG_FS_PWRCLK:
   _strip: FS_

--- a/devices/stm32f469.yaml
+++ b/devices/stm32f469.yaml
@@ -193,12 +193,14 @@ OTG_FS_DEVICE:
   _strip: OTG_FS_
   _include:
     - patches/usb_otg/fs_v2_device.yaml
+    #- patches/usb_otg/fs_f4_device.yaml # read fs_f4.yaml before activate this
     - collect/usb_otg/fs_device.yaml
 OTG_FS_GLOBAL:
   _strip: OTG_FS_
   _include:
     - patches/usb_otg/fs_fixes_446_469.yaml
     - patches/usb_otg/fs_v2_global.yaml
+    #- fields/usb_otg/otg_fs_global_f4.yaml # read fs_f4.yaml before activate this
     - collect/usb_otg/fs_global.yaml
 OTG_FS_HOST:
   _strip: OTG_FS_


### PR DESCRIPTION
Note:
renaming branch lead to accidently close #849. 

---------

not affect at all:
F410, which has no `OTG` peripheral.

doc on `OTG_FS_GLOBAL`, `OTG_FS_DEVICE`, `OTG_FS_HOST` and `OTG_FS_PWRCLK`(`OTG_FS_PCGCCTL`) peripherals for `F4` device with a standalone `OTG_FS` section:  
include 401, 411, 405, 407, ~417~(not in repo) , 427, ~437~(not in repo), 429, ~439~(not in repo)  
not include 412, 413, ~423~(not in repo), 446, 469, ~479~(not in repo)  