### PR TITLE
Update stm32h735 RNG.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 * F4: collect SDIO RESP
 * Fix DAC for stm32f4 (#921)
 * tools_install: support `$CARGO_HOME` environment variable
+* Update RNG for stm32h735
 
 [#854]: https://github.com/stm32-rs/stm32-rs/pull/854
 

--- a/devices/common_patches/rng/h735.yaml
+++ b/devices/common_patches/rng/h735.yaml
@@ -1,0 +1,41 @@
+RNG:
+  _add:
+    HTCR:
+      description: health test control register
+      addressOffset: 0x10
+      resetValue: 0x00005A4E
+      fields:
+        HTCFG:
+          description: health test configuration
+          bitOffset: 0
+          bitWidth: 32
+  CR:
+    _add:
+      CONFIGLOCK:
+        description: RNG Config lock
+        bitOffset: 31
+        bitWidth: 1
+      CONDRST:
+        description: Conditioning soft reset
+        bitOffset: 30
+        bitWidth: 1
+      RNG_CONFIG1:
+        description: RNG configuration 1
+        bitOffset: 20
+        bitWidth: 6
+      CLKDIV:
+        description: Clock divider factor
+        bitOffset: 16
+        bitWidth: 4
+      RNG_CONFIG2:
+        description: RNG configuration 2
+        bitOffset: 13
+        bitWidth: 3
+      NISTC:
+        description: Non NIST compliant
+        bitOffset: 12
+        bitWidth: 1
+      RNG_CONFIG3:
+        description: RNG configuration 3
+        bitOffset: 8
+        bitWidth: 4

--- a/devices/common_patches/rng/l4+.yaml
+++ b/devices/common_patches/rng/l4+.yaml
@@ -1,44 +1,9 @@
+_include:
+ - ./h735.yaml
+
 RNG:
-  _add:
-    HTCR:
-      description: health test control register
-      addressOffset: 0x10
-      resetValue: 0x00005A4E
-      fields:
-        HTCFG:
-          description: health test configuration
-          bitOffset: 0
-          bitWidth: 32
   CR:
     _add:
-      CONFIGLOCK:
-        description: RNG Config lock
-        bitOffset: 31
-        bitWidth: 1
-      CONDRST:
-        description: Conditioning soft reset
-        bitOffset: 30
-        bitWidth: 1
-      RNG_CONFIG1:
-        description: RNG configuration 1
-        bitOffset: 20
-        bitWidth: 6
-      CLKDIV:
-        description: Clock divider factor
-        bitOffset: 16
-        bitWidth: 4
-      RNG_CONFIG2:
-        description: RNG configuration 2
-        bitOffset: 13
-        bitWidth: 3
-      NISTC:
-        description: Non NIST compliant
-        bitOffset: 12
-        bitWidth: 1
-      RNG_CONFIG3:
-        description: RNG configuration 3
-        bitOffset: 8
-        bitWidth: 4
       CED:
         description: Clock error detection
         bitOffset: 5

--- a/devices/stm32h735.yaml
+++ b/devices/stm32h735.yaml
@@ -982,8 +982,8 @@ _include:
  - collect/ltdc/layer.yaml
  - ../peripherals/rcc/rcc_h7.yaml
  - ../peripherals/rcc/rcc_h7_revision_v.yaml
- - ../peripherals/rng/rng_v1.yaml
- - ../peripherals/rng/rng_v1_ced.yaml
+ - common_patches/rng/h735.yaml
+ - ../peripherals/rng/rng_wl.yaml
  - ../peripherals/spi/spi_v3.yaml
  - common_patches/tim/v2/h7.yaml
  - common_patches/tim/common.yaml


### PR DESCRIPTION
A register and several bits in the control register were missing from the SVD file. These missing registers were very similar to those in the l4+, so I edited those patches to make it work.