### PR TITLE
Add CRS peripheral and add to H5 family

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-* Remove workaround for bug in duckscript's `mv` 
+* Remove workaround for bug in duckscript's `mv`
 * Replace `makehtml.py` with `svd2html`
 * Updated to svd2rust 0.30.0, svdtools 0.3.0, use tools binaries for CI
 * Enable atomic operations on register support, Rust edition 2021 (#846)
@@ -11,6 +11,7 @@
 * DMAMUX: merge registers in arrays
 * STM32U5xx: Update SVD version and add variants for xx=35,45,95,A5,99,A9 (#844)
 * Fix ADC SR OVR enums
+* H5: Add CRS definitions
 
 [#854]: https://github.com/stm32-rs/stm32-rs/pull/854
 

--- a/devices/stm32h503.yaml
+++ b/devices/stm32h503.yaml
@@ -2,3 +2,5 @@ _svd: ../svd/stm32h503.svd
 
 _include:
   - common_patches/h5.yaml
+
+  - ../peripherals/crs/crs.yaml

--- a/devices/stm32h562.yaml
+++ b/devices/stm32h562.yaml
@@ -26,3 +26,5 @@ _include:
   # - ../peripherals/rtc/rtc_common.yaml
 
   - ../peripherals/sai/sai.yaml
+
+  - ../peripherals/crs/crs.yaml

--- a/devices/stm32h563.yaml
+++ b/devices/stm32h563.yaml
@@ -25,3 +25,5 @@ _include:
   # - ../peripherals/rtc/rtc_common.yaml
 
   - ../peripherals/sai/sai.yaml
+
+  - ../peripherals/crs/crs.yaml

--- a/devices/stm32h573.yaml
+++ b/devices/stm32h573.yaml
@@ -25,3 +25,5 @@ _include:
   # - ../peripherals/rtc/rtc_common.yaml
 
   - ../peripherals/sai/sai.yaml
+
+  - ../peripherals/crs/crs.yaml

--- a/peripherals/crs/crs.yaml
+++ b/peripherals/crs/crs.yaml
@@ -1,0 +1,53 @@
+CRS:
+  CR:
+    TRIM: [0, 0x3F]
+    SWSYNC:
+      Sync: [1, "A software sync is generated"]
+    AUTOTRIMEN:
+      Disabled: [0, "Automatic trimming disabled"]
+      Enabled: [1, "Automatic trimming enabled"]
+    CEN:
+      Disabled: [0, "Frequency error counter disabled"]
+      Enabled: [1, "Frequency error counter enabled"]
+    "*IE":
+      Disabled: [0, "Interrupt disabled"]
+      Enabled: [1, "Interrupt enabled"]
+
+  CFGR:
+    SYNCPOL:
+      RisingEdge: [0, "SYNC active on rising edge"]
+      FallingEdge: [1, "SYNC active on falling edge"]
+    SYNCSRC:
+      GPIO_AF: [0, "GPIO AF (crs_sync_in_1) selected as SYNC signal source"]
+      LSE: [1, "LSE (crs_sync_in_2) selected as SYNC signal source"]
+      USB_SOF: [2, "USB SOF (crs_sync_in_3) selected as SYNC signal source"]
+    SYNCDIV:
+      NotDivided: [0, "SYNC not divided"]
+      DivideBy2: [1, "SYNC divided by 2"]
+      DivideBy4: [2, "SYNC divided by 4"]
+      DivideBy8: [3, "SYNC divided by 8"]
+      DivideBy16: [4, "SYNC divided by 16"]
+      DivideBy32: [5, "SYNC divided by 32"]
+      DivideBy64: [6, "SYNC divided by 64"]
+      DivideBy128: [7, "SYNC divided by 128"]
+    FELIM: [0, 0xFF]
+    RELOAD: [0, 0xFFFF]
+
+  ISR:
+    FECAP: [0, 0xFFFF]
+    FEDIR:
+      UpCounting: [0, "Error in up-counting direction"]
+      DownCounting: [1, "Error in down-counting direction"]
+    SYNCMISS:
+      NotSignaled: [0, "Signal not set"]
+      Signaled: [1, "Signal set"]
+    SYNCERR:
+      NotSignaled: [0, "Signal not set"]
+      Signaled: [1, "Signal set"]
+    "*F":
+      NotSignaled: [0, "Signal not set"]
+      Signaled: [1, "Signal set"]
+
+  ICR:
+    "*C":
+      Clear: [1, "Clear flag"]


### PR DESCRIPTION
The CRS peripheral was missing from stm32-rs (I'm not sure whether or not it's new with the H5 family), so this adds the definitions relevant to the H5 family, and includes it in the H5 PAC.