### PR TITLE
Add RCC definitions for H5 family

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-* Remove workaround for bug in duckscript's `mv` 
+* Remove workaround for bug in duckscript's `mv`
 * Replace `makehtml.py` with `svd2html`
 * Updated to svd2rust 0.30.0, svdtools 0.3.0, use tools binaries for CI
 * Enable atomic operations on register support, Rust edition 2021 (#846)
@@ -11,6 +11,7 @@
 * DMAMUX: merge registers in arrays
 * STM32U5xx: Update SVD version and add variants for xx=35,45,95,A5,99,A9 (#844)
 * Fix ADC SR OVR enums
+* H5: Add RCC definitions
 
 [#854]: https://github.com/stm32-rs/stm32-rs/pull/854
 

--- a/devices/common_patches/h5.yaml
+++ b/devices/common_patches/h5.yaml
@@ -127,3 +127,6 @@ WWDG:
 #   _modify:
 #     CNT_alternate:
 #       name: "CNT"
+
+_include:
+  - ./rcc/h5.yaml

--- a/devices/common_patches/rcc/h5.yaml
+++ b/devices/common_patches/rcc/h5.yaml
@@ -1,0 +1,88 @@
+RCC:
+  AHB2ENR:
+    _modify:
+      ADC1EN:
+        name: ADCEN
+        description: ADC peripherals clock enabled
+
+  AHB2LPENR:
+    _modify:
+      ADC1LPEN:
+        name: ADCLPEN
+        description: ADC peripherals clock enable during sleep mode
+
+  AHB2RSTR:
+    _modify:
+      ADC1RST:
+        name: ADCRST
+        description: ADC block reset
+
+  APB1HENR:
+    _modify:
+      FDCAN1EN:
+        name: FDCANEN
+        description: FDCAN peripheral clock enable
+
+  APB1HLPENR:
+    _modify:
+      FDCAN1LPEN:
+        name: FDCANLPEN
+        description: FDCAN peripheral clock enable during sleep mode
+
+  APB1HRSTR:
+    _modify:
+      FDCAN1RST:
+        name: FDCANRST
+        description: FDCAN block reset
+
+  APB2ENR:
+    _modify:
+      USBFSEN:
+        name: USBEN
+        description: USB clock enable
+
+  APB2LPENR:
+    _modify:
+      USBFSLPEN:
+        name: USBLPEN
+        description: USB clock enable during sleep mode
+
+  APB2RSTR:
+    _modify:
+      USBFSRST:
+        name: USBRST
+        description: USB block reset
+
+  _modify:
+    CFGR:           # There are 2 CFGR registers on the H5
+      name: CFGR1
+      displayName: CFGR1
+
+  CFGR1:
+    _modify:
+      SW:
+        bitWidth: 2
+      SWS:
+        bitWidth: 2
+
+  PLL1CFGR:
+    _modify:
+      DIVM1:
+        name: PLL1M
+
+  PLL2CFGR:
+    _modify:
+      DIVM2:
+        name: PLL2M
+
+  CCIPR4:
+    _modify:
+      USBFSSEL:
+        name: USBSEL
+        description: USB kernel clock source selection
+
+  CCIPR5:
+    _modify:
+      FDCAN12SEL:
+        name: FDCANSEL
+        description: FDCAN kernel clock source selection

--- a/devices/common_patches/rcc/h503.yaml
+++ b/devices/common_patches/rcc/h503.yaml
@@ -1,0 +1,35 @@
+RCC:
+  _add:
+    PRIVCFGR:
+      description: RCC privilege configuration register
+      addressOffset: 0x114
+      access: read-write
+      fields:
+        PRIV:
+          description: RCC functions privilege configuration
+          bitOffset: 1
+          bitWidth: 1
+          access: read-write
+
+  AHB1ENR:
+    _add:
+      GTZC1EN:
+        description: GTZC1 clock enable
+        bitOffset: 24
+        bitWidth: 1
+        access: read-write
+
+  AHB1LPENR:
+    _add:
+      GTZC1LPEN:
+        description: GTZC1 clock enable during sleep mode
+        bitOffset: 24
+        bitWidth: 1
+        access: read-write
+
+  CCIPR5:
+    _modify:
+      DACSEL:
+        name: DAC1SEL
+      FDCAN1SEL:
+        name: FDCANSEL

--- a/devices/stm32h503.yaml
+++ b/devices/stm32h503.yaml
@@ -1,4 +1,8 @@
 _svd: ../svd/stm32h503.svd
 
 _include:
-  - common_patches/h5.yaml
+  - ./common_patches/h5.yaml
+
+  - ./common_patches/rcc/h503.yaml
+
+  - ../peripherals/rcc/rcc_h503.yaml

--- a/devices/stm32h562.yaml
+++ b/devices/stm32h562.yaml
@@ -16,9 +16,7 @@ _include:
 
   - ../peripherals/gpio/v3/common.yaml
 
-  # - ../peripherals/rcc/rcc_v3.yaml
-  # - ../peripherals/rcc/rcc_v3_pll.yaml
-  # - ../peripherals/rcc/rcc_v3_h7_ccip.yaml
+  - ../peripherals/rcc/rcc_h5.yaml
 
   - common_patches/rtc/alarm.yaml
   # - common_patches/rtc/rtc_bkpr.yaml

--- a/devices/stm32h563.yaml
+++ b/devices/stm32h563.yaml
@@ -15,9 +15,7 @@ _include:
 
   - ../peripherals/gpio/v3/common.yaml
 
-  # - ../peripherals/rcc/rcc_v3.yaml
-  # - ../peripherals/rcc/rcc_v3_pll.yaml
-  # - ../peripherals/rcc/rcc_v3_h7_ccip.yaml
+  - ../peripherals/rcc/rcc_h5.yaml
 
   - common_patches/rtc/alarm.yaml
   # - common_patches/rtc/rtc_bkpr.yaml

--- a/devices/stm32h573.yaml
+++ b/devices/stm32h573.yaml
@@ -15,9 +15,7 @@ _include:
 
   - ../peripherals/gpio/v3/common.yaml
 
-  # - ../peripherals/rcc/rcc_v3.yaml
-  # - ../peripherals/rcc/rcc_v3_pll.yaml
-  # - ../peripherals/rcc/rcc_v3_h7_ccip.yaml
+  - ../peripherals/rcc/rcc_h5.yaml
 
   - common_patches/rtc/alarm.yaml
   # - common_patches/rtc/rtc_bkpr.yaml

--- a/peripherals/rcc/rcc_h5.yaml
+++ b/peripherals/rcc/rcc_h5.yaml
@@ -1,0 +1,70 @@
+# Common RCC patches for H5 chips
+# The H562/3 and H573 chips are typically a superset of H503, so additional fields
+# need to be specified for those chips. Some registers (notably CCIPRx) because of
+# difference in available clocks between H503 and (H562/3 and H573 family)
+
+
+_include:
+  - ./rcc_v3.yaml
+  - ./rcc_v3_cr_hseext.yaml
+  - ./rcc_v3_hsicfgr.yaml
+  - ./rcc_v3_cfgr1_cfgr2.yaml
+  - ./rcc_v3_bdcr_ext.yaml
+
+RCC:
+  CSICFGR:
+    CSITRIM: [0, 0x3F]
+    _read:
+      CSICAL: [0, 0xFF]
+  PLL?CFGR:
+    PLL??EN:
+      Disabled: [0, "Clock output is disabled"]
+      Enabled: [1, "Clock output is enabled"]
+    PLL?M: [0, 0,0x3F]
+    PLL?VCOSEL:
+      WideVCO: [0, "VCO frequency range 192 to 836 MHz"]
+      MediumVCO: [1, "VCO frequency range 150 to 420 MHz"]
+    PLL?FRACEN:
+      Reset: [0, "Reset latch to transfer FRACN to the Sigma-Delta modulator"]
+      Set: [1, "Set latch to transfer FRACN to the Sigma-Delta modulator"]
+    PLL?RGE:
+      Range1: [0, "Frequency is between 1 and 2 MHz"]
+      Range2: [1, "Frequency is between 2 and 4 MHz"]
+      Range4: [2, "Frequency is between 4 and 8 MHz"]
+      Range8: [3, "Frequency is between 8 and 16 MHz"]
+    PLL?SRC:
+      None: [0, "No clock sent to DIVMx dividers and PLLs"]
+      HSI: [1, "HSI selected as PLL clock"]
+      CSI: [2, "CSI selected as PLL clock"]
+      HSE: [3, "HSE selected as PLL clock"]
+  PLL?DIVR:
+    PLL?[PQR]: [0, 0x7F]
+    PLL?N: [3, 0x1FF]
+  PLL?FRACR:
+    PLL?FRACN: [0, 0x1FFF]
+  CIFR:
+    HSECSSF:
+      _read:
+        NoInterrupt: [ 0, "No clock security interrupt caused by HSE clock failure" ]
+        Interrupt: [ 1, "Clock security interrupt caused by HSE clock failure" ]
+  CCIPR5:
+    CKPERSEL:
+      HSI_KER: [0, "HSI kernel clock selected as clock source (hsi_ker_ck)"]
+      CSI_KER: [1, "CSI kernel clock selected as clock source (csi_ker_ck)"]
+      HSE: [2, "HSE clock selected as clock source (hse_ck)"]
+    FDCANSEL:
+      HSE: [0, "HSE clock selected as clock source (hse_ck)"]
+      PLL1_Q: [1, "PLL1 Q clock selected as clock source (pll1_q_ck)"]
+      PLL2_Q: [2, "PLL2 Q clock selected as clock source (pll2_q_ck)"]
+    RNGSEL:
+      HSI48_KER: [0, "HSI48 kernel clock selected as clock source (hsi48_ker_ck)"]
+      PLL1_Q: [1, "PLL1 Q clock selected as clock source (pll1_q_ck)"]
+      LSE: [2, "LSE clock selected as clock source (lse_ck)"]
+      LSI: [3, "LSI kernel clock selected as clock source (lsi_ker_ck)"]
+    ADCDACSEL:
+      HCLK: [0, "HLCK clock selected as clock source (rcc_hclk)"]
+      SYS: [1, "System clock selected as pclock source (sys_ck)"]
+      PLL2_R: [2, "PLL2 R clock selected as clock source (pll2_r_ck)"]
+      HSE: [3, "HSE clock selected as clock source (hse_ck)"]
+      HSI_KER: [4, "HSI kernel clock selected as clock source (hsi_ker_ck)"]
+      CSI_KER: [5, "CSI kernel clock selected as clock source (csi_ker_ck)"]

--- a/peripherals/rcc/rcc_h503.yaml
+++ b/peripherals/rcc/rcc_h503.yaml
@@ -1,0 +1,102 @@
+# Common RCC patches for H5 chips
+# The H562/3 and H573 chips are typically a superset of H503, so additional fields
+# need to be specified for those chips.
+
+
+_include:
+  - ./rcc_h5.yaml
+
+RCC:
+  CCIPR1:
+    TIMICSEL:
+      Disabled: [0, "No internal clock available for timers input capture"]
+      Enabled: [1, "hsi_ker_ck/1024, hsi_ker_ck/8 and csi_ker_ck/128 selected for timers input capture"]
+    USART3SEL:
+      RCC_PCLK1: [0, "PCLK1 selected as clock source (rcc_pclk1)"]
+      PLL2_Q: [1, "PLL2 Q clock selected as clock source (pll2_q_ck)"]
+      HSI_KER: [3, "HSI kernel clock selected as clock source (hsi_ker_ck)"]
+      CSI_KER: [4, "CSI kernel clock selected as clock source (csi_ker_ck)"]
+      LSE: [5, "LSE clock selected as clock source (lse_ck)"]
+    USART2SEL:
+      RCC_PCLK1: [0, "PCLK1 selected as clock source (rcc_pclk1)"]
+      PLL2_Q: [1, "PLL2 Q clock selected as clock source (pll2_q_ck)"]
+      HSI_KER: [3, "HSI kernel clock selected as clock source (hsi_ker_ck)"]
+      CSI_KER: [4, "CSI kernel clock selected as clock source (csi_ker_ck)"]
+      LSE: [5, "LSE clock selected as clock source (lse_ck)"]
+    USART1SEL:
+      RCC_PCLK2: [0, "PCLK2 selected as clock source (rcc_pclk2)"]
+      PLL2_Q: [1, "PLL2 Q clock selected as clock source (pll2_q_ck)"]
+      HSI_KER: [3, "HSI kernel clock selected as clock source (hsi_ker_ck)"]
+      CSI_KER: [4, "CSI kernel clock selected as clock source (csi_ker_ck)"]
+      LSE: [5, "LSE clock selected as clock source (lse_ck)"]
+  CCIPR2:
+    LPTIM2SEL:
+      RCC_PCLK1: [0, "PCLK1 selected as clock source (rcc_pclk1)"]
+      PLL2_P: [1, "PLL2 P clock selected as clock source (pll2_p_ck)"]
+      LSE_KER: [3, "LSE kernel selected as clock source (lse_ck)"]
+      LSI_KER: [4, "LSI kernel selected as clock source (lsi_ker_ck)"]
+      PER_CK: [5, "per_ck clock selected as clock source"]
+    LPTIM1SEL:
+      RCC_PCLK3: [0, "PCLK3 selected as clock source (rcc_pclk3)"]
+      PLL2_P: [1, "PLL2 P clock selected as clock source (pll2_p_ck)"]
+      LSE_KER: [3, "LSE kernel selected as clock source (lse_ck)"]
+      LSI_KER: [4, "LSI kernel selected as clock source (lsi_ker_ck)"]
+      PER_CK: [5, "per_ck clock selected as clock source"]
+  CCIPR3:
+    LPUART1SEL:
+      RCC_PCLK3: [0, "PCLK3 selected as clock source (rcc_pclk3)"]
+      PLL2_Q: [1, "PLL2 Q clock selected as clock source (pll2_q_ck)"]
+      HSI_KER: [3, "HSI kernel clock selected as clock source (hsi_ker_ck)"]
+      CSI_KER: [4, "CSI kernel clock selected as clock source (csi_ker_ck)"]
+      LSE: [5, "LSE selected as clock source (lse_ck)"]
+    SPI1SEL:
+      PLL1_Q: [0, "PLL1 Q clock selected as clock source (pll1_q_ck)"]
+      PLL2_P: [1, "PLL2 P clock selected as clock source (pll2_p_ck)"]
+      AUDIOCLK: [3, "AUDIOCLK clock selected as clock source"]
+      PER_CK: [4, "per_ck clock selected as clock source"]
+    SPI2SEL:
+      PLL1_Q: [0, "PLL1 Q clock selected as clock source (pll1_q_ck)"]
+      PLL2_P: [1, "PLL2 QP clock selected as clock source (pll2_p_ck)"]
+      AUDIOCLK: [3, "AUDIOCLK clock selected as clock source"]
+      PER_CK: [4, "per_ck clock selected as clock source"]
+    SPI3SEL:
+      PLL1_Q: [0, "PLL1 Q clock selected as clock source (pll1_q_ck)"]
+      PLL2_P: [1, "PLL2 P clock selected as clock source (pll2_p_ck)"]
+      AUDIOCLK: [3, "AUDIOCLK clock selected as clock source"]
+      PER_CK: [4, "per_ck clock selected as clock source"]
+  CCIPR4:
+    I3C2SEL:
+      RCC_PCLK3: [0, "PCLK3 selected as clock source (rcc_pclk3)"]
+      PLL2_R: [1, "PLL2 R clock selected as clock source (pll2_r_ck)"]
+      HSI_KER: [2, "HSI kernel clock selected as clock source (hsi_ker_ck)"]
+    I3C1SEL:
+      RCC_PCLK1: [0, "PCLK1 selected as clock source (rcc_pclk1)"]
+      PLL2_R: [1, "PLL2 R Clock selected as clock source (pll2_r_ck)"]
+      HSI_KER: [2, "HSI kernel clock selected as clock source (hsi_ker_ck)"]
+    I2C1SEL:
+      RCC_PCLK1: [0, "PCLK1 selected as clock source (rcc_pclk1)"]
+      PLL2_R: [1, "PLL2 R Clock selected as clock source (pll2_r_ck)"]
+      HSI_KER: [2, "HSI kernel clock selected as clock source (hsi_ker_ck)"]
+      CSI_KER: [3, "CSI kernel clock selected as clock source (csi_ker_ck)"]
+    I2C2SEL:
+      RCC_PCLK1: [0, "PCLK1 selected as clock source (rcc_pclk1)"]
+      PLL2_R: [1, "PLL2 R Clock selected as clock source (pll2_r_ck)"]
+      HSI_KER: [2, "HSI kernel clock selected as clock source (hsi_ker_ck)"]
+      CSI_KER: [3, "CSI kernel clock selected as clock source (csi_ker_ck)"]
+    USBSEL:
+      DISABLE: [0, "Disable the clock"]
+      PLL1_Q: [1, "PLL1 Q clock selected as clock source (pll1_q_ck)"]
+      PLL2_Q: [2, "PLL2 Q clock selected as clock source (pll2_q_ck)"]
+      HSI48: [3, "HSI48 clock selected as clock source (hsi48_ker_ck)"]
+    SYSTICKSEL:
+      HCLK_DIV8: [0, "RCC HLCK divided by 8 selected as clock source (rcc_hclk / 8)"]
+      LSI_KER: [1, "LSI kernel selected as clock source (lsi_ker_ck)"]
+      LSE: [2, "LSE selected as clock source (lse_ck)"]
+  CCIPR5:
+    DAC1SEL:
+      LSE: [0, "LSE selected as clock source (lse_ck)"]
+      LSI_KER: [1, "LSI kernel selected as clock source (lsi_ker_ck)"]
+  PRIVCFGR:
+    PRIV:
+      Any: [0, "RCC functions can be modified by privileged or unprivileged access"]
+      PrivilegedOnly: [1, "RCC functions can only be modified by privileged access"]

--- a/peripherals/rcc/rcc_h7.yaml
+++ b/peripherals/rcc/rcc_h7.yaml
@@ -1,4 +1,8 @@
 _include:
   - ./rcc_v3.yaml
+  - ./rcc_v3_cfgr.yaml
+  - ./rcc_v3_csr.yaml
+  - ./rcc_v3_gsr.yaml
+  - ./rcc_v3_d3amr_srdamr.yaml
   - ./rcc_v3_pll.yaml
   - ./rcc_v3_h7_ccip.yaml

--- a/peripherals/rcc/rcc_h7_revision_v.yaml
+++ b/peripherals/rcc/rcc_h7_revision_v.yaml
@@ -2,11 +2,10 @@
 
 # Does not apply to Revsion Y of H7
 
+_include:
+  - ./rcc_v3_hsicfgr.yaml
+
 RCC:
-  HSICFGR:
-    HSITRIM: [0, 0x7F]
-    _read:
-      HSICAL: [0, 0xFFF]
   CSICFGR:
     CSITRIM: [0, 0x3F]
     _read:

--- a/peripherals/rcc/rcc_v3.yaml
+++ b/peripherals/rcc/rcc_v3.yaml
@@ -26,48 +26,21 @@ RCC:
   CRRCR:
     _read:
       HSI48CAL: [0, 0x3FF]
-  CFGR:
-    MCO2:
-      SYSCLK: [0, "System clock selected for micro-controller clock output"]
-      PLL2_P: [1, "pll2_p selected for micro-controller clock output"]
-      HSE: [2, "HSE selected for micro-controller clock output"]
-      PLL1_P: [3, "pll1_p selected for micro-controller clock output"]
-      CSI: [4, "CSI selected for micro-controller clock output"]
-      LSI: [5, "LSI selected for micro-controller clock output"]
-    MCO1:
-      HSI: [0, "HSI selected for micro-controller clock output"]
-      LSE: [1, "LSE selected for micro-controller clock output"]
-      HSE: [2, "HSE selected for micro-controller clock output"]
-      PLL1_Q: [3, "pll1_q selected for micro-controller clock output"]
-      HSI48: [4, "HSI48 selected for micro-controller clock output"]
-    MCO?PRE: [0, 15]
-    TIMPRE:
-      DefaultX2: [0, "Timer kernel clock equal to 2x pclk by default"]
-      DefaultX4: [1, "Timer kernel clock equal to 4x pclk by default"]
-    RTCPRE: [0, 63]
-    STOPWUCK,STOPKERWUCK:
-      HSI: [0, "HSI selected as wake up clock from system Stop"]
-      CSI: [1, "CSI selected as wake up clock from system Stop"]
-    SWS:
-      _read:
-        HSI: [0, "HSI oscillator used as system clock"]
-        CSI: [1, "CSI oscillator used as system clock"]
-        HSE: [2, "HSE oscillator used as system clock"]
-        PLL1: [3, "PLL1 used as system clock"]
-    SW:
-      HSI: [0, "HSI selected as system clock"]
-      CSI: [1, "CSI selected as system clock"]
-      HSE: [2, "HSE selected as system clock"]
-      PLL1: [3, "PLL1 selected as system clock"]
   CIER:
     "*IE":
       Disabled: [0, "Interrupt disabled"]
       Enabled: [1, "Interrupt enabled"]
+  CIFR:
+    "*RDYF":
+      _read:
+        NotInterrupted: [0, "No clock ready interrupt"]
+        Interrupted: [1, "Clock ready interrupt"]
   CICR:
     "*C":
       Clear: [1, "Clear interrupt flag"]
   BDCR:
     BDRST,VSWRST:
+      NotActivated: [0, "Reset not activated"]
       Reset: [1, "Resets the entire VSW domain"]
     RTCEN:
       Disabled: [0, "RTC clock disabled"]
@@ -99,33 +72,17 @@ RCC:
     LSEON:
       "Off": [0, "LSE oscillator Off"]
       "On": [1, "LSE oscillator On"]
-  CSR:
-    LSIRDY:
-      _read:
-        NotReady: [0, "LSI oscillator not ready"]
-        Ready: [1, "LSI oscillator ready"]
-    LSION:
-      "Off": [0, "LSI oscillator Off"]
-      "On": [1, "LSI oscillator On"]
   "A?B?RSTR,A?B??RSTR":
     "*RST":
       Reset: [1, "Reset the selected module"]
-  GCR:
-    WW1RSC:
-      Clear: [0, "Clear WWDG1 scope control"]
-      Set: [1, "Set WWDG1 scope control"]
-  D3AMR,SRDAMR:
-    "*AMEN":
-      Disabled: [0, "Clock disabled in autonomous mode"]
-      Enabled: [1, "Clock enabled in autonomous mode"]
   RSR,C1_RSR:
     "*RSTF":
       _read:
-        NoResetOccoured: [0, "No reset occoured for block"]
-        ResetOccourred: [1, "Reset occoured for block"]
+        NoResetOccurred: [0, "No reset occurred for block"]
+        ResetOccurred: [1, "Reset occurred for block"]
     RMVF:
-      NotActive: [0, "Not clearing the the reset flags"]
-      Clear: [1, "Clear the reset flags"]
+      NotActivated: [0, "Reset not activated"]
+      Reset: [1, "Reset the reset status flags"]
   "A?B?ENR,A?B??ENR,C1_A?B?ENR,C1_A?B??ENR":
     "*EN":
       Disabled: [0, "The selected clock is disabled"]

--- a/peripherals/rcc/rcc_v3_bdcr_ext.yaml
+++ b/peripherals/rcc/rcc_v3_bdcr_ext.yaml
@@ -1,0 +1,17 @@
+# Should be applied on top of rcc_v3.yaml
+
+RCC:
+  BDCR:
+    LSIRDY:
+      _read:
+        NotReady: [0, "Clock not ready"]
+        Ready: [1, "Clock ready"]
+    LSION:
+      Disabled: [0, "Oscillator disabled"]
+      Enabled: [1, "Oscillator enabled"]
+    LSCOSEL:
+      LSI: [0, "LSI clock selected"]
+      LSE: [1, "LSE clock selected"]
+    LSEEXT:
+      Analog: [0, "HSE in analog mode"]
+      Digital: [1, "HSE in digital mode"]

--- a/peripherals/rcc/rcc_v3_cfgr.yaml
+++ b/peripherals/rcc/rcc_v3_cfgr.yaml
@@ -1,0 +1,34 @@
+RCC:
+  CFGR:
+    MCO2:
+      SYSCLK: [0, "System clock selected for micro-controller clock output"]
+      PLL2_P: [1, "pll2_p selected for micro-controller clock output"]
+      HSE: [2, "HSE selected for micro-controller clock output"]
+      PLL1_P: [3, "pll1_p selected for micro-controller clock output"]
+      CSI: [4, "CSI selected for micro-controller clock output"]
+      LSI: [5, "LSI selected for micro-controller clock output"]
+    MCO1:
+      HSI: [0, "HSI selected for micro-controller clock output"]
+      LSE: [1, "LSE selected for micro-controller clock output"]
+      HSE: [2, "HSE selected for micro-controller clock output"]
+      PLL1_Q: [3, "pll1_q selected for micro-controller clock output"]
+      HSI48: [4, "HSI48 selected for micro-controller clock output"]
+    MCO?PRE: [0, 15]
+    TIMPRE:
+      DefaultX2: [0, "Timer kernel clock equal to 2x pclk by default"]
+      DefaultX4: [1, "Timer kernel clock equal to 4x pclk by default"]
+    RTCPRE: [0, 63]
+    STOPWUCK,STOPKERWUCK:
+      HSI: [0, "HSI selected as wake up clock from system Stop"]
+      CSI: [1, "CSI selected as wake up clock from system Stop"]
+    SWS:
+      _read:
+        HSI: [0, "HSI oscillator used as system clock"]
+        CSI: [1, "CSI oscillator used as system clock"]
+        HSE: [2, "HSE oscillator used as system clock"]
+        PLL1: [3, "PLL1 used as system clock"]
+    SW:
+      HSI: [0, "HSI selected as system clock"]
+      CSI: [1, "CSI selected as system clock"]
+      HSE: [2, "HSE selected as system clock"]
+      PLL1: [3, "PLL1 selected as system clock"]

--- a/peripherals/rcc/rcc_v3_cfgr1_cfgr2.yaml
+++ b/peripherals/rcc/rcc_v3_cfgr1_cfgr2.yaml
@@ -1,0 +1,54 @@
+RCC:
+  CFGR1:
+    MCO2SEL:
+      SYSCLK: [0, "System clock selected (sys_ck)"]
+      PLL2_P: [1, "PLL2 oscillator clock selected (pll2_p_ck)"]
+      HSE: [2, "HSE clock selected (hse_ck)"]
+      PLL1_P: [3, "PLL1 clock selected (pll1_p_ck)"]
+      CSI: [4, "CSI clock selected (csi_ck)"]
+      LSI: [5, "LSI clock selected (lsi_ck)"]
+    MCO1SEL:
+      HSI: [0, "HSI clock selected (hsi_ck)"]
+      LSE: [1, "LSE clock selected (lse_ck)"]
+      HSE: [2, "HSE clock selected (hse_ck)"]
+      PLL1_Q: [3, "PLL1 clock selected (pll1_q_ck)"]
+      HSI48: [4, "HSI48 clock selected (hsi48_ck)"]
+    MCO?PRE: [0, 15]
+    TIMPRE:
+      DefaultX2: [0, "Timer kernel clock equal to 2x pclk by default"]
+      DefaultX4: [1, "Timer kernel clock equal to 4x pclk by default"]
+    RTCPRE: [0, 63]
+    STOPWUCK,STOPKERWUCK:
+      HSI: [0, "HSI selected as wake up clock from system Stop"]
+      CSI: [1, "CSI selected as wake up clock from system Stop"]
+    SWS:
+      _read:
+        HSI: [0, "HSI oscillator used as system clock"]
+        CSI: [1, "CSI oscillator used as system clock"]
+        HSE: [2, "HSE oscillator used as system clock"]
+        PLL1: [3, "PLL1 used as system clock"]
+    SW:
+      HSI: [0, "HSI selected as system clock"]
+      CSI: [1, "CSI selected as system clock"]
+      HSE: [2, "HSE selected as system clock"]
+      PLL1: [3, "PLL1 selected as system clock"]
+  CFGR2:
+    A?B?DIS:
+      Enabled: [0, "The selected clock is enabled"]
+      Disabled: [1, "The selected clock is disabled"]
+    PPRE*:
+      Div1: [0, "HCLK not divided"] # Same for [0, 8]
+      Div2: [4, "HCLK divided by 2"]
+      Div4: [5, "HCLK divided by 4"]
+      Div8: [6, "HCLK divided by 8"]
+      Div16: [7, "HCLK divided by 16"]
+    HPRE:
+      Div1: [0, "SYSCLK not divided"] # Same for [0, 7]
+      Div2: [8, "SYSCLK divided by 2"]
+      Div4: [9, "SYSCLK divided by 4"]
+      Div8: [10, "SYSCLK divided by 8"]
+      Div16: [11, "SYSCLK divided by 16"]
+      Div64: [12, "SYSCLK divided by 64"]
+      Div128: [13, "SYSCLK divided by 128"]
+      Div256: [14, "SYSCLK divided by 256"]
+      Div512: [15, "SYSCLK divided by 512"]

--- a/peripherals/rcc/rcc_v3_cr_hseext.yaml
+++ b/peripherals/rcc/rcc_v3_cr_hseext.yaml
@@ -1,0 +1,7 @@
+# Should be applied on top of rcc_v3.yaml
+
+RCC:
+  CR:
+    HSEEXT:
+      Analog: [0, "HSE in analog mode"]
+      Digital: [1, "HSE in digital mode"]

--- a/peripherals/rcc/rcc_v3_csr.yaml
+++ b/peripherals/rcc/rcc_v3_csr.yaml
@@ -1,0 +1,11 @@
+# CSR definition for V3. Not available on all devices
+
+RCC:
+  CSR:
+    LSIRDY:
+      _read:
+        NotReady: [0, "LSI oscillator not ready"]
+        Ready: [1, "LSI oscillator ready"]
+    LSION:
+      "Off": [0, "LSI oscillator Off"]
+      "On": [1, "LSI oscillator On"]

--- a/peripherals/rcc/rcc_v3_d3amr_srdamr.yaml
+++ b/peripherals/rcc/rcc_v3_d3amr_srdamr.yaml
@@ -1,0 +1,7 @@
+# Applicable at least to H7
+
+RCC:
+  D3AMR,SRDAMR:
+    "*AMEN":
+      Disabled: [0, "Clock disabled in autonomous mode"]
+      Enabled: [1, "Clock enabled in autonomous mode"]

--- a/peripherals/rcc/rcc_v3_gsr.yaml
+++ b/peripherals/rcc/rcc_v3_gsr.yaml
@@ -1,0 +1,7 @@
+# Applicable at least to H7
+
+RCC:
+  GCR:
+    WW1RSC:
+      Clear: [0, "Clear WWDG1 scope control"]
+      Set: [1, "Set WWDG1 scope control"]

--- a/peripherals/rcc/rcc_v3_hsicfgr.yaml
+++ b/peripherals/rcc/rcc_v3_hsicfgr.yaml
@@ -1,0 +1,5 @@
+RCC:
+  HSICFGR:
+    HSITRIM: [0, 0x7F]
+    _read:
+      HSICAL: [0, 0xFFF]


### PR DESCRIPTION
This is exhaustive for the H503 chip, but doesn't include all field definitions for the H562/563/573 processors, which have quite a few more registers, particularly related to security features.

It also fixes register and field names for the H5 family that are inconsistent between the SVD and the Reference manuals.

It also includes some light refactoring of some fields common to the H5 and H7 families.