### PR TITLE
Add dual bank related fields to stm32g4 cat 3 devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 * Update RNG for stm32h735
 * H5: Add CRS, WWDG, IWDG, I2C, SBS, PWR, GPIO, EXTI, GPDMA, SPI, UART, RCC, TIM1-8 definitios
 * Add GPIOx:HSLVR
+* Add dual bank flash related fields to g4 cat 3 devices
 * Merge USART BRR fields on G4
 * Add G4 DAC peripheral
 * Fix incorrectly used `_read`, `_modify`

--- a/devices/common_patches/flash/g4_dual_bank.yaml
+++ b/devices/common_patches/flash/g4_dual_bank.yaml
@@ -1,0 +1,28 @@
+"FLASH":
+  _modify:
+    OPTR:
+      resetValue: 0xFFEFF8AA
+  OPTR:
+    _add:
+      DBANK:
+        description: Single or dual bank mode
+        bitOffset: 22
+        bitWidth: 1
+      BFB2:
+        description: Bank to boot from
+        bitOffset: 20
+        bitWidth: 1
+  CR:
+    _add:
+      BKER:
+        description: Bank erase
+        bitOffset: 11
+        bitWidth: 1
+      MER2:
+        description: Bank 2 Mass erase
+        bitOffset: 15
+        bitWidth: 1
+      SEC_PROT2:
+        description: Securable memory area protection bit for bank 2.
+        bitOffset: 29
+        bitWidth: 1

--- a/devices/stm32g471.yaml
+++ b/devices/stm32g471.yaml
@@ -58,4 +58,6 @@ _include:
  - common_patches/tim/v2/g4.yaml
  - ../peripherals/tim/v2/ccm.yaml
  - collect/tim/ccr.yaml
+ - common_patches/flash/g4_dual_bank.yaml
  - ../peripherals/flash/flash_g4.yaml
+ - ../peripherals/flash/flash_g4_dual_bank.yaml

--- a/devices/stm32g473.yaml
+++ b/devices/stm32g473.yaml
@@ -70,4 +70,6 @@ _include:
  - common_patches/tim/v2/g4.yaml
  - ../peripherals/tim/v2/ccm.yaml
  - collect/tim/ccr.yaml
+ - common_patches/flash/g4_dual_bank.yaml
  - ../peripherals/flash/flash_g4.yaml
+ - ../peripherals/flash/flash_g4_dual_bank.yaml

--- a/devices/stm32g474.yaml
+++ b/devices/stm32g474.yaml
@@ -72,4 +72,6 @@ _include:
  - common_patches/tim/v2/g4.yaml
  - ../peripherals/tim/v2/ccm.yaml
  - collect/tim/ccr.yaml
+ - common_patches/flash/g4_dual_bank.yaml
  - ../peripherals/flash/flash_g4.yaml
+ - ../peripherals/flash/flash_g4_dual_bank.yaml

--- a/devices/stm32g483.yaml
+++ b/devices/stm32g483.yaml
@@ -71,4 +71,6 @@ _include:
  - common_patches/tim/v2/g4.yaml
  - ../peripherals/tim/v2/ccm.yaml
  - collect/tim/ccr.yaml
+ - common_patches/flash/g4_dual_bank.yaml
  - ../peripherals/flash/flash_g4.yaml
+ - ../peripherals/flash/flash_g4_dual_bank.yaml

--- a/devices/stm32g484.yaml
+++ b/devices/stm32g484.yaml
@@ -72,4 +72,6 @@ _include:
  - common_patches/tim/v2/g4.yaml
  - ../peripherals/tim/v2/ccm.yaml
  - collect/tim/ccr.yaml
+ - common_patches/flash/g4_dual_bank.yaml
  - ../peripherals/flash/flash_g4.yaml
+ - ../peripherals/flash/flash_g4_dual_bank.yaml

--- a/peripherals/flash/flash_g4_dual_bank.yaml
+++ b/peripherals/flash/flash_g4_dual_bank.yaml
@@ -1,0 +1,15 @@
+# Flash Peripheral
+# Applicable to STM32G4 category 3 devices only
+
+FLASH:
+  OPTR:
+    DBANK:
+      SingleBankMode: [ 0, "Single-bank mode with 128 bits data read width" ]
+      DualBankMode: [ 1, "Dual-bank mode with 64 bits data" ]
+    BFB2:
+      Disabled: [ 0, "Boot from memory bank 1" ]
+      Enabled: [ 1, "Boot from memory bank 2" ]
+  CR:
+    BKER:
+      Bank1: [ 0, "Bank 1 is selected for page erase" ]
+      Bank2: [ 1, "Bank 2 is selected for page erase" ]


### PR DESCRIPTION
This adds the missing dual bank flash related fields to stm32g4 devices:
* stm32g471
* stm32g473
* stm32g474
* stm32g483
* stm32g484