### PR TITLE
mmaps_pr: also take SVDs from PR

### DIFF
--- a/.github/workflows/mmaps_pr.yaml
+++ b/.github/workflows/mmaps_pr.yaml
@@ -55,10 +55,10 @@ jobs:
           BRANCH=pr-${{ github.event.number }}-$COMMIT
           echo "BRANCH=$BRANCH" >> $GITHUB_ENV
 
-          # Use the PR's YAML files to rebuild mmaps
+          # Use the PR's SVDs and YAML files to rebuild mmaps
           cd ../master
-          rm -rf devices peripherals
-          mv ../pr/devices ../pr/peripherals .
+          rm -rf devices peripherals svd
+          mv ../pr/devices ../pr/peripherals ../pr/svd .
           make -j2 mmaps
 
           # Use the new mmaps to make a commit in the mmaps repo


### PR DESCRIPTION
The YAML files in the pull request might be based off of updated SVD files; ensure we are using the most up-to-date SVD files to generate the pull request's memory map files.