### PR TITLE
Add IWDG for H5 family

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-* Remove workaround for bug in duckscript's `mv` 
+* Remove workaround for bug in duckscript's `mv`
 * Replace `makehtml.py` with `svd2html`
 * Updated to svd2rust 0.30.0, svdtools 0.3.0, use tools binaries for CI
 * Enable atomic operations on register support, Rust edition 2021 (#846)
@@ -11,6 +11,7 @@
 * DMAMUX: merge registers in arrays
 * STM32U5xx: Update SVD version and add variants for xx=35,45,95,A5,99,A9 (#844)
 * Fix ADC SR OVR enums
+* H5: Add IWDG definitions
 
 [#854]: https://github.com/stm32-rs/stm32-rs/pull/854
 

--- a/devices/common_patches/h5.yaml
+++ b/devices/common_patches/h5.yaml
@@ -64,6 +64,15 @@ ICACHE:
 IWDG:
   _strip:
     - "IWDG_"
+  SR:
+    _add:
+      ONF:
+        description: "Watchdog enable status bit.
+                      Set to ‘1’ by hardware as soon as the IWDG is started. In software mode, it remains to '1' until
+                      the IWDG is reset. In hardware mode, this bit is always set to '1'."
+        bitOffset: 8
+        bitWidth: 1
+        access: read-only
 
 LPTIM?:
   _strip:

--- a/devices/stm32h503.yaml
+++ b/devices/stm32h503.yaml
@@ -2,3 +2,9 @@ _svd: ../svd/stm32h503.svd
 
 _include:
   - common_patches/h5.yaml
+
+  - ../peripherals/iwdg/iwdg_with_WINR.yaml
+  - ../peripherals/iwdg/iwdg_sr.yaml
+  - ../peripherals/iwdg/iwdg_sr_ext.yaml
+  - ../peripherals/iwdg/iwdg_ewcr.yaml
+  - ../peripherals/iwdg/iwdg_pr_ext.yaml

--- a/devices/stm32h562.yaml
+++ b/devices/stm32h562.yaml
@@ -26,3 +26,9 @@ _include:
   # - ../peripherals/rtc/rtc_common.yaml
 
   - ../peripherals/sai/sai.yaml
+
+  - ../peripherals/iwdg/iwdg_with_WINR.yaml
+  - ../peripherals/iwdg/iwdg_sr.yaml
+  - ../peripherals/iwdg/iwdg_sr_ext.yaml
+  - ../peripherals/iwdg/iwdg_ewcr.yaml
+  - ../peripherals/iwdg/iwdg_pr_ext.yaml

--- a/devices/stm32h563.yaml
+++ b/devices/stm32h563.yaml
@@ -25,3 +25,9 @@ _include:
   # - ../peripherals/rtc/rtc_common.yaml
 
   - ../peripherals/sai/sai.yaml
+  
+  - ../peripherals/iwdg/iwdg_with_WINR.yaml
+  - ../peripherals/iwdg/iwdg_sr.yaml
+  - ../peripherals/iwdg/iwdg_sr_ext.yaml
+  - ../peripherals/iwdg/iwdg_ewcr.yaml
+  - ../peripherals/iwdg/iwdg_pr_ext.yaml

--- a/devices/stm32h573.yaml
+++ b/devices/stm32h573.yaml
@@ -25,3 +25,9 @@ _include:
   # - ../peripherals/rtc/rtc_common.yaml
 
   - ../peripherals/sai/sai.yaml
+
+  - ../peripherals/iwdg/iwdg_with_WINR.yaml
+  - ../peripherals/iwdg/iwdg_sr.yaml
+  - ../peripherals/iwdg/iwdg_sr_ext.yaml
+  - ../peripherals/iwdg/iwdg_ewcr.yaml
+  - ../peripherals/iwdg/iwdg_pr_ext.yaml

--- a/peripherals/iwdg/iwdg.yaml
+++ b/peripherals/iwdg/iwdg.yaml
@@ -17,6 +17,5 @@
       DivideBy64: [4, "Divider /64"]
       DivideBy128: [5, "Divider /128"]
       DivideBy256: [6, "Divider /256"]
-      DivideBy256bis: [7, "Divider /256"]
   RLR:
     RL: [0, 4095]

--- a/peripherals/iwdg/iwdg_ewcr.yaml
+++ b/peripherals/iwdg/iwdg_ewcr.yaml
@@ -1,0 +1,11 @@
+# EWCR register. Present on H5 family.
+
+"IWDG,IWDG?":
+  EWCR:
+    EWIE:
+      Disabled: [0, "Early interrupt is disabled"]
+      Enabled: [1, "Early interrupt is enabled"]
+    EWIC:
+      _write:
+        Acknowledge: [1, "Acknowledge early wake-up interrupt"]
+    EWIT: [0x1, 0xFFF]

--- a/peripherals/iwdg/iwdg_pr_ext.yaml
+++ b/peripherals/iwdg/iwdg_pr_ext.yaml
@@ -1,0 +1,5 @@
+"IWDG,IWDG?":
+  PR:
+    PR:
+      DivideBy512: [7, "Divider /512"]
+      DivideBy1024: [8, "Divider /1024"]

--- a/peripherals/iwdg/iwdg_sr.yaml
+++ b/peripherals/iwdg/iwdg_sr.yaml
@@ -1,11 +1,5 @@
 "IWDG,IWDG?":
   SR:
-    WVU:
-      Idle: [0, "No update on-going"]
-      Busy: [1, "Update on-going"]
-    RVU:
-      Idle: [0, "No update on-going"]
-      Busy: [1, "Update on-going"]
-    PVU:
+    "*U":
       Idle: [0, "No update on-going"]
       Busy: [1, "Update on-going"]

--- a/peripherals/iwdg/iwdg_sr_ext.yaml
+++ b/peripherals/iwdg/iwdg_sr_ext.yaml
@@ -1,0 +1,11 @@
+
+"IWDG,IWDG?":
+  SR:
+    "*IF":
+      _read:
+        NotPending: [0, "No pending interrupt"]
+        Pending: [1, "Interrupt pending"]
+    ONF:
+      _read:
+        NotActivated: [0, "IWDG is not activated"]
+        Activated: [1, "IWDG is activated"]


### PR DESCRIPTION
Modifies some common IWDG field definitions to account for the larger fields on the H5 family, fixes some register definitions for the H5 family and adds the definitions for all H5 processors.