### PR TITLE
Add definitions for TIM1-8 for H5 family

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-* Remove workaround for bug in duckscript's `mv` 
+* Remove workaround for bug in duckscript's `mv`
 * Replace `makehtml.py` with `svd2html`
 * Updated to svd2rust 0.30.0, svdtools 0.3.0, use tools binaries for CI
 * Enable atomic operations on register support, Rust edition 2021 (#846)
@@ -11,6 +11,7 @@
 * DMAMUX: merge registers in arrays
 * STM32U5xx: Update SVD version and add variants for xx=35,45,95,A5,99,A9 (#844)
 * Fix ADC SR OVR enums
+* H5: Add TIM1-8 definitions
 
 [#854]: https://github.com/stm32-rs/stm32-rs/pull/854
 

--- a/devices/common_patches/h5.yaml
+++ b/devices/common_patches/h5.yaml
@@ -109,6 +109,22 @@ TIM1:
   _strip:
     - "TIM1_"
 
+TIM2:
+  _strip:
+    - "TIM2_"
+
+TIM3:
+  _strip:
+    - "TIM3_"
+
+TIM6:
+  _strip:
+    - "TIM6_"
+
+TIM7:
+  _strip:
+    - "TIM7_"
+
 USART?:
   _strip:
     - "USART_"
@@ -120,10 +136,3 @@ USB:
 WWDG:
   _strip:
     - "WWDG_"
-
-# TIM3:
-#   _delete:
-#     - CNT
-#   _modify:
-#     CNT_alternate:
-#       name: "CNT"

--- a/devices/common_patches/h56x_h57x.yaml
+++ b/devices/common_patches/h56x_h57x.yaml
@@ -50,9 +50,34 @@ VREFBUF:
   _strip:
     - "VREFBUF_"
 
-# TIM3:
-#   _delete:
-#     - CNT
-#   _modify:
-#     CNT_alternate:
-#       name: "CNT"
+TIM4:
+  _strip:
+    - "TIM4_"
+
+TIM5:
+  _strip:
+    - "TIM5_"
+
+TIM12:
+  _strip:
+    - "TIM2_"
+
+TIM13:
+  _strip:
+    - "TIM2_"
+
+TIM14:
+  _strip:
+    - "TIM2_"
+
+TIM15:
+  _strip:
+    - "TIM15_"
+
+TIM16:
+  _strip:
+    - "TIM16_"
+
+TIM17:
+  _strip:
+    - "TIM17_"

--- a/devices/common_patches/tim/tim_ccm_ext.yaml
+++ b/devices/common_patches/tim/tim_ccm_ext.yaml
@@ -1,0 +1,35 @@
+"TIM[18]":
+  CCMR1_Output:
+    _modify:
+      OC1M_1:
+        name: OC1M_3
+      OC2M_1:
+        name: OC2M_3
+  CCMR2_Output:
+    _modify:
+      OC3M_1:
+        name: OC3M_3
+      OC4M_1:
+        name: OC4M_3
+
+"TIM[2-5]":
+  CCMR1_Output:
+    _modify:
+      OC1M1:
+        name: OC1M
+      OC1M2:
+        name: OC1M_3
+      OC2M1:
+        name: OC2M
+      OC2M2:
+        name: OC2M_3
+  CCMR2_Output:
+    _modify:
+      OC3M1:
+        name: OC3M
+      OC3M2:
+        name: OC3M_3
+      OC4M1:
+        name: OC4M
+      OC4M2:
+        name: OC4M_3

--- a/devices/common_patches/tim/tim_ccr.yaml
+++ b/devices/common_patches/tim/tim_ccr.yaml
@@ -1,7 +1,7 @@
 "TIM[1-589],TIM??":
   _modify:
     "CCR?":
-      description: "capture/compare register"
+      description: "Capture/compare register"
   "CCR?":
     _modify:
       "CCR?":

--- a/devices/common_patches/tim/tim_dither.yaml
+++ b/devices/common_patches/tim/tim_dither.yaml
@@ -1,0 +1,62 @@
+# Applicable to the H5 family
+# The timers support dithering, and the ARR and CCRx registers store the
+# dithering part of the value in the least significant 4 bytes. This adds
+# overlapping field definitions to address the integer and dithering parts
+# separately
+
+"TIM[13489],TIM??":
+  "CCR?s":
+    _add:
+      INTEGER:
+        description: Integer part in dithering mode
+        bitOffset: 4
+        bitWidth: 16
+        access: read-write
+      DITHER:
+        description: Dithered part in dithering mode
+        bitOffset: 0
+        bitWidth: 4
+        access: read-write
+
+"TIM[25]":
+  "CCR?s":
+    _add:
+      INTEGER:
+        description: Integer part in dithering mode
+        bitOffset: 4
+        bitWidth: 28
+        access: read-write
+      DITHER:
+        description: Dithered part in dithering mode
+        bitOffset: 0
+        bitWidth: 4
+        access: read-write
+
+"TIM[1346789],TIM??":
+  ARR:
+    _add:
+      INTEGER:
+        description: Integer part in dithering mode
+        bitOffset: 4
+        bitWidth: 16
+        access: read-write
+      DITHER:
+        description: Dithered part in dithering mode
+        bitOffset: 0
+        bitWidth: 4
+        access: read-write
+
+"TIM[25]":
+  ARR:
+    _add:
+      INTEGER:
+        description: Integer part in dithering mode
+        bitOffset: 4
+        bitWidth: 28
+        access: read-write
+      DITHER:
+        description: Dithered part in dithering mode
+        bitOffset: 0
+        bitWidth: 4
+        access: read-write
+

--- a/devices/common_patches/tim/tim_mms_ts_sms_ext.yaml
+++ b/devices/common_patches/tim/tim_mms_ts_sms_ext.yaml
@@ -1,0 +1,39 @@
+# Applicable to H5
+# The MMS, TS, SMS fields in the CR2 and SMCR registers are
+# extended in the general purpose and advanced timers
+
+"TIM[18]":
+  CR2:
+    _modify:
+      MMS:
+        name: MMS_L
+      MMS_1:
+        name: MMS_H
+  SMCR:
+    _modify:
+      TS:
+        name: TS_L
+      TS_1:
+        name: TS_H
+      SMS:
+        name: SMS_L
+      SMS_1:
+        name: SMS_H
+
+"TIM[2-5]":
+  CR2:
+    _modify:
+      MMS1:
+        name: MMS_L
+      MMS2:
+        name: MMS_H
+  SMCR:
+    _modify:
+      TS1:
+        name: TS_L
+      TS2:
+        name: TS_H
+      SMS1:
+        name: SMS_L
+      SMS2:
+        name: SMS_H

--- a/devices/common_patches/tim/tim_uifremap.yaml
+++ b/devices/common_patches/tim/tim_uifremap.yaml
@@ -1,0 +1,18 @@
+# Applicable to the H5 family
+# The MSB of the 32-bit CNT register on TIM2 and TIM5 stores a read-only copy of
+# the UIF flag, UIFCPY, if UIFREMAP is set. This adds a field to access it and fix
+# the description of CNT when applied.
+"TIM[25]":
+  CNT:
+    _modify:
+        CNT:
+          description: "Non-dithering mode (DITHEN = 0)\n
+                        The register holds the counter value.\n
+                        Dithering mode (DITHEN = 1)\n
+                        The register holds the non-dithered part. The fractional part is not available."
+    _add:
+      UIFCPY:
+        description: Read-only copy of the UIF bit of the TIMx_ISR register
+        bitOffset: 31
+        bitWidth: 1
+        access: read-only

--- a/devices/stm32f301.yaml
+++ b/devices/stm32f301.yaml
@@ -174,6 +174,7 @@ _include:
  - ../peripherals/tim/tim6.yaml
  - common_patches/tim/tim2345_mixed.yaml
  - ../peripherals/tim/tim2_common.yaml
+ - ../peripherals/tim/tim_mms_ts_sms.yaml
  - ../peripherals/tim/tim_advanced.yaml
  - common_patches/tim/tim_ccr.yaml
  - ../peripherals/tim/v2/ccm.yaml

--- a/devices/stm32h503.yaml
+++ b/devices/stm32h503.yaml
@@ -2,3 +2,19 @@ _svd: ../svd/stm32h503.svd
 
 _include:
   - common_patches/h5.yaml
+
+
+  - common_patches/tim/tim_ccr.yaml
+  - common_patches/tim/tim_ccm_ext.yaml
+  - common_patches/tim/tim_dither.yaml
+  - common_patches/tim/tim_mms_ts_sms_ext.yaml
+  - common_patches/tim/tim_uifremap.yaml
+
+  - ../peripherals/tim/tim_basic.yaml
+  - ../peripherals/tim/tim1_advanced.yaml
+  - ../peripherals/tim/tim2_common.yaml
+  - ../peripherals/tim/tim6_dither.yaml
+  - ../peripherals/tim/tim_common_ext.yaml
+  - ../peripherals/tim/tim_uifremap.yaml
+  - ../peripherals/tim/tim_dither.yaml
+  - ../peripherals/tim/v2/ccm_1_8.yaml

--- a/devices/stm32h562.yaml
+++ b/devices/stm32h562.yaml
@@ -26,3 +26,18 @@ _include:
   # - ../peripherals/rtc/rtc_common.yaml
 
   - ../peripherals/sai/sai.yaml
+
+  - common_patches/tim/tim_ccr.yaml
+  - common_patches/tim/tim_ccm_ext.yaml
+  - common_patches/tim/tim_dither.yaml
+  - common_patches/tim/tim_mms_ts_sms_ext.yaml
+  - common_patches/tim/tim_uifremap.yaml
+
+  - ../peripherals/tim/tim_basic.yaml
+  - ../peripherals/tim/tim1_advanced.yaml
+  - ../peripherals/tim/tim2_common.yaml
+  - ../peripherals/tim/tim6_dither.yaml
+  - ../peripherals/tim/tim_common_ext.yaml
+  - ../peripherals/tim/tim_uifremap.yaml
+  - ../peripherals/tim/tim_dither.yaml
+  - ../peripherals/tim/v2/ccm_1_8.yaml

--- a/devices/stm32h563.yaml
+++ b/devices/stm32h563.yaml
@@ -25,3 +25,18 @@ _include:
   # - ../peripherals/rtc/rtc_common.yaml
 
   - ../peripherals/sai/sai.yaml
+
+  - common_patches/tim/tim_ccr.yaml
+  - common_patches/tim/tim_ccm_ext.yaml
+  - common_patches/tim/tim_dither.yaml
+  - common_patches/tim/tim_mms_ts_sms_ext.yaml
+  - common_patches/tim/tim_uifremap.yaml
+
+  - ../peripherals/tim/tim_basic.yaml
+  - ../peripherals/tim/tim1_advanced.yaml
+  - ../peripherals/tim/tim2_common.yaml
+  - ../peripherals/tim/tim6_dither.yaml
+  - ../peripherals/tim/tim_common_ext.yaml
+  - ../peripherals/tim/tim_uifremap.yaml
+  - ../peripherals/tim/tim_dither.yaml
+  - ../peripherals/tim/v2/ccm_1_8.yaml

--- a/devices/stm32h573.yaml
+++ b/devices/stm32h573.yaml
@@ -25,3 +25,18 @@ _include:
   # - ../peripherals/rtc/rtc_common.yaml
 
   - ../peripherals/sai/sai.yaml
+
+  - common_patches/tim/tim_ccr.yaml
+  - common_patches/tim/tim_ccm_ext.yaml
+  - common_patches/tim/tim_dither.yaml
+  - common_patches/tim/tim_mms_ts_sms_ext.yaml
+  - common_patches/tim/tim_uifremap.yaml
+
+  - ../peripherals/tim/tim_basic.yaml
+  - ../peripherals/tim/tim1_advanced.yaml
+  - ../peripherals/tim/tim2_common.yaml
+  - ../peripherals/tim/tim6_dither.yaml
+  - ../peripherals/tim/tim_common_ext.yaml
+  - ../peripherals/tim/tim_uifremap.yaml
+  - ../peripherals/tim/tim_dither.yaml
+  - ../peripherals/tim/v2/ccm_1_8.yaml

--- a/peripherals/tim/tim1_advanced.yaml
+++ b/peripherals/tim/tim1_advanced.yaml
@@ -1,0 +1,180 @@
+TIM1:
+  CR2:
+    OIS?N:
+      Reset: [0, "OCxN=0 after a dead-time when MOE=0"]
+      Set: [1, "OCxN=1 after a dead-time when MOE=0"]
+    OIS?:
+      Reset: [0, "OCx=0 (after a dead-time if OCx(N) is implemented) when MOE=0"]
+      Set: [1, "OCx=1 (after a dead-time if OCx(N) is implemented) when MOE=0"]
+    CCUS:
+      Bit: [0, "When capture/compare control bits are preloaded (CCPC=1), they are updated by setting the COMG bit only"]
+      BitOrEdge: [1, "When capture/compare control bits are preloaded (CCPC=1), they are updated by setting the COMG bit or when an rising edge occurs on TRGI"]
+    CCPC:
+      NotPreloaded: [0, "CCxE, CCxNE and OCxM bits are not preloaded"]
+      Preloaded: [1, "CCxE, CCxNE and OCxM bits are preloaded"]
+
+  DIER:
+    COMDE:
+      Disabled: [0, "COM DMA request disabled"]
+      Enabled: [1, "COM DMA request enabled"]
+    BIE:
+      Disabled: [0, "Break interrupt disabled"]
+      Enabled: [1, "Break interrupt enabled"]
+    COMIE:
+      Disabled: [0, "COM interrupt disabled"]
+      Enabled: [1, "COM interrupt enabled"]
+
+  SR:
+    SBIF:
+      _read:
+        NoTrigger: [0, "No break event occurred"]
+        Trigger: [1, "An active level has been detected on the system break input. An interrupt is generated if BIE=1 in the TIMx_DIER register"]
+      _W0C:
+        Clear: [0, "Clear flag"]
+    B2IF:
+      _read:
+        NoTrigger: [0, "No break event occurred"]
+        Trigger: [1, "An active level has been detected on the break 2 input. An interrupt is generated if BIE=1 in the TIMx_DIER register"]
+      _W0C:
+        Clear: [0, "Clear flag"]
+    BIF:
+      _read:
+        NoTrigger: [0, "No break event occurred"]
+        Trigger: [1, "An active level has been detected on the break input. An interrupt is generated if BIE=1 in the TIMx_DIER register"]
+      _W0C:
+        Clear: [0, "Clear flag"]
+    COMIF:
+      _read:
+        NoCOM: [0, "No COM event occurred"]
+        COM: [1, "COM interrupt pending"]
+      _W0C:
+        Clear: [0, "Clear flag"]
+
+  EGR:
+    B2G:
+      _write:
+        Trigger: [1, "A break 2 event is generated. MOE bit is cleared and B2IF flag is set. Related interrupt can occur if enabled"]
+    BG:
+      _write:
+        Trigger: [1, "A break event is generated. MOE bit is cleared and BIF flag is set. Related interrupt or DMA transfer can occur if enabled"]
+    COMG:
+      _write:
+        Trigger: [1, "When CCPC bit is set, it allows CCxE, CCxNE and OCxM bits to be updated"]
+
+  RCR:
+    REP: [0, 65535]
+
+  AF1:
+    BKCMP?P:
+      NotInverted: [0, "Input polarity not inverted"]
+      Inverted: [1, "Input polarity inverted"]
+    BKINP:
+      NotInverted: [0, "Input polarity not inverted"]
+      Inverted: [1, "Input polarity inverted"]
+    BKCMP?E:
+      Disabled: [0, "Input disabled"]
+      Enabled: [1, "Input enabled"]
+    BKINE:
+      Disabled: [0, "BKIN input disabled"]
+      Enabled: [1, "BKIN input enabled"]
+
+  AF2:
+    BK2CMP?P:
+      NotInverted: [0, "Input polarity not inverted"]
+      Inverted: [1, "Input polarity inverted"]
+    BK2INP:
+      NotInverted: [0, "Input polarity not inverted"]
+      Inverted: [1, "Input polarity inverted"]
+    BK2CMP?E:
+      Disabled: [0, "Input disabled"]
+      Enabled: [1, "Input enabled"]
+    BK2INE:
+      Disabled: [0, "BKIN input disabled"]
+      Enabled: [1, "BKIN input enabled"]
+
+  BDTR:
+    _modify:
+      DT:
+        name: DTG
+    BK2BID:
+      Input: [0, "Break input BRK2 in input mode"]
+      Bidirectional: [1, "Break input BRK2 in bidirectional mode"]
+    BKBID:
+      Input: [0, "Break input BRK in input mode"]
+      Bidirectional: [1, "Break input BRK in bidirectional mode"]
+    BK2DSRM:
+      Armed: [0, "Break input BRK2 is armed"]
+      Disarmed: [1, "Break input BRK2 is disarmed"]
+    BKDSRM:
+      Armed: [0, "Break input BRK is armed"]
+      Disarmed: [1, "Break input BRK is disarmed"]
+    BK2P:
+      Low: [0, "Break input BRK2 is active low"]
+      High: [1, "Break input BRK2 is active high"]
+    BK2E:
+      Disabled: [0, "Break function disabled"]
+      Enabled: [1, "Break function enabled"]
+    BK2F:
+      NoFilter: [0, "No filter, sampling is done at fDTS"]
+      FCK_INT_N2: [1, "fSAMPLING=fCK_INT, N=2"]
+      FCK_INT_N4: [2, "fSAMPLING=fCK_INT, N=4"]
+      FCK_INT_N8: [3, "fSAMPLING=fCK_INT, N=8"]
+      FDTS_Div2_N6: [4, "fSAMPLING=fDTS/2, N=6"]
+      FDTS_Div2_N8: [5, "fSAMPLING=fDTS/2, N=8"]
+      FDTS_Div4_N6: [6, "fSAMPLING=fDTS/4, N=6"]
+      FDTS_Div4_N8: [7, "fSAMPLING=fDTS/4, N=8"]
+      FDTS_Div8_N6: [8, "fSAMPLING=fDTS/8, N=6"]
+      FDTS_Div8_N8: [9, "fSAMPLING=fDTS/8, N=8"]
+      FDTS_Div16_N5: [10, "fSAMPLING=fDTS/16, N=5"]
+      FDTS_Div16_N6: [11, "fSAMPLING=fDTS/16, N=6"]
+      FDTS_Div16_N8: [12, "fSAMPLING=fDTS/16, N=8"]
+      FDTS_Div32_N5: [13, "fSAMPLING=fDTS/32, N=5"]
+      FDTS_Div32_N6: [14, "fSAMPLING=fDTS/32, N=6"]
+      FDTS_Div32_N8: [15, "fSAMPLING=fDTS/32, N=8"]
+    BKF:
+      NoFilter: [0, "No filter, sampling is done at fDTS"]
+      FCK_INT_N2: [1, "fSAMPLING=fCK_INT, N=2"]
+      FCK_INT_N4: [2, "fSAMPLING=fCK_INT, N=4"]
+      FCK_INT_N8: [3, "fSAMPLING=fCK_INT, N=8"]
+      FDTS_Div2_N6: [4, "fSAMPLING=fDTS/2, N=6"]
+      FDTS_Div2_N8: [5, "fSAMPLING=fDTS/2, N=8"]
+      FDTS_Div4_N6: [6, "fSAMPLING=fDTS/4, N=6"]
+      FDTS_Div4_N8: [7, "fSAMPLING=fDTS/4, N=8"]
+      FDTS_Div8_N6: [8, "fSAMPLING=fDTS/8, N=6"]
+      FDTS_Div8_N8: [9, "fSAMPLING=fDTS/8, N=8"]
+      FDTS_Div16_N5: [10, "fSAMPLING=fDTS/16, N=5"]
+      FDTS_Div16_N6: [11, "fSAMPLING=fDTS/16, N=6"]
+      FDTS_Div16_N8: [12, "fSAMPLING=fDTS/16, N=8"]
+      FDTS_Div32_N5: [13, "fSAMPLING=fDTS/32, N=5"]
+      FDTS_Div32_N6: [14, "fSAMPLING=fDTS/32, N=6"]
+      FDTS_Div32_N8: [15, "fSAMPLING=fDTS/32, N=8"]
+    MOE:
+      Disabled: [0, "In response to a break 2 event OC and OCN outputs are disabled - In response to a break event or if MOE is written to 0 OC and OCN outputs are disabled or forced to idle state depending on the OSSI bit"]
+      Enabled: [1, "OC and OCN outputs are enabled if their respective enable bits are set (CCxE, CCxNE in TIMx_CCER register)"]
+    AOE:
+      Disabled: [0, "MOE can be set only by software"]
+      Enabled: [1, "MOE can be set by software or automatically at the next update event (if none of the break inputs BRK and BRK2 is active)"]
+    BKP:
+      ActiveLow: [0, "Break input BRK is active low"]
+      ActiveHigh: [1, "Break input BRK is active high"]
+    BKE:
+      Disabled: [0, "Break function disabled"]
+      Enabled: [1, "Break function enabled"]
+    OSSR:
+      Disabled: [0, "OC/OCN outputs are disabled when inactive"]
+      Enabled: [1, "OC/OCN outputs are enabled with their inactive level as soon as CCxE=1 or CCxNE=1"]
+    OSSI:
+      Disabled: [0, "OC/OCN outputs are disabled when inactive"]
+      Enabled: [1, "OC/OCN outputs are first forced with their inactive level then forced to their idle level after the deadtime"]
+    LOCK:
+      "Off": [0, "No write protection"]
+      Level1: [1, "Level 1 write protection"]
+      Level2: [2, "Level 2 write protection"]
+      Level3: [3, "Level 3 write protection"]
+    DTG: [0, 0xFF]
+  CCER:
+    "CC?NE":
+      Disabled: [0, "Complementary output disabled"]
+      Enabled: [1, "Complementary output enabled"]
+  DMAR:
+    DMAB: [0, 0xFFFF]

--- a/peripherals/tim/tim2345_16bit.yaml
+++ b/peripherals/tim/tim2345_16bit.yaml
@@ -3,6 +3,7 @@
 
 _include:
   - ./tim2_common.yaml
+  - ./tim_mms_ts_sms.yaml
 
 "TIM[2345]":
   _include:

--- a/peripherals/tim/tim2345_mixed.yaml
+++ b/peripherals/tim/tim2345_mixed.yaml
@@ -3,6 +3,7 @@
 
 _include:
   - ./tim2_common.yaml
+  - ./tim_mms_ts_sms.yaml
 
 "TIM[34]":
   _include:

--- a/peripherals/tim/tim2_32bit.yaml
+++ b/peripherals/tim/tim2_32bit.yaml
@@ -5,6 +5,7 @@
 
 _include:
   - ./tim2_common.yaml
+  - ./tim_mms_ts_sms.yaml
 
 "TIM2":
   _include:

--- a/peripherals/tim/tim2_common.yaml
+++ b/peripherals/tim/tim2_common.yaml
@@ -5,15 +5,6 @@
     TI1S:
       Normal: [0, "The TIMx_CH1 pin is connected to TI1 input"]
       XOR: [1, "The TIMx_CH1, CH2, CH3 pins are connected to TI1 input"]
-    MMS:
-      Reset: [0, "The UG bit from the TIMx_EGR register is used as trigger output"]
-      Enable: [1, "The counter enable signal, CNT_EN, is used as trigger output"]
-      Update: [2, "The update event is selected as trigger output"]
-      ComparePulse: [3, "The trigger output send a positive pulse when the CC1IF flag it to be set, as soon as a capture or a compare match occurred"]
-      CompareOC1: [4, "OC1REF signal is used as trigger output"]
-      CompareOC2: [5, "OC2REF signal is used as trigger output"]
-      CompareOC3: [6, "OC3REF signal is used as trigger output"]
-      CompareOC4: [7, "OC4REF signal is used as trigger output"]
     CCDS:
       OnCompare: [0, "CCx DMA request sent when CCx event occurs"]
       OnUpdate: [1, "CCx DMA request sent when update event occurs"]
@@ -49,23 +40,6 @@
     MSM:
       NoSync: [0, "No action"]
       Sync: [1, "The effect of an event on the trigger input (TRGI) is delayed to allow a perfect synchronization between the current timer and its slaves (through TRGO). It is useful if we want to synchronize several timers on a single external event."]
-    TS:
-      ITR0: [0, "Internal Trigger 0 (ITR0)"]
-      ITR1: [1, "Internal Trigger 1 (ITR1)"]
-      ITR2: [2, "Internal Trigger 2 (ITR2)"]
-      TI1F_ED: [4, "TI1 Edge Detector (TI1F_ED)"]
-      TI1FP1: [5, "Filtered Timer Input 1 (TI1FP1)"]
-      TI2FP2: [6, "Filtered Timer Input 2 (TI2FP2)"]
-      ETRF: [7, "External Trigger input (ETRF)"]
-    SMS:
-      Disabled: [0, "Slave mode disabled - if CEN = ‘1 then the prescaler is clocked directly by the internal clock."]
-      Encoder_Mode_1: [1, "Encoder mode 1 - Counter counts up/down on TI2FP1 edge depending on TI1FP2 level."]
-      Encoder_Mode_2: [2, "Encoder mode 2 - Counter counts up/down on TI1FP2 edge depending on TI2FP1 level."]
-      Encoder_Mode_3: [3, "Encoder mode 3 - Counter counts up/down on both TI1FP1 and TI2FP2 edges depending on the level of the other input."]
-      Reset_Mode: [4, "Reset Mode - Rising edge of the selected trigger input (TRGI) reinitializes the counter and generates an update of the registers."]
-      Gated_Mode: [5, "Gated Mode - The counter clock is enabled when the trigger input (TRGI) is high. The counter stops (but is not reset) as soon as the trigger becomes low. Both start and stop of the counter are controlled."]
-      Trigger_Mode: [6, "Trigger Mode - The counter starts at a rising edge of the trigger TRGI (but it is not reset). Only the start of the counter is controlled."]
-      Ext_Clock_Mode: [7, "External Clock Mode 1 - Rising edges of the selected trigger (TRGI) clock the counter."]
   DIER:
     TDE:
       Disabled: [0, "Trigger DMA request disabled"]

--- a/peripherals/tim/tim6.yaml
+++ b/peripherals/tim/tim6.yaml
@@ -1,18 +1,7 @@
-# TIM6 and TIM7
-# Present accross all STM32 except STM32F401 and STM32F411 devices.
-# STM32F410 has only TIM6
+# TIM6 and TIM7 without dithering support
 
 "TIM[67]":
-  CR2:
-    MMS:
-      Reset: [0, "Use UG bit from TIMx_EGR register"]
-      Enable: [1, "Use CNT bit from TIMx_CEN register"]
-      Update: [2, "Use the update event"]
-  CNT:
-    CNT: [0, 65535]
+  _include:
+    - tim6_base.yaml
   ARR:
-    ARR: [0, 65535]
-  DIER:
-    UDE:
-      Disabled: [0, "Update DMA request disabled"]
-      Enabled: [1, "Update DMA request enabled"]
+    ARR: [0, 0xFFFF]

--- a/peripherals/tim/tim6_base.yaml
+++ b/peripherals/tim/tim6_base.yaml
@@ -1,0 +1,15 @@
+# TIM6 and TIM7 base registers
+# Present accross all STM32 except STM32F401 and STM32F411 devices.
+# STM32F410 has only TIM6
+
+CR2:
+  MMS:
+    Reset: [0, "Use UG bit from TIMx_EGR register"]
+    Enable: [1, "Use CNT bit from TIMx_CEN register"]
+    Update: [2, "Use the update event"]
+CNT:
+  CNT: [0, 65535]
+DIER:
+  UDE:
+    Disabled: [0, "Update DMA request disabled"]
+    Enabled: [1, "Update DMA request enabled"]

--- a/peripherals/tim/tim6_dither.yaml
+++ b/peripherals/tim/tim6_dither.yaml
@@ -1,0 +1,7 @@
+# TIM6 and TIM7 with dithering support
+
+"TIM[67]":
+  _include:
+    - tim6_base.yaml
+  ARR:
+    ARR: [0, 0xFFFFFF]

--- a/peripherals/tim/tim_common_ext.yaml
+++ b/peripherals/tim/tim_common_ext.yaml
@@ -1,0 +1,74 @@
+# Extended functionality for GP and Advanced timers. Applicable to H5.
+
+"TIM[1-58]":
+  CR2:
+    MMS_L: [0, 7]
+    MMS_H: [0, 1]
+
+  SMCR:
+    TS_L: [0, 7]
+    TS_H: [0, 3]
+    SMS_L: [0, 7]
+    SMS_H: [0, 1]
+    SMSPS:
+      Update: [0, "SMSM[3:0] is preloaded from Update event"]
+      Index: [1, "SMSM[3:0] is preloaded from Index event"]
+    SMSPE:
+      NotPreloaded: [0, "SMSM[3:0] is not preloaded"]
+      PreloadEnabled: [1, "SMSM[3:0] is preload is enabled"]
+
+  DIER:
+    TERRIE:
+      Disabled: [0, "Transition error interrupt disabled"]
+      Enabled: [1, "Transition error interrupt enabled"]
+    IERRIE:
+      Disabled: [0, "Index error interrupt disabled"]
+      Enabled: [1, "Index error interrupt enabled"]
+    DIRIE:
+      Disabled: [0, "Direction change interrupt disabled"]
+      Enabled: [1, "Direction change interrupt enabled"]
+    IDXIE:
+      Disabled: [0, "Index change interrupt disabled"]
+      Enabled: [1, "Index change interrupt enabled"]
+
+  SR:
+    TERRF:
+      _read:
+        NoTrigger: [0, "No encoder transition error has been detected"]
+        Trigger: [1, "An encoder transition error has been detected"]
+      _W0C:
+        Clear: [0, "Clear flag"]
+    IERRF:
+      _read:
+        NoTrigger: [0, "No index error has been detected"]
+        Trigger: [1, "An index erorr has been detected"]
+      _W0C:
+        Clear: [0, "Clear flag"]
+    DIRF:
+      _read:
+        NoTrigger: [0, "No direction change has been detected"]
+        Trigger: [1, "A direction change has been detected"]
+      _W0C:
+        Clear: [0, "Clear flag"]
+    IDXF:
+      _read:
+        NoTrigger: [0, "No index event occurred"]
+        Trigger: [1, "An index event has occurred"]
+      _W0C:
+        Clear: [0, "Clear flag"]
+
+  AF1:
+    ETRSEL:
+      Legacy: [0, 'ETR legacy mode']
+      COMP1: [1, 'COMP1 output']
+      COMP2: [2, 'COMP2 output']
+
+  AF2:
+    OCRSEL: [0, 7]
+
+  TISEL:
+    TI?SEL:
+      Selected: [0, "TIM1_CHx input selected"]
+
+  DCR:
+    DBSS: [0, 7]

--- a/peripherals/tim/tim_dither.yaml
+++ b/peripherals/tim/tim_dither.yaml
@@ -1,0 +1,21 @@
+"TIM[25]":
+  CNT:
+    CNT: [0, 0xFFFFFFFF]
+  ARR:
+    ARR: [0, 0xFFFFF]
+  "CCR?s":
+    CCR: [0, 0xFFFFFFFF]
+
+"TIM[1348]":
+  CNT:
+    CNT: [0, 0xFFFF]
+  ARR:
+    ARR: [0, 0xFFFFF]
+  "CCR?s":
+    CCR: [0, 0xFFFFF]
+
+"TIM*":
+  CR1:
+    DITHEN:
+      Disabled: [0, "Dithering disabled"]
+      Enabled: [1, "Dithering enabled"]

--- a/peripherals/tim/tim_mms_ts_sms.yaml
+++ b/peripherals/tim/tim_mms_ts_sms.yaml
@@ -1,0 +1,29 @@
+"TIM[1-58]":
+  CR2:
+    MMS:
+      Reset: [0, "The UG bit from the TIMx_EGR register is used as trigger output"]
+      Enable: [1, "The counter enable signal, CNT_EN, is used as trigger output"]
+      Update: [2, "The update event is selected as trigger output"]
+      ComparePulse: [3, "The trigger output send a positive pulse when the CC1IF flag it to be set, as soon as a capture or a compare match occurred"]
+      CompareOC1: [4, "OC1REF signal is used as trigger output"]
+      CompareOC2: [5, "OC2REF signal is used as trigger output"]
+      CompareOC3: [6, "OC3REF signal is used as trigger output"]
+      CompareOC4: [7, "OC4REF signal is used as trigger output"]
+  SMCR:
+    TS:
+      ITR0: [0, "Internal Trigger 0 (ITR0)"]
+      ITR1: [1, "Internal Trigger 1 (ITR1)"]
+      ITR2: [2, "Internal Trigger 2 (ITR2)"]
+      TI1F_ED: [4, "TI1 Edge Detector (TI1F_ED)"]
+      TI1FP1: [5, "Filtered Timer Input 1 (TI1FP1)"]
+      TI2FP2: [6, "Filtered Timer Input 2 (TI2FP2)"]
+      ETRF: [7, "External Trigger input (ETRF)"]
+    SMS:
+      Disabled: [0, "Slave mode disabled - if CEN = ‘1 then the prescaler is clocked directly by the internal clock."]
+      Encoder_Mode_1: [1, "Encoder mode 1 - Counter counts up/down on TI2FP1 edge depending on TI1FP2 level."]
+      Encoder_Mode_2: [2, "Encoder mode 2 - Counter counts up/down on TI1FP2 edge depending on TI2FP1 level."]
+      Encoder_Mode_3: [3, "Encoder mode 3 - Counter counts up/down on both TI1FP1 and TI2FP2 edges depending on the level of the other input."]
+      Reset_Mode: [4, "Reset Mode - Rising edge of the selected trigger input (TRGI) reinitializes the counter and generates an update of the registers."]
+      Gated_Mode: [5, "Gated Mode - The counter clock is enabled when the trigger input (TRGI) is high. The counter stops (but is not reset) as soon as the trigger becomes low. Both start and stop of the counter are controlled."]
+      Trigger_Mode: [6, "Trigger Mode - The counter starts at a rising edge of the trigger TRGI (but it is not reset). Only the start of the counter is controlled."]
+      Ext_Clock_Mode: [7, "External Clock Mode 1 - Rising edges of the selected trigger (TRGI) clock the counter."]

--- a/peripherals/tim/tim_uifremap.yaml
+++ b/peripherals/tim/tim_uifremap.yaml
@@ -1,0 +1,10 @@
+"TIM*":
+  CR1:
+    UIFREMAP:
+      Disabled: [0, "No remapping. UIF status bit is not copied to TIMx_CNT register bit 31"]
+      Enabled: [1, "Remapping enabled. UIF status bit is copied to TIMx_CNT register bit 31"]
+  CNT:
+    UIFCPY:
+      _read:
+        NoUpdateOccurred: [0, "No update occurred"]
+        UpdatePending: [1, "Update interrupt pending"]

--- a/peripherals/tim/v2/ccm_1_8.yaml
+++ b/peripherals/tim/v2/ccm_1_8.yaml
@@ -1,0 +1,3 @@
+"TIM[18],TIM[2-5]":
+  _include:
+    - ccm_extended.yaml

--- a/peripherals/tim/v2/ccm_common.yaml
+++ b/peripherals/tim/v2/ccm_common.yaml
@@ -1,17 +1,6 @@
 "TIM[18],TIM20,TIM[2-5],TIM19":
-  CCMR?_Output:
-    OC?M:
-      Frozen: [0, "The comparison between the output compare register TIMx_CCRy and the counter TIMx_CNT has no effect on the outputs / OpmMode1: Retriggerable OPM mode 1 - In up-counting mode, the channel is active until a trigger event is detected (on TRGI signal). In down-counting mode, the channel is inactive"]
-      ActiveOnMatch: [1, "Set channel to active level on match. OCyREF signal is forced high when the counter matches the capture/compare register / OpmMode2: Inversely to OpmMode1"]
-      InactiveOnMatch: [2, "Set channel to inactive level on match. OCyREF signal is forced low when the counter matches the capture/compare register / Reserved"]
-      Toggle: [3, "OCyREF toggles when TIMx_CNT=TIMx_CCRy / Reserved"]
-      ForceInactive: [4, "OCyREF is forced low / CombinedPwmMode1: OCyREF has the same behavior as in PWM mode 1. OCyREFC is the logical OR between OC1REF and OC2REF"]
-      ForceActive: [5, "OCyREF is forced high / CombinedPwmMode2: OCyREF has the same behavior as in PWM mode 2. OCyREFC is the logical AND between OC1REF and OC2REF"]
-      PwmMode1: [6, "In upcounting, channel is active as long as TIMx_CNT<TIMx_CCRy else inactive. In downcounting, channel is inactive as long as TIMx_CNT>TIMx_CCRy else active / AsymmetricPwmMode1: OCyREF has the same behavior as in PWM mode 1. OCyREFC outputs OC1REF when the counter is counting up, OC2REF when it is counting down"]
-      PwmMode2: [7, "Inversely to PwmMode1 / AsymmetricPwmMode2: Inversely to AsymmetricPwmMode1"]
-    OC?M_3:
-      Normal: [0, "Normal output compare mode (modes 0-7)"]
-      Extended: [1, "Extended output compare mode (modes 7-15)"]
+  _include:
+    - ccm_extended.yaml
 
 "TIM10,TIM11,TIM13,TIM14,TIM16,TIM17":
   CCMR?_Output:

--- a/peripherals/tim/v2/ccm_extended.yaml
+++ b/peripherals/tim/v2/ccm_extended.yaml
@@ -1,0 +1,13 @@
+CCMR?_Output:
+  OC?M:
+    Frozen: [0, "The comparison between the output compare register TIMx_CCRy and the counter TIMx_CNT has no effect on the outputs / OpmMode1: Retriggerable OPM mode 1 - In up-counting mode, the channel is active until a trigger event is detected (on TRGI signal). In down-counting mode, the channel is inactive"]
+    ActiveOnMatch: [1, "Set channel to active level on match. OCyREF signal is forced high when the counter matches the capture/compare register / OpmMode2: Inversely to OpmMode1"]
+    InactiveOnMatch: [2, "Set channel to inactive level on match. OCyREF signal is forced low when the counter matches the capture/compare register / Reserved"]
+    Toggle: [3, "OCyREF toggles when TIMx_CNT=TIMx_CCRy / Reserved"]
+    ForceInactive: [4, "OCyREF is forced low / CombinedPwmMode1: OCyREF has the same behavior as in PWM mode 1. OCyREFC is the logical OR between OC1REF and OC2REF"]
+    ForceActive: [5, "OCyREF is forced high / CombinedPwmMode2: OCyREF has the same behavior as in PWM mode 2. OCyREFC is the logical AND between OC1REF and OC2REF"]
+    PwmMode1: [6, "In upcounting, channel is active as long as TIMx_CNT<TIMx_CCRy else inactive. In downcounting, channel is inactive as long as TIMx_CNT>TIMx_CCRy else active / AsymmetricPwmMode1: OCyREF has the same behavior as in PWM mode 1. OCyREFC outputs OC1REF when the counter is counting up, OC2REF when it is counting down"]
+    PwmMode2: [7, "Inversely to PwmMode1 / AsymmetricPwmMode2: Inversely to AsymmetricPwmMode1"]
+  OC?M_3:
+    Normal: [0, "Normal output compare mode (modes 0-7)"]
+    Extended: [1, "Extended output compare mode (modes 7-15)"]


### PR DESCRIPTION
This does some light refactoring of the timer field definitions to account for similarities and differences between the H5 family and other families, and provides full definitions for Timers 1-8, which are common to the H5 family. Note: It does not provide any definitions for TIM1x found on the larger H562, H563 and H573 chips.