### PR TITLE
Add UART definitions for H5 family

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-* Remove workaround for bug in duckscript's `mv` 
+* Remove workaround for bug in duckscript's `mv`
 * Replace `makehtml.py` with `svd2html`
 * Updated to svd2rust 0.30.0, svdtools 0.3.0, use tools binaries for CI
 * Enable atomic operations on register support, Rust edition 2021 (#846)
@@ -11,6 +11,7 @@
 * DMAMUX: merge registers in arrays
 * STM32U5xx: Update SVD version and add variants for xx=35,45,95,A5,99,A9 (#844)
 * Fix ADC SR OVR enums
+* H5: Add UART definitions
 
 [#854]: https://github.com/stm32-rs/stm32-rs/pull/854
 

--- a/devices/common_patches/h5.yaml
+++ b/devices/common_patches/h5.yaml
@@ -127,3 +127,7 @@ WWDG:
 #   _modify:
 #     CNT_alternate:
 #       name: "CNT"
+
+_include:
+  - usart/merge_CR3_WUS_field.yaml
+  - usart/rename_CR1_ISR_enabled_disabled.yaml

--- a/devices/common_patches/usart/merge_CR3_WUS_field.yaml
+++ b/devices/common_patches/usart/merge_CR3_WUS_field.yaml
@@ -1,0 +1,4 @@
+"USART*":
+  CR3:
+    _merge:
+      - "WUS*"

--- a/devices/common_patches/usart/rename_CR1_ISR_enabled_disabled.yaml
+++ b/devices/common_patches/usart/rename_CR1_ISR_enabled_disabled.yaml
@@ -1,0 +1,15 @@
+"USART*":
+  _modify:
+    CR1_enabled:
+      name: CR1
+    ISR_enabled:
+      name: ISR
+  _delete:
+    - CR1_disabled
+    - ISR_disabled
+  CR1:
+    _modify:
+      TXFNFIE:
+        name: TXEIE
+      RXFNEIE:
+        name: RXNEIE

--- a/devices/stm32h503.yaml
+++ b/devices/stm32h503.yaml
@@ -2,3 +2,9 @@ _svd: ../svd/stm32h503.svd
 
 _include:
   - common_patches/h5.yaml
+
+  - ../peripherals/usart/usart_v2B1.yaml
+  - ../peripherals/usart/usart_fifoen.yaml
+  - ../peripherals/usart/usart_sync_slave.yaml
+  - ../peripherals/usart/usart_smartcard.yaml
+  - ../peripherals/usart/usart_prescalar.yaml

--- a/devices/stm32h562.yaml
+++ b/devices/stm32h562.yaml
@@ -26,3 +26,9 @@ _include:
   # - ../peripherals/rtc/rtc_common.yaml
 
   - ../peripherals/sai/sai.yaml
+
+  - ../peripherals/usart/usart_v2B1.yaml
+  - ../peripherals/usart/usart_fifoen.yaml
+  - ../peripherals/usart/usart_sync_slave.yaml
+  - ../peripherals/usart/usart_smartcard.yaml
+  - ../peripherals/usart/usart_prescalar.yaml

--- a/devices/stm32h563.yaml
+++ b/devices/stm32h563.yaml
@@ -25,3 +25,9 @@ _include:
   # - ../peripherals/rtc/rtc_common.yaml
 
   - ../peripherals/sai/sai.yaml
+
+  - ../peripherals/usart/usart_v2B1.yaml
+  - ../peripherals/usart/usart_fifoen.yaml
+  - ../peripherals/usart/usart_sync_slave.yaml
+  - ../peripherals/usart/usart_smartcard.yaml
+  - ../peripherals/usart/usart_prescalar.yaml

--- a/devices/stm32h573.yaml
+++ b/devices/stm32h573.yaml
@@ -25,3 +25,9 @@ _include:
   # - ../peripherals/rtc/rtc_common.yaml
 
   - ../peripherals/sai/sai.yaml
+
+  - ../peripherals/usart/usart_v2B1.yaml
+  - ../peripherals/usart/usart_fifoen.yaml
+  - ../peripherals/usart/usart_sync_slave.yaml
+  - ../peripherals/usart/usart_smartcard.yaml
+  - ../peripherals/usart/usart_prescalar.yaml

--- a/peripherals/usart/_v2_ABC_common.yaml
+++ b/peripherals/usart/_v2_ABC_common.yaml
@@ -123,7 +123,7 @@ ISR:
   RXNE:
   IDLE:
   ORE:
-  NF:
+  "NF,NE":
   FE:
   PE:
 ICR:
@@ -137,7 +137,7 @@ ICR:
     Clear: [1, "Clears the IDLE flag in the ISR register"]
   ORECF:
     Clear: [1, "Clears the ORE flag in the ISR register"]
-  NCF:
+  "NCF,NECF":
     Clear: [1, "Clears the NF flag in the ISR register"]
   FECF:
     Clear: [1, "Clears the FE flag in the ISR register"]

--- a/peripherals/usart/_v2_AB_common.yaml
+++ b/peripherals/usart/_v2_AB_common.yaml
@@ -13,7 +13,7 @@ CR3:
     Start: [2, "WuF active on Start bit detection"]
     RXNE: [3, "WUF active on RXNE"]
 ISR:
-  REAK:
+  "REAK,REACK":
   WUF:
   RWU:
 ICR:

--- a/peripherals/usart/fifoen_common.yaml
+++ b/peripherals/usart/fifoen_common.yaml
@@ -29,3 +29,8 @@ CR3:
   TXFTIE:
     Disabled: [0, "Interrupt inhibited"]
     Enabled:  [1, "USART interrupt generated when Transmit FIFO reaches the threshold programmed in TXFTCFG"]
+ISR:
+  TXFT:
+  RXFT:
+  RXFF:
+  TXFE:

--- a/peripherals/usart/fifoen_usart.yaml
+++ b/peripherals/usart/fifoen_usart.yaml
@@ -1,9 +1,3 @@
-CR3:
-  TCBGTIE:
-      Disabled: [0, "Interrupt inhibited"]
-      Enabled:  [1, "USART interrupt generated whenever TCBGT=1 in the USART_ISR register"]
 ICR:
-  TCBGTCF:
-    Clear: [1, "Clear the TCBGT flag in the ISR register"]
   TXFECF:
     Clear: [1, "Clear the TXFE flag in the ISR register"]

--- a/peripherals/usart/prescalar.yaml
+++ b/peripherals/usart/prescalar.yaml
@@ -1,0 +1,14 @@
+PRESC:
+  PRESCALER:
+    Div1: [0b0000, "Input clock divided by 1"]
+    Div2: [0b0001, "Input clock divided by 2"]
+    Div4: [0b0010, "Input clock divided by 4"]
+    Div6: [0b0011, "Input clock divided by 6"]
+    Div8: [0b0100, "Input clock divided by 8"]
+    Div10: [0b0101, "Input clock divided by 10"]
+    Div12: [0b0110, "Input clock divided by 12"]
+    Div16: [0b0111, "Input clock divided by 16"]
+    Div32: [0b1000, "Input clock divided by 32"]
+    Div64: [0b1001, "Input clock divided by 64"]
+    Div128: [0b1010, "Input clock divided by 128"]
+    Div256: [0b1011, "Input clock divided by 256"]

--- a/peripherals/usart/smartcard.yaml
+++ b/peripherals/usart/smartcard.yaml
@@ -1,0 +1,13 @@
+CR3:
+  TCBGTIE:
+    Disabled: [0, "Interrupt inhibited"]
+    Enabled:  [1, "USART interrupt generated whenever TCBGT=1 in the USART_ISR register"]
+
+ISR:
+  TCBGT:
+    NotCompleted: [0, "Transmission not completed"]
+    Completed: [1, "Transmission has completed"]
+
+ICR:
+  TCBGTCF:
+    Clear: [1, "Clear the TCBGT flag in the ISR register"]

--- a/peripherals/usart/sync_slave.yaml
+++ b/peripherals/usart/sync_slave.yaml
@@ -1,0 +1,12 @@
+CR2:
+  DIS_NSS:
+    Disabled: [0, "SPI slave selection depends on NSS input pin"]
+    Enabled:  [1, "SPI slave is always selected and NSS input pin is ignored"]
+  SLVEN:
+    Disabled: [0, "Slave mode disabled"]
+    Enabled:  [1, "Slave mode enabled"]
+ISR:
+  UDR:
+ICR:
+  UDRCF:
+    Clear: [1, "Clear the UDR flag in the ISR register"]

--- a/peripherals/usart/usart_fifoen.yaml
+++ b/peripherals/usart/usart_fifoen.yaml
@@ -1,0 +1,4 @@
+"USART*":
+  _include:
+    - fifoen_common.yaml
+    - fifoen_usart.yaml

--- a/peripherals/usart/usart_prescalar.yaml
+++ b/peripherals/usart/usart_prescalar.yaml
@@ -1,0 +1,3 @@
+"USART*":
+  _include:
+    - prescalar.yaml

--- a/peripherals/usart/usart_smartcard.yaml
+++ b/peripherals/usart/usart_smartcard.yaml
@@ -1,0 +1,3 @@
+"USART*":
+  _include:
+    - smartcard.yaml

--- a/peripherals/usart/usart_sync_slave.yaml
+++ b/peripherals/usart/usart_sync_slave.yaml
@@ -1,0 +1,3 @@
+"USART*":
+  _include:
+    - sync_slave.yaml

--- a/peripherals/usart/usart_wl.yaml
+++ b/peripherals/usart/usart_wl.yaml
@@ -3,27 +3,6 @@
     - fifoen_common.yaml
     - fifoen_usart.yaml
     - _v2_AB_common.yaml
-  CR2:
-    DIS_NSS:
-      Disabled: [0, "SPI slave selection depends on NSS input pin"]
-      Enabled:  [1, "SPI slave is always selected and NSS input pin is ignored"]
-    SLVEN:
-      Disabled: [0, "Slave mode disabled"]
-      Enabled:  [1, "Slave mode enabled"]
-  ICR:
-    UDRCF:
-      Clear: [1, "Clear the UDR flag in the ISR register"]
-  PRESC:
-    PRESCALER:
-      Div1: [0b0000, "/1"]
-      Div2: [0b0001, "/2"]
-      Div4: [0b0010, "/4"]
-      Div6: [0b0011, "/6"]
-      Div8: [0b0100, "/8"]
-      Div10: [0b0101, "/10"]
-      Div12: [0b0110, "/12"]
-      Div16: [0b0111, "/16"]
-      Div32: [0b1000, "/32"]
-      Div64: [0b1001, "/64"]
-      Div128: [0b1010, "/128"]
-      Div256: [0b1011, "/256"]
+    - sync_slave.yaml
+    - smartcard.yaml
+    - prescalar.yaml


### PR DESCRIPTION
This does some light refactoring of the UART organization, adds some missing fields (for multiple processor families), and fixes some naming for the H5 family specifically.