### PR TITLE
Add I2C for H5 family

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-* Remove workaround for bug in duckscript's `mv` 
+* Remove workaround for bug in duckscript's `mv`
 * Replace `makehtml.py` with `svd2html`
 * Updated to svd2rust 0.30.0, svdtools 0.3.0, use tools binaries for CI
 * Enable atomic operations on register support, Rust edition 2021 (#846)
@@ -11,6 +11,7 @@
 * DMAMUX: merge registers in arrays
 * STM32U5xx: Update SVD version and add variants for xx=35,45,95,A5,99,A9 (#844)
 * Fix ADC SR OVR enums
+* H5: Add I2C definitions
 
 [#854]: https://github.com/stm32-rs/stm32-rs/pull/854
 

--- a/devices/stm32h503.yaml
+++ b/devices/stm32h503.yaml
@@ -2,3 +2,6 @@ _svd: ../svd/stm32h503.svd
 
 _include:
   - common_patches/h5.yaml
+
+  - ../peripherals/i2c/i2c_v2.yaml
+  - ../peripherals/i2c/i2c_v2_cr1_fmp_addraclr_stopfaclr.yaml

--- a/devices/stm32h562.yaml
+++ b/devices/stm32h562.yaml
@@ -26,3 +26,6 @@ _include:
   # - ../peripherals/rtc/rtc_common.yaml
 
   - ../peripherals/sai/sai.yaml
+
+  - ../peripherals/i2c/i2c_v2.yaml
+  - ../peripherals/i2c/i2c_v2_cr1_fmp_addraclr_stopfaclr.yaml

--- a/devices/stm32h563.yaml
+++ b/devices/stm32h563.yaml
@@ -25,3 +25,6 @@ _include:
   # - ../peripherals/rtc/rtc_common.yaml
 
   - ../peripherals/sai/sai.yaml
+
+  - ../peripherals/i2c/i2c_v2.yaml
+  - ../peripherals/i2c/i2c_v2_cr1_fmp_addraclr_stopfaclr.yaml

--- a/devices/stm32h573.yaml
+++ b/devices/stm32h573.yaml
@@ -25,3 +25,6 @@ _include:
   # - ../peripherals/rtc/rtc_common.yaml
 
   - ../peripherals/sai/sai.yaml
+
+  - ../peripherals/i2c/i2c_v2.yaml
+  - ../peripherals/i2c/i2c_v2_cr1_fmp_addraclr_stopfaclr.yaml

--- a/peripherals/i2c/i2c_v2_cr1_fmp_addraclr_stopfaclr.yaml
+++ b/peripherals/i2c/i2c_v2_cr1_fmp_addraclr_stopfaclr.yaml
@@ -1,0 +1,11 @@
+"I2C*":
+  CR1:
+    FMP:
+      Disabled: [0, "20 mA I/O drive disabled"]
+      Enabled: [1, "20 mA I/O drive enabled"]
+    ADDRACLR:
+      Disabled: [0, "ADDR flag is set by hardware, cleared by software"]
+      Enabled: [1, "ADDR flag remains cleared by hardware"]
+    STOPFACLR:
+      Disabled: [0, "STOPF flag is set by hardware, cleared by software"]
+      Enabled: [1, "STOPF flag remains cleared by hardware"]


### PR DESCRIPTION
The H5 I2C is largely the same as the existing v2 definition. Additional fields were added to a supplemental yaml.