### PR TITLE
Add SBS peripheral for H5 family

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-* Remove workaround for bug in duckscript's `mv` 
+* Remove workaround for bug in duckscript's `mv`
 * Replace `makehtml.py` with `svd2html`
 * Updated to svd2rust 0.30.0, svdtools 0.3.0, use tools binaries for CI
 * Enable atomic operations on register support, Rust edition 2021 (#846)
@@ -11,6 +11,7 @@
 * DMAMUX: merge registers in arrays
 * STM32U5xx: Update SVD version and add variants for xx=35,45,95,A5,99,A9 (#844)
 * Fix ADC SR OVR enums
+* H5: Add SBS definitions
 
 [#854]: https://github.com/stm32-rs/stm32-rs/pull/854
 

--- a/devices/common_patches/h5.yaml
+++ b/devices/common_patches/h5.yaml
@@ -96,6 +96,16 @@ RTC:
 SBS:
   _strip:
     - "SBS_"
+  PMCR:
+    # Rename these fields on H503 to match other H5 processors
+    _modify:
+      PB6_FMPLUS:
+        name: PB6_FMP
+      PB7_FMPLUS:
+        name: PB7_FMP
+      PB8_FMPLUS:
+        name: PB8_FMP
+
 
 SPI?:
   _strip:
@@ -127,3 +137,6 @@ WWDG:
 #   _modify:
 #     CNT_alternate:
 #       name: "CNT"
+
+_include:
+  - sbs/sbs.yaml

--- a/devices/common_patches/sbs/sbs.yaml
+++ b/devices/common_patches/sbs/sbs.yaml
@@ -1,0 +1,6 @@
+SBS:
+  FPUIMR:
+    _split:
+      FPU_IE:
+        name: FPU_IE%s
+        description: FPU interrupt enable

--- a/devices/stm32h503.yaml
+++ b/devices/stm32h503.yaml
@@ -2,3 +2,5 @@ _svd: ../svd/stm32h503.svd
 
 _include:
   - common_patches/h5.yaml
+
+  - ../peripherals/sbs/sbs.yaml

--- a/peripherals/sbs/sbs.yaml
+++ b/peripherals/sbs/sbs.yaml
@@ -1,0 +1,102 @@
+# System configuration, boot, and security (SBS). Applicable to H5 family, at least.
+
+SBS:
+  HDPLCR:
+    INCR_HDPL:
+      Increment: [0x6A, "Increment HDPL value"]
+
+  HDPLSR:
+    HDPL:
+      _read:
+        HDPL0: [0xB4, "Protection level reserved for ST code and data"]
+        HDPL1: [0x51, "Protection level to be used to execute and protect immutable Root of Trust (IROT) stage"]
+        HDPL2: [0x8A, "Protection level to be used to execute and protect an updatable Root of Trust (UROT) stage"]
+        HDPL3: [0x6F, "Protection level to be used to execute the application"]
+
+  DBGCR:
+    DBG_AUTH_HDPL:
+      HDPL1: [0x51, "Protection level to be used to execute and protect immutable Root of Trust (IROT) stage"]
+      HDPL2: [0x8A, "Protection level to be used to execute and protect an updatable Root of Trust (UROT) stage"]
+      HDPL3: [0x6F, "Protection level to be used to execute the application"]
+    DBG_UNLOCK:
+      Unlocked: [0xB4, "Debug unlocked when HDPLSR:HDPL is equal to DBG_AUTH_HDPL"]
+    AP_UNLOCK:
+      Unlocked: [0xB4, "Device access port unlocked"]
+
+  DBGLOCKR:
+    DBGCFG_LOCK:
+      _write:
+        Locked: [0xC3, "Debug configuration register (DBGCR) locked"]
+        Unlocked: [0xB4, "Debug configuration register (DBGCR) unlocked"]
+      _read:
+        Locked: [0x6A, "Debug configuration register (DBGCR) locked"]
+        Unlocked: [0xB4, "Debug configuration register (DBGCR) unlocked"]
+
+  PMCR:
+    PB8_FMP:
+      Disabled: [0, "Fast-mode Plus mode on PB8 disabled"]
+      Enabled: [1, "Fast-mode Plus mode on PB8 enabled"]
+    PB7_FMP:
+      Disabled: [0, "Fast-mode Plus mode on PB7 disabled"]
+      Enabled: [1, "Fast-mode Plus mode on PB7 enabled"]
+    PB6_FMP:
+      Disabled: [0, "Fast-mode Plus mode on PB6 disabled"]
+      Enabled: [1, "Fast-mode Plus mode on PB6 enabled"]
+
+  FPUIMR:
+    FPU_IE?:
+      Disabled: [0, "Interrupt disabled"]
+      Enabled: [1, "Interrupt enabled"]
+
+  MESR:
+    IPMEE:
+      _read:
+        EraseInProgress: [0, "ICACHE erase ongoing"]
+        EraseCompleted: [1, "ICACHE erase completed"]
+      _W1C:
+        Clear: [1, "Clear ICACHE erase status flag"]
+    MCLR:
+      _read:
+        EraseInProgress: [0, "Memory erase in progress"]
+        EraseComplete: [1, "Memory erase complete"]
+      _W1C:
+        Clear: [1, "Clear memory erase status flag"]
+
+  CCCSR:
+    RDY?:
+      _read:
+        NotReady: [0, "VDDIO compensation cell not ready"]
+        Ready: [1, "VDDIO compensation cell ready"]
+    CS?:
+      Cell: [0, "Code from cell selected"]
+      CCSWCR: [1, "Code from CCSWCR selected"]
+    EN?:
+      Disabled: [0, "I/O compensation cell disabled"]
+      Enabled: [1, "I/O compensation cell enabled"]
+
+  CCVALR:
+    _read:
+      ANSRC?: [0, 0xF]
+      APSRC?: [0, 0xF]
+
+  CCSWCR:
+    SW_APSRC?: [0, 0xF]
+    SW_ANSRC?: [0, 0xF]
+
+  CFGR2:
+    "*L":
+      Disconnected: [0, "Flag/Interrupt disconnected from timer break inputs"]
+      Connected: [1, "Flag/Interrupt connected to timer break inputs"]
+
+  CNSLCKR:
+    LOCKNSMPU:
+      Unlocked: [0, "MPU registers write enabled"]
+      Locked: [1, "MPU registers write disabled"]
+    LOCKNSVTOR:
+      Unlocked: [0, "VTOR_NS register write enabled"]
+      Locked: [1, "VTOR_NS register write disabled"]
+
+  ECCNMIR:
+    ECCNMI_MASK_EN:
+      Enabled: [0, "NMI enabled"]
+      Disabled: [1, "NMI disabled"]


### PR DESCRIPTION
The SBS peripheral is new for the M33 series of processors (replacing SYSCFG). This adds the definitions relevant for the H5 family.