### PR TITLE
Add SPI definitions for H5 family

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-* Remove workaround for bug in duckscript's `mv` 
+* Remove workaround for bug in duckscript's `mv`
 * Replace `makehtml.py` with `svd2html`
 * Updated to svd2rust 0.30.0, svdtools 0.3.0, use tools binaries for CI
 * Enable atomic operations on register support, Rust edition 2021 (#846)
@@ -11,6 +11,7 @@
 * DMAMUX: merge registers in arrays
 * STM32U5xx: Update SVD version and add variants for xx=35,45,95,A5,99,A9 (#844)
 * Fix ADC SR OVR enums
+* H5: Add SPI definitions
 
 [#854]: https://github.com/stm32-rs/stm32-rs/pull/854
 

--- a/devices/stm32h503.yaml
+++ b/devices/stm32h503.yaml
@@ -2,3 +2,6 @@ _svd: ../svd/stm32h503.svd
 
 _include:
   - common_patches/h5.yaml
+
+  - ../peripherals/spi/spi_v3_base.yaml
+  - ../peripherals/spi/spi_v3_cfg1_bpass.yaml

--- a/devices/stm32h562.yaml
+++ b/devices/stm32h562.yaml
@@ -26,3 +26,6 @@ _include:
   # - ../peripherals/rtc/rtc_common.yaml
 
   - ../peripherals/sai/sai.yaml
+
+  - ../peripherals/spi/spi_v3_base.yaml
+  - ../peripherals/spi/spi_v3_cfg1_bpass.yaml

--- a/devices/stm32h563.yaml
+++ b/devices/stm32h563.yaml
@@ -25,3 +25,6 @@ _include:
   # - ../peripherals/rtc/rtc_common.yaml
 
   - ../peripherals/sai/sai.yaml
+
+  - ../peripherals/spi/spi_v3_base.yaml
+  - ../peripherals/spi/spi_v3_cfg1_bpass.yaml

--- a/devices/stm32h573.yaml
+++ b/devices/stm32h573.yaml
@@ -25,3 +25,6 @@ _include:
   # - ../peripherals/rtc/rtc_common.yaml
 
   - ../peripherals/sai/sai.yaml
+
+  - ../peripherals/spi/spi_v3_base.yaml
+  - ../peripherals/spi/spi_v3_cfg1_bpass.yaml

--- a/devices/stm32h735.yaml
+++ b/devices/stm32h735.yaml
@@ -977,7 +977,9 @@ _include:
  - ../peripherals/rcc/rcc_h7_revision_v.yaml
  - ../peripherals/rng/rng_v1.yaml
  - ../peripherals/rng/rng_v1_ced.yaml
- - ../peripherals/spi/spi_v3.yaml
+ - ../peripherals/spi/spi_v3_base.yaml
+ - ../peripherals/spi/spi_v3_tser.yaml
+ - ../peripherals/spi/spi_v3_cfg1_udrdet.yaml
  - common_patches/tim/v2/h7.yaml
  - common_patches/tim/common.yaml
  - ../peripherals/tim/tim_basic.yaml

--- a/devices/stm32h735.yaml
+++ b/devices/stm32h735.yaml
@@ -979,7 +979,7 @@ _include:
  - ../peripherals/rng/rng_v1_ced.yaml
  - ../peripherals/spi/spi_v3_base.yaml
  - ../peripherals/spi/spi_v3_tser.yaml
- - ../peripherals/spi/spi_v3_cfg1_udrdet.yaml
+ - ../peripherals/spi/spi_v3_cfg1_udrdet_udrcfg.yaml
  - common_patches/tim/v2/h7.yaml
  - common_patches/tim/common.yaml
  - ../peripherals/tim/tim_basic.yaml

--- a/devices/stm32h743.yaml
+++ b/devices/stm32h743.yaml
@@ -78,7 +78,9 @@ _include:
  - ../peripherals/rcc/rcc_h7_revision_y.yaml
  - ../peripherals/rng/rng_v1.yaml
  - ../peripherals/rng/rng_v1_ced.yaml
- - ../peripherals/spi/spi_v3.yaml
+ - ../peripherals/spi/spi_v3_base.yaml
+ - ../peripherals/spi/spi_v3_tser.yaml
+ - ../peripherals/spi/spi_v3_cfg1_udrdet.yaml
  - common_patches/tim/v2/h7.yaml
  - common_patches/tim/common.yaml
  - ../peripherals/tim/tim_basic.yaml

--- a/devices/stm32h743.yaml
+++ b/devices/stm32h743.yaml
@@ -80,7 +80,7 @@ _include:
  - ../peripherals/rng/rng_v1_ced.yaml
  - ../peripherals/spi/spi_v3_base.yaml
  - ../peripherals/spi/spi_v3_tser.yaml
- - ../peripherals/spi/spi_v3_cfg1_udrdet.yaml
+ - ../peripherals/spi/spi_v3_cfg1_udrdet_udrcfg.yaml
  - common_patches/tim/v2/h7.yaml
  - common_patches/tim/common.yaml
  - ../peripherals/tim/tim_basic.yaml

--- a/devices/stm32h743v.yaml
+++ b/devices/stm32h743v.yaml
@@ -80,7 +80,9 @@ _include:
  - ../peripherals/rcc/rcc_h7_revision_v.yaml
  - ../peripherals/rng/rng_v1.yaml
  - ../peripherals/rng/rng_v1_ced.yaml
- - ../peripherals/spi/spi_v3.yaml
+ - ../peripherals/spi/spi_v3_base.yaml
+ - ../peripherals/spi/spi_v3_tser.yaml
+ - ../peripherals/spi/spi_v3_cfg1_udrdet.yaml
  - common_patches/tim/v2/h7.yaml
  - common_patches/tim/common.yaml
  - ../peripherals/tim/tim_basic.yaml

--- a/devices/stm32h743v.yaml
+++ b/devices/stm32h743v.yaml
@@ -82,7 +82,7 @@ _include:
  - ../peripherals/rng/rng_v1_ced.yaml
  - ../peripherals/spi/spi_v3_base.yaml
  - ../peripherals/spi/spi_v3_tser.yaml
- - ../peripherals/spi/spi_v3_cfg1_udrdet.yaml
+ - ../peripherals/spi/spi_v3_cfg1_udrdet_udrcfg.yaml
  - common_patches/tim/v2/h7.yaml
  - common_patches/tim/common.yaml
  - ../peripherals/tim/tim_basic.yaml

--- a/devices/stm32h747cm4.yaml
+++ b/devices/stm32h747cm4.yaml
@@ -83,7 +83,7 @@ _include:
  - ../peripherals/rng/rng_v1_ced.yaml
  - ../peripherals/spi/spi_v3_base.yaml
  - ../peripherals/spi/spi_v3_tser.yaml
- - ../peripherals/spi/spi_v3_cfg1_udrdet.yaml
+ - ../peripherals/spi/spi_v3_cfg1_udrdet_udrcfg.yaml
  - ../peripherals/syscfg/syscfg_h747.yaml
  - common_patches/tim/v2/h7.yaml
  - common_patches/tim/common.yaml

--- a/devices/stm32h747cm4.yaml
+++ b/devices/stm32h747cm4.yaml
@@ -81,7 +81,9 @@ _include:
  - common_patches/rtc/rtc_bkpr.yaml
  - ../peripherals/rng/rng_v1.yaml
  - ../peripherals/rng/rng_v1_ced.yaml
- - ../peripherals/spi/spi_v3.yaml
+ - ../peripherals/spi/spi_v3_base.yaml
+ - ../peripherals/spi/spi_v3_tser.yaml
+ - ../peripherals/spi/spi_v3_cfg1_udrdet.yaml
  - ../peripherals/syscfg/syscfg_h747.yaml
  - common_patches/tim/v2/h7.yaml
  - common_patches/tim/common.yaml

--- a/devices/stm32h747cm7.yaml
+++ b/devices/stm32h747cm7.yaml
@@ -80,7 +80,9 @@ _include:
  - ../peripherals/rcc/rcc_h7_revision_v.yaml
  - ../peripherals/rng/rng_v1.yaml
  - ../peripherals/rng/rng_v1_ced.yaml
- - ../peripherals/spi/spi_v3.yaml
+ - ../peripherals/spi/spi_v3_base.yaml
+ - ../peripherals/spi/spi_v3_tser.yaml
+ - ../peripherals/spi/spi_v3_cfg1_udrdet.yaml
  - ../peripherals/syscfg/syscfg_h747.yaml
  - common_patches/tim/v2/h7.yaml
  - common_patches/tim/common.yaml

--- a/devices/stm32h747cm7.yaml
+++ b/devices/stm32h747cm7.yaml
@@ -82,7 +82,7 @@ _include:
  - ../peripherals/rng/rng_v1_ced.yaml
  - ../peripherals/spi/spi_v3_base.yaml
  - ../peripherals/spi/spi_v3_tser.yaml
- - ../peripherals/spi/spi_v3_cfg1_udrdet.yaml
+ - ../peripherals/spi/spi_v3_cfg1_udrdet_udrcfg.yaml
  - ../peripherals/syscfg/syscfg_h747.yaml
  - common_patches/tim/v2/h7.yaml
  - common_patches/tim/common.yaml

--- a/devices/stm32h753.yaml
+++ b/devices/stm32h753.yaml
@@ -91,7 +91,7 @@ _include:
  - ../peripherals/rng/rng_v1_ced.yaml
  - ../peripherals/spi/spi_v3_base.yaml
  - ../peripherals/spi/spi_v3_tser.yaml
- - ../peripherals/spi/spi_v3_cfg1_udrdet.yaml
+ - ../peripherals/spi/spi_v3_cfg1_udrdet_udrcfg.yaml
  - common_patches/tim/v2/h7.yaml
  - common_patches/tim/common.yaml
  - ../peripherals/tim/tim_basic.yaml

--- a/devices/stm32h753.yaml
+++ b/devices/stm32h753.yaml
@@ -89,7 +89,9 @@ _include:
  - ../peripherals/rcc/rcc_h7_revision_y.yaml
  - ../peripherals/rng/rng_v1.yaml
  - ../peripherals/rng/rng_v1_ced.yaml
- - ../peripherals/spi/spi_v3.yaml
+ - ../peripherals/spi/spi_v3_base.yaml
+ - ../peripherals/spi/spi_v3_tser.yaml
+ - ../peripherals/spi/spi_v3_cfg1_udrdet.yaml
  - common_patches/tim/v2/h7.yaml
  - common_patches/tim/common.yaml
  - ../peripherals/tim/tim_basic.yaml

--- a/devices/stm32h753v.yaml
+++ b/devices/stm32h753v.yaml
@@ -93,7 +93,7 @@ _include:
  - ../peripherals/rng/rng_v1_ced.yaml
  - ../peripherals/spi/spi_v3_base.yaml
  - ../peripherals/spi/spi_v3_tser.yaml
- - ../peripherals/spi/spi_v3_cfg1_udrdet.yaml
+ - ../peripherals/spi/spi_v3_cfg1_udrdet_udrcfg.yaml
  - common_patches/tim/v2/h7.yaml
  - common_patches/tim/common.yaml
  - ../peripherals/tim/tim_basic.yaml

--- a/devices/stm32h753v.yaml
+++ b/devices/stm32h753v.yaml
@@ -91,7 +91,9 @@ _include:
  - ../peripherals/rcc/rcc_h7_revision_v.yaml
  - ../peripherals/rng/rng_v1.yaml
  - ../peripherals/rng/rng_v1_ced.yaml
- - ../peripherals/spi/spi_v3.yaml
+ - ../peripherals/spi/spi_v3_base.yaml
+ - ../peripherals/spi/spi_v3_tser.yaml
+ - ../peripherals/spi/spi_v3_cfg1_udrdet.yaml
  - common_patches/tim/v2/h7.yaml
  - common_patches/tim/common.yaml
  - ../peripherals/tim/tim_basic.yaml

--- a/devices/stm32h7b3.yaml
+++ b/devices/stm32h7b3.yaml
@@ -137,7 +137,7 @@ _include:
  - ../peripherals/rng/rng_v1_ced.yaml
  - ../peripherals/spi/spi_v3_base.yaml
  - ../peripherals/spi/spi_v3_tser.yaml
- - ../peripherals/spi/spi_v3_cfg1_udrdet.yaml
+ - ../peripherals/spi/spi_v3_cfg1_udrdet_udrcfg.yaml
  - common_patches/tim/v2/h7.yaml
  - common_patches/tim/common.yaml
  - ../peripherals/tim/tim_basic.yaml

--- a/devices/stm32h7b3.yaml
+++ b/devices/stm32h7b3.yaml
@@ -135,7 +135,9 @@ _include:
  - ../peripherals/rcc/rcc_h7_revision_v.yaml
  - ../peripherals/rng/rng_v1.yaml
  - ../peripherals/rng/rng_v1_ced.yaml
- - ../peripherals/spi/spi_v3.yaml
+ - ../peripherals/spi/spi_v3_base.yaml
+ - ../peripherals/spi/spi_v3_tser.yaml
+ - ../peripherals/spi/spi_v3_cfg1_udrdet.yaml
  - common_patches/tim/v2/h7.yaml
  - common_patches/tim/common.yaml
  - ../peripherals/tim/tim_basic.yaml

--- a/peripherals/spi/spi_v3_base.yaml
+++ b/peripherals/spi/spi_v3_base.yaml
@@ -33,7 +33,6 @@
       Enabled: [1, "Peripheral enabled"]
 
   CR2:
-    TSER: [0, 65535]
     TSIZE: [0, 65535]
 
   CFG1:
@@ -56,10 +55,6 @@
     RXDMAEN:
       Disabled: [0, "Rx buffer DMA disabled"]
       Enabled: [1, "Rx buffer DMA enabled"]
-    UDRDET:
-      StartOfFrame: [0, "Underrun is detected at begin of data frame"]
-      EndOfFrame: [1, "Underrun is detected at end of last data frame"]
-      StartOfSlaveSelect: [2, "Underrun is detected at begin of active SS signal"]
     UDRCFG:
       Constant: [0, "Slave sends a constant underrun pattern"]
       RepeatReceived: [1, "Slave repeats last received data frame from master"]
@@ -126,9 +121,6 @@
     MSSI: [0, 15]
 
   IER:
-    TSERFIE:
-      Masked: [0, "TSER loaded interrupt masked"]
-      NotMasked: [1, "TSER loaded interrupt not masked"]
     MODFIE:
       Masked: [0, "Mode fault interrupt masked"]
       NotMasked: [1, "Mode fault interrupt not masked"]
@@ -176,9 +168,6 @@
     SUSP:
       NotSuspended: [0, "Master not suspended"]
       Suspended: [1, "Master suspended"]
-    TSERF:
-      NotLoaded: [0, "Additional number of SPI data to be transacted not yet loaded"]
-      Loaded: [1, "Additional number of SPI data to be transacted was reloaded"]
     MODF:
       NoFault: [0, "No mode fault detected"]
       Fault: [1, "Mode fault detected"]

--- a/peripherals/spi/spi_v3_base.yaml
+++ b/peripherals/spi/spi_v3_base.yaml
@@ -58,7 +58,6 @@
     UDRCFG:
       Constant: [0, "Slave sends a constant underrun pattern"]
       RepeatReceived: [1, "Slave repeats last received data frame from master"]
-      RepeatTransmitted: [2, "Slave repeats last transmitted data frame"]
     FTHLV:
       OneFrame: [0, "1 frame"]
       TwoFrames: [1, "2 frames"]

--- a/peripherals/spi/spi_v3_cfg1_bpass.yaml
+++ b/peripherals/spi/spi_v3_cfg1_bpass.yaml
@@ -1,0 +1,5 @@
+"SPI*":
+  CFG1:
+    BPASS:
+      Disabled: [0, "Bypass is disabled"]
+      Enabled: [1, "Bypass is enabled"]

--- a/peripherals/spi/spi_v3_cfg1_udrdet.yaml
+++ b/peripherals/spi/spi_v3_cfg1_udrdet.yaml
@@ -1,0 +1,6 @@
+"SPI*":
+  CFG1:
+    UDRDET:
+      StartOfFrame: [0, "Underrun is detected at begin of data frame"]
+      EndOfFrame: [1, "Underrun is detected at end of last data frame"]
+      StartOfSlaveSelect: [2, "Underrun is detected at begin of active SS signal"]

--- a/peripherals/spi/spi_v3_cfg1_udrdet_udrcfg.yaml
+++ b/peripherals/spi/spi_v3_cfg1_udrdet_udrcfg.yaml
@@ -4,3 +4,5 @@
       StartOfFrame: [0, "Underrun is detected at begin of data frame"]
       EndOfFrame: [1, "Underrun is detected at end of last data frame"]
       StartOfSlaveSelect: [2, "Underrun is detected at begin of active SS signal"]
+    UDRCFG:
+      RepeatTransmitted: [2, "Slave repeats last transmitted data frame"]

--- a/peripherals/spi/spi_v3_tser.yaml
+++ b/peripherals/spi/spi_v3_tser.yaml
@@ -1,0 +1,11 @@
+"SPI*":
+  CR2:
+    TSER: [0, 65535]
+  IER:
+    TSERFIE:
+      Masked: [0, "TSER loaded interrupt masked"]
+      NotMasked: [1, "TSER loaded interrupt not masked"]
+  SR:
+    TSERF:
+      NotLoaded: [0, "Additional number of SPI data to be transacted not yet loaded"]
+      Loaded: [1, "Additional number of SPI data to be transacted was reloaded"]


### PR DESCRIPTION
The SPI peripheral is largely shared with the H7 family, except that UDRCFG is 2 bits instead of 1 bit on the H7 family. This refactors the SPI field definitions slightly to account for this slight difference (moving the difference into a specific file only included on the H7 devices). Ultimately, the H7 definitions should be unchanged, and the H5 definitions should be complete for the whole family.