### PR TITLE
Fix reset values for STM32H7 GPIO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 * Fix incorrectly used `_read`, `_modify`
 * G4:COMP fix and collect array
 * doc on `RNG` peripheral for STM32F4 ([#870])
+* H7: fix GPIO register reset values (#973)
 
 [#854]: https://github.com/stm32-rs/stm32-rs/pull/854
 [#870]: https://github.com/stm32-rs/stm32-rs/pull/870

--- a/devices/common_patches/gpio/h7_ijk.yaml
+++ b/devices/common_patches/gpio/h7_ijk.yaml
@@ -1,0 +1,8 @@
+# Fix the reset values for H7 devices with GPIOI, GPIOJ and GPIOK peripherals
+_include:
+  - h7_reset_values_common.yaml
+
+_derive:
+  GPIOI: GPIOC
+  GPIOJ: GPIOC
+  GPIOK: GPIOC

--- a/devices/common_patches/gpio/h7_jk.yaml
+++ b/devices/common_patches/gpio/h7_jk.yaml
@@ -1,0 +1,37 @@
+# Fix the reset values for H7 devices with GPIOJ and GPIOK peripherals (RM0468)
+_include:
+  - h7_reset_values_common.yaml
+
+# We cannot derive GPIOJ and GPIOK from GPIOC, since their MODER register
+# has a different reset value
+_delete:
+  - GPIOJ
+  - GPIOK
+_copy:
+  GPIOJ:
+    from: GPIOA
+  GPIOK:
+    from: GPIOA
+_modify:
+  GPIOJ:
+    baseAddress: "0x58022400"
+  GPIOK:
+    baseAddress: "0x58022800"
+
+GPIOJ:
+  _modify:
+    MODER:
+      resetValue: "0x00ff0000"
+    OSPEEDR:
+      resetValue: "0x00000000"
+    PUPDR:
+      resetValue: "0x00000000"
+
+GPIOK:
+  _modify:
+    MODER:
+      resetValue: "0x0000003f"
+    OSPEEDR:
+      resetValue: "0x00000000"
+    PUPDR:
+      resetValue: "0x00000000"

--- a/devices/common_patches/gpio/h7_reset_values_common.yaml
+++ b/devices/common_patches/gpio/h7_reset_values_common.yaml
@@ -1,0 +1,72 @@
+# In the H7 SVDs all GPIOs are derived from GPIOA,
+# but this leads to wrong reset values for some of the GPIO registers.
+#
+# We want the following reset values (omitted values are 0x0000_0000):
+#
+#   GPIOA:
+#     MODER:   0xABFF_FFFF
+#     OSPEEDR: 0x0C00_0000
+#     PUPDR:   0x6400_0000
+#
+#   GPIOB:
+#     MODER:   0xFFFF_FEBF
+#     OSPEEDR: 0x0000_00C0
+#     PUPDR:   0x0000_0100
+#
+# To this end, this patch ensures there are three different GPIO peripherals,
+# GPIOA, GPIOB, and GPIOC. GPIOC has all-zero reset values and all other GPIO
+# peripherals derive from that.
+# This file only derives the common GPIO peripherals, so don't include
+# this directly but through one of the other h7_xxx.yaml files.
+
+# Since GPIOC and GPIOC are derived from GPIOA, we need to delete and re-add
+# to be able to modify their reset values.
+_delete:
+  - GPIOB
+  - GPIOC
+_copy:
+  GPIOB:
+    from: GPIOA
+  GPIOC:
+    from: GPIOA
+_modify:
+  GPIOB:
+    baseAddress: "0x58020400"
+  GPIOC:
+    baseAddress: "0x58020800"
+
+# These GPIO's are common to all H7 devices
+_derive:
+  GPIOD: GPIOC
+  GPIOE: GPIOC
+  GPIOF: GPIOC
+  GPIOG: GPIOC
+  GPIOH: GPIOC
+
+GPIOA:
+  _modify:
+    MODER:
+      resetValue: "0xabffffff"
+    OSPEEDR:
+      resetValue: "0x0c000000"
+    PUPDR:
+      resetValue: "0x64000000"
+
+GPIOB:
+  _modify:
+    MODER:
+      resetValue: "0xfffffebf"
+    OSPEEDR:
+      resetValue: "0x000000c0"
+    PUPDR:
+      resetValue: "0x00000100"
+
+GPIOC:
+  _modify:
+    MODER:
+      resetValue: "0xffffffff"
+    OSPEEDR:
+      resetValue: "0x00000000"
+    PUPDR:
+      resetValue: "0x00000000"
+

--- a/devices/stm32h735.yaml
+++ b/devices/stm32h735.yaml
@@ -973,6 +973,7 @@ _include:
  - ../peripherals/crc/crc_advanced.yaml
  - ../peripherals/crc/crc_idr_32bit.yaml
  - ../peripherals/crc/crc_pol.yaml
+ - common_patches/gpio/h7_jk.yaml
  - ../peripherals/gpio/v2/common.yaml
  - collect/gpio/v2.yaml
  - ../peripherals/lptim/lptim_v1.yaml

--- a/devices/stm32h743.yaml
+++ b/devices/stm32h743.yaml
@@ -77,6 +77,7 @@ _include:
  - ../peripherals/crc/crc_advanced.yaml
  - ../peripherals/crc/crc_idr_32bit.yaml
  - ../peripherals/crc/crc_pol.yaml
+ - common_patches/gpio/h7_ijk.yaml
  - ../peripherals/gpio/v2/common.yaml
  - collect/gpio/v2.yaml
  - ../peripherals/lptim/lptim_v1.yaml

--- a/devices/stm32h743v.yaml
+++ b/devices/stm32h743v.yaml
@@ -79,6 +79,7 @@ _include:
  - ../peripherals/crc/crc_advanced.yaml
  - ../peripherals/crc/crc_idr_32bit.yaml
  - ../peripherals/crc/crc_pol.yaml
+ - common_patches/gpio/h7_ijk.yaml
  - ../peripherals/gpio/v2/common.yaml
  - collect/gpio/v2.yaml
  - ../peripherals/lptim/lptim_v1.yaml

--- a/devices/stm32h747cm4.yaml
+++ b/devices/stm32h747cm4.yaml
@@ -79,6 +79,7 @@ _include:
  - ../peripherals/crc/crc_advanced.yaml
  - ../peripherals/crc/crc_idr_32bit.yaml
  - ../peripherals/crc/crc_pol.yaml
+ - common_patches/gpio/h7_ijk.yaml
  - ../peripherals/gpio/v2/common.yaml
  - collect/gpio/v2.yaml
  - ../peripherals/lptim/lptim_v1.yaml

--- a/devices/stm32h747cm7.yaml
+++ b/devices/stm32h747cm7.yaml
@@ -80,6 +80,7 @@ _include:
  - ../peripherals/crc/crc_advanced.yaml
  - ../peripherals/crc/crc_idr_32bit.yaml
  - ../peripherals/crc/crc_pol.yaml
+ - common_patches/gpio/h7_ijk.yaml
  - ../peripherals/gpio/v2/common.yaml
  - collect/gpio/v2.yaml
  - ../peripherals/lptim/lptim_v1.yaml

--- a/devices/stm32h753.yaml
+++ b/devices/stm32h753.yaml
@@ -88,6 +88,7 @@ _include:
  - ../peripherals/crc/crc_advanced.yaml
  - ../peripherals/crc/crc_idr_32bit.yaml
  - ../peripherals/crc/crc_pol.yaml
+ - common_patches/gpio/h7_ijk.yaml
  - ../peripherals/gpio/v2/common.yaml
  - collect/gpio/v2.yaml
  - ../peripherals/lptim/lptim_v1.yaml

--- a/devices/stm32h753v.yaml
+++ b/devices/stm32h753v.yaml
@@ -90,6 +90,7 @@ _include:
  - ../peripherals/crc/crc_advanced.yaml
  - ../peripherals/crc/crc_idr_32bit.yaml
  - ../peripherals/crc/crc_pol.yaml
+ - common_patches/gpio/h7_ijk.yaml
  - ../peripherals/gpio/v2/common.yaml
  - collect/gpio/v2.yaml
  - ../peripherals/lptim/lptim_v1.yaml

--- a/devices/stm32h7b3.yaml
+++ b/devices/stm32h7b3.yaml
@@ -135,6 +135,7 @@ _include:
  - ../peripherals/crc/crc_advanced.yaml
  - ../peripherals/crc/crc_idr_32bit.yaml
  - ../peripherals/crc/crc_pol.yaml
+ - common_patches/gpio/h7_ijk.yaml
  - ../peripherals/gpio/v2/common.yaml
  - collect/gpio/v2.yaml
  - ../peripherals/lptim/lptim_v1.yaml


### PR DESCRIPTION
Currently, all GPIO peripherals are derived from GPIOA for the STM32H7 devices.
However, the reset values of some registers are different for GPIOA and GPIOB
compared to the other GPIO's.
This PR fixes this issue.