### PR TITLE
Add I2C5 to stm32h735.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 * Add USART v2C peripheral on G4
 * doc on `RNG` peripheral for STM32F4 ([#870])
 * H7: fix GPIO register reset values (#973)
+* H735: add I2C5
 * Doc `QUADSPI` peripheral ([#875])
     * `DR` register can be access by 1 byte, half word and full word. Use `.dr8()`, `.dr16()`, `.dr()` to access this register.
 

--- a/devices/stm32h735.yaml
+++ b/devices/stm32h735.yaml
@@ -86,6 +86,17 @@ _add:
         description: USART10 global interrupt
         value: 156
 
+  I2C5:
+    derivedFrom: I2C1
+    baseAddress: 0x40006400
+    interrupts:
+      I2C5_EV:
+        description: I2C5 event interrupt
+        value: 157
+      I2C5_ER:
+        description: I2C5 error interrupt
+        value: 158
+
   # Additional timers
   TIM23:
     derivedFrom: TIM2


### PR DESCRIPTION
Add I2C5 according to the latest SVD file:

```
<peripheral derivedFrom="I2C1">
      <name>I2C5</name>
      <baseAddress>0x40006400</baseAddress>
      <interrupt>
        <name>I2C5_EV</name>
        <description>I2C5 event interrupt</description>
        <value>157</value>
      </interrupt>
      <interrupt>
        <name>I2C5_ER</name>
        <description>I2C5 error interrupt</description>
        <value>158</value>
      </interrupt>
    </peripheral>
```