### PR TITLE
only a single CAN on F103

### DIFF
--- a/.github/workflows/mmaps_pr_compare.yaml
+++ b/.github/workflows/mmaps_pr_compare.yaml
@@ -19,9 +19,9 @@ jobs:
           ssh-key: ${{ secrets.MMAPS_KEY }}
 
       - name: Download new mmaps
-        uses: actions/download-artifact@v4
+        uses: dawidd6/action-download-artifact@v6
         with:
-          #name: mmaps
+          name: mmaps
           run-id: ${{ github.event.workflow_run.id }}
 
       - name: Commit new mmaps

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 * GFXMMU LUT cluster
 * Add missing CAN registers to l4x3/x5
 * Remove CAN from F101/102
+* Remove CAN2 from F103, rename CAN1 to CAN
 * Fix L5 DMA cluster
 * Fix writeConstraint bugs
 * STM32G491: Add FDCAN2 peripheral

--- a/devices/stm32f103.yaml
+++ b/devices/stm32f103.yaml
@@ -7,7 +7,14 @@ _copy:
   ADC3:
     from: ADC2
 
+# Only one CAN on STM32F103
+_delete:
+  - CAN2
+
 _modify:
+  # Only one CAN on STM32F103
+  CAN1:
+    name: CAN
   # Fix case on Ethernet peripherals to match other devices
   ETHERNET_DMA:
     name: Ethernet_DMA
@@ -17,6 +24,21 @@ _modify:
     name: Ethernet_MMC
   ETHERNET_PTP:
     name: Ethernet_PTP
+
+AFIO:
+  MAPR:
+    _modify:
+      CAN_REMAP:
+        description: CAN remapping
+
+DBGMCU:
+  CR:
+    _modify:
+      DBG_CAN1_STOP:
+        name: DBG_CAN_STOP
+        description: DBG_CAN_STOP
+    _delete:
+      DBG_CAN2_STOP
 
 RCC:
   CFGR:


### PR DESCRIPTION
Drops `CAN2`, renames all occurrences of `CAN1` to `CAN` to match `RCC`

See also https://github.com/stm32-rs/stm32-rs/pull/731#issuecomment-1113274361

CC @burrbull 