### PR TITLE
fix DAC peripheral for stm32f4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * Fix writeConstraint bugs
 * STM32G491: Add FDCAN2 peripheral
 * Fix typo in STM32G491 FDCAN2 patch
+* Fix DAC for stm32f4 (#921)
 
 [#854]: https://github.com/stm32-rs/stm32-rs/pull/854
 

--- a/devices/stm32f410.yaml
+++ b/devices/stm32f410.yaml
@@ -157,6 +157,18 @@ MPU:
   _strip:
     - "MPU_"
 
+DAC:
+  CR:
+    _delete:
+      - DMAUDRIE2
+      - DMAEN2
+      - MAMP2
+      - WAVE2
+      - TSEL2
+      - TEN2
+      - BOFF2
+      - EN2
+
 _include:
  - common_patches/nvic/4_prio_bits.yaml
  - common_patches/i2c/merge_OAR1_ADDx_fields.yaml
@@ -165,7 +177,7 @@ _include:
  - common_patches/adc/f4_single_ccr.yaml
  - common_patches/rcc/f41x_bdcr_lsemod.yaml
  - ../peripherals/dac/dac_wavegen.yaml
- - ../peripherals/dac/dac_common_2ch.yaml
+ - ../peripherals/dac/dac_f410.yaml
  - ../peripherals/dac/dac_dmaudr.yaml
  - ../peripherals/rcc/rcc_merge_sw_sws.yaml
  - ../peripherals/rcc/rcc_v2.yaml

--- a/devices/stm32f413.yaml
+++ b/devices/stm32f413.yaml
@@ -281,7 +281,7 @@ _include:
  - common_patches/fsmc/fsmc_sram.yaml
  - ../peripherals/fsmc/fsmc_sram.yaml
  - ../peripherals/dac/dac_wavegen.yaml
- - ../peripherals/dac/dac_common_2ch.yaml
+ - ../peripherals/dac/dac_f4_2ch.yaml
  - ../peripherals/dac/dac_dmaudr.yaml
  - ../peripherals/rcc/rcc_merge_sw_sws.yaml
  - ../peripherals/rcc/rcc_v2.yaml

--- a/devices/stm32f427.yaml
+++ b/devices/stm32f427.yaml
@@ -187,7 +187,7 @@ _include:
  - ../peripherals/fsmc/fsmc_nand.yaml
  - ../peripherals/fsmc/fsmc_sd.yaml
  - ../peripherals/dac/dac_wavegen.yaml
- - ../peripherals/dac/dac_common_2ch.yaml
+ - ../peripherals/dac/dac_f4_2ch.yaml
  - ../peripherals/dac/dac_dmaudr.yaml
  - ../peripherals/rcc/rcc_merge_sw_sws.yaml
  - ../peripherals/rcc/rcc_v2.yaml

--- a/devices/stm32f429.yaml
+++ b/devices/stm32f429.yaml
@@ -138,7 +138,7 @@ _include:
  - common_patches/sai/sai_v1.yaml
  - ../peripherals/sai/sai.yaml
  - ../peripherals/dac/dac_wavegen.yaml
- - ../peripherals/dac/dac_common_2ch.yaml
+ - ../peripherals/dac/dac_f4_2ch.yaml
  - ../peripherals/dac/dac_dmaudr.yaml
  - ../peripherals/rcc/rcc_merge_sw_sws.yaml
  - ../peripherals/rcc/rcc_v2.yaml

--- a/devices/stm32f446.yaml
+++ b/devices/stm32f446.yaml
@@ -533,7 +533,7 @@ _include:
  - ../peripherals/sai/sai.yaml
  - common_patches/rcc/f4_fmpi2c.yaml
  - ../peripherals/dac/dac_wavegen.yaml
- - ../peripherals/dac/dac_common_2ch.yaml
+ - ../peripherals/dac/dac_f4_2ch.yaml
  - ../peripherals/dac/dac_dmaudr.yaml
  - ../peripherals/gpio/v2/common.yaml
  - ../peripherals/rcc/rcc_merge_sw_sws.yaml

--- a/devices/stm32f469.yaml
+++ b/devices/stm32f469.yaml
@@ -137,7 +137,7 @@ _include:
  - common_patches/sai/sai_v1.yaml
  - ../peripherals/sai/sai.yaml
  - ../peripherals/dac/dac_wavegen.yaml
- - ../peripherals/dac/dac_common_2ch.yaml
+ - ../peripherals/dac/dac_f4_2ch.yaml
  - ../peripherals/dac/dac_dmaudr.yaml
  - ../peripherals/rcc/rcc_v2.yaml
  - ../peripherals/rcc/rcc_v2_pllcfgr_pllr.yaml

--- a/peripherals/dac/dac_f410.yaml
+++ b/peripherals/dac/dac_f410.yaml
@@ -1,0 +1,28 @@
+DAC:
+  CR:
+    EN?:
+      Disabled: [0, "DAC channel X disabled"]
+      Enabled: [1, "DAC channel X enabled"]
+    BOFF?:
+      Enabled: [0, "DAC channel X output buffer enabled"]
+      Disabled: [1, "DAC channel X output buffer disabled"]
+    TEN?:
+      Disabled: [0, "DAC channel X trigger disabled"]
+      Enabled: [1, "DAC channel X trigger enabled"]
+    TSEL?:
+      TIM5_TRGO: [3, "Timer 5 TRGO event"]
+      EXTI9: [6, "EXTI line9"]
+      SOFTWARE: [7, "Software trigger"]
+    DMAEN?:
+      Disabled: [0, "DAC channel X DMA mode disabled"]
+      Enabled: [1, "DAC channel X DMA mode enabled"]
+  SWTRIGR:
+    SWTRIG?:
+      Disabled: [0, "DAC channel X software trigger disabled"]
+      Enabled: [1, "DAC channel X software trigger enabled"]
+  DHR12R?:
+    DACC?DHR: [0, 4095]
+  DHR12L?:
+    DACC?DHR: [0, 4095]
+  DHR8R?:
+    DACC?DHR: [0, 255]

--- a/peripherals/dac/dac_f4_2ch.yaml
+++ b/peripherals/dac/dac_f4_2ch.yaml
@@ -1,0 +1,33 @@
+DAC,DAC?:
+  CR:
+    EN?:
+      Disabled: [0, "DAC channel X disabled"]
+      Enabled: [1, "DAC channel X enabled"]
+    BOFF?:
+      Enabled: [0, "DAC channel X output buffer enabled"]
+      Disabled: [1, "DAC channel X output buffer disabled"]
+    TEN?:
+      Disabled: [0, "DAC channel X trigger disabled"]
+      Enabled: [1, "DAC channel X trigger enabled"]
+    TSEL?:
+      TIM6_TRGO: [0, "Timer 6 TRGO event"]
+      TIM8_TRGO: [1, "Timer 8 TRGO event"]
+      TIM7_TRGO: [2, "Timer 7 TRGO event"]
+      TIM5_TRGO: [3, "Timer 5 TRGO event"]
+      TIM2_TRGO: [4, "Timer 2 TRGO event"]
+      TIM4_TRGO: [5, "Timer 4 TRGO event"]
+      EXTI9: [6, "EXTI line9"]
+      SOFTWARE: [7, "Software trigger"]
+    DMAEN?:
+      Disabled: [0, "DAC channel X DMA mode disabled"]
+      Enabled: [1, "DAC channel X DMA mode enabled"]
+  SWTRIGR:
+    SWTRIG?:
+      Disabled: [0, "DAC channel X software trigger disabled"]
+      Enabled: [1, "DAC channel X software trigger enabled"]
+  DHR12R?:
+    DACC?DHR: [0, 4095]
+  DHR12L?:
+    DACC?DHR: [0, 4095]
+  DHR8R?:
+    DACC?DHR: [0, 255]

--- a/peripherals/dac/dac_wavegen.yaml
+++ b/peripherals/dac/dac_wavegen.yaml
@@ -2,13 +2,8 @@
 
 DAC,DAC?:
   CR:
-    WAVE1:
+    WAVE?:
       Disabled: [0, "Wave generation disabled"]
       Noise: [1, "Noise wave generation enabled"]
       Triangle: [2, "Triangle wave generation enabled"]
-    MAMP1: [0, 15]
-    WAVE2:
-      Disabled: [0, "Wave generation disabled"]
-      Noise: [1, "Noise wave generation enabled"]
-      Triangle: [2, "Triangle wave generation enabled"]
-    MAMP2: [0, 15]
+    MAMP?: [0, 15]


### PR DESCRIPTION
remove Channel 2 from STM32F410, correct variants of `TSEL?`(TIM3 -> TIM8, TIM15 -> TIM5, add TIM4), merge `WAVE` field and `MAMP`field