### PR TITLE
STM32U5: Add ADC peripheral

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@
     * `DR` register can be access by 1 byte, half word and full word. Use `.dr8()`, `.dr16()`, `.dr()` to access this register.
 * 16-bit SPI registers, add DR8
 * U5: Strip prefixes from peripheral registers
-* U5: Add DMA2D, EXTI, FMC, GPIO, I2C, OCTOSPI, PWR, RCC peripherals
+* U5: Add ADC, DMA2D, EXTI, FMC, GPIO, I2C, OCTOSPI, PWR, RCC peripherals
 * H7: add stm32h7r/s devices (#972)
 * WB: add `RCC`, `SYSCFG` enums
 * G4: fix FDCAN interrupt numbers being swapped

--- a/devices/common_patches/adc/u5.yaml
+++ b/devices/common_patches/adc/u5.yaml
@@ -1,0 +1,10 @@
+ADC1,ADC2,ADC4:
+  CR:
+    _modify:
+      ADCAL,ADSTP,JADSTP,ADSTART,JADSTART,ADDIS,ADEN:
+        access: read-write
+
+ADC4:
+  _modify:
+    PWR:
+      name: PWRR

--- a/devices/common_patches/adc/u5_extra_adc12_fields.yaml
+++ b/devices/common_patches/adc/u5_extra_adc12_fields.yaml
@@ -1,0 +1,5 @@
+# DAMDF, DELAY and DUAL should only exist on U59x, U5Ax, U5Fx, U5Gx
+
+ADC12_Common:
+  CCR:
+    _delete: [DAMDF, DELAY, DUAL]

--- a/devices/common_patches/adc/u5_vsensesel.yaml
+++ b/devices/common_patches/adc/u5_vsensesel.yaml
@@ -1,0 +1,7 @@
+# Some U5 devices have the VSENSESEL field incorrectly named as TSEN
+
+ADC4:
+  CCR:
+    _modify:
+      TSEN:
+        name: VSENSESEL

--- a/devices/stm32u535.yaml
+++ b/devices/stm32u535.yaml
@@ -20,8 +20,12 @@ SPI?:
 
 _include:
  - common_patches/u5.yaml
+ - common_patches/adc/u5.yaml
+ - common_patches/adc/u5_extra_adc12_fields.yaml
+ - common_patches/adc/u5_vsensesel.yaml
  - common_patches/octospi/u535_u545.yaml
  - common_patches/tim/common.yaml
+ - ../peripherals/adc/adc_u5.yaml
  - ../peripherals/exti/exti_u5.yaml
  - ../peripherals/gpio/gpio_l5_u5.yaml
  - ../peripherals/i2c/i2c_v2.yaml

--- a/devices/stm32u545.yaml
+++ b/devices/stm32u545.yaml
@@ -20,8 +20,12 @@ SPI?:
 
 _include:
  - common_patches/u5.yaml
+ - common_patches/adc/u5.yaml
+ - common_patches/adc/u5_extra_adc12_fields.yaml
+ - common_patches/adc/u5_vsensesel.yaml
  - common_patches/octospi/u535_u545.yaml
  - common_patches/tim/common.yaml
+ - ../peripherals/adc/adc_u5.yaml
  - ../peripherals/exti/exti_u5.yaml
  - ../peripherals/gpio/gpio_l5_u5.yaml
  - ../peripherals/i2c/i2c_v2.yaml

--- a/devices/stm32u575.yaml
+++ b/devices/stm32u575.yaml
@@ -68,8 +68,11 @@ SPI?:
 
 _include:
  - common_patches/u5.yaml
+ - common_patches/adc/u5.yaml
+ - common_patches/adc/u5_extra_adc12_fields.yaml
  - common_patches/fsmc/fsmc_u5.yaml
  - common_patches/octospi/u5.yaml
+ - ../peripherals/adc/adc_u5.yaml
  - ../peripherals/dma/dma2d_v2.yaml
  - ../peripherals/exti/exti_u5.yaml
  - ../peripherals/fsmc/fsmc_nand.yaml

--- a/devices/stm32u585.yaml
+++ b/devices/stm32u585.yaml
@@ -66,8 +66,11 @@ SPI?:
 
 _include:
  - common_patches/u5.yaml
+ - common_patches/adc/u5.yaml
+ - common_patches/adc/u5_extra_adc12_fields.yaml
  - common_patches/fsmc/fsmc_u5.yaml
  - common_patches/octospi/u5.yaml
+ - ../peripherals/adc/adc_u5.yaml
  - ../peripherals/dma/dma2d_v2.yaml
  - ../peripherals/exti/exti_u5.yaml
  - ../peripherals/fsmc/fsmc_nand.yaml

--- a/devices/stm32u595.yaml
+++ b/devices/stm32u595.yaml
@@ -19,9 +19,12 @@ SPI?:
 
 _include:
  - common_patches/u5.yaml
+ - common_patches/adc/u5.yaml
+ - common_patches/adc/u5_vsensesel.yaml
  - common_patches/fsmc/fsmc_u5.yaml
  - common_patches/octospi/u5.yaml
  - common_patches/tim/common.yaml
+ - ../peripherals/adc/adc_u5_dual.yaml
  - ../peripherals/dma/dma2d_v2.yaml
  - ../peripherals/exti/exti_u5.yaml
  - ../peripherals/fsmc/fsmc_nand.yaml

--- a/devices/stm32u599.yaml
+++ b/devices/stm32u599.yaml
@@ -33,10 +33,13 @@ SPI?:
 
 _include:
  - common_patches/u5.yaml
+ - common_patches/adc/u5.yaml
+ - common_patches/adc/u5_vsensesel.yaml
  - common_patches/fsmc/fsmc_u5.yaml
  - collect/gfxmmu/lut.yaml
  - common_patches/octospi/u5.yaml
  - common_patches/tim/common.yaml
+ - ../peripherals/adc/adc_u5_dual.yaml
  - ../peripherals/exti/exti_u5.yaml
  - ../peripherals/fsmc/fsmc_nand.yaml
  - ../peripherals/fsmc/fsmc_sram.yaml

--- a/devices/stm32u5a5.yaml
+++ b/devices/stm32u5a5.yaml
@@ -19,9 +19,12 @@ SPI?:
 
 _include:
  - common_patches/u5.yaml
+ - common_patches/adc/u5.yaml
+ - common_patches/adc/u5_vsensesel.yaml
  - common_patches/fsmc/fsmc_u5.yaml
  - common_patches/octospi/u5.yaml
  - common_patches/tim/common.yaml
+ - ../peripherals/adc/adc_u5_dual.yaml
  - ../peripherals/dma/dma2d_v2.yaml
  - ../peripherals/exti/exti_u5.yaml
  - ../peripherals/fsmc/fsmc_nand.yaml

--- a/devices/stm32u5a9.yaml
+++ b/devices/stm32u5a9.yaml
@@ -29,10 +29,13 @@ SPI?:
 
 _include:
  - common_patches/u5.yaml
+ - common_patches/adc/u5.yaml
+ - common_patches/adc/u5_vsensesel.yaml
  - common_patches/fsmc/fsmc_u5.yaml
  - collect/gfxmmu/lut.yaml
  - common_patches/octospi/u5.yaml
  - common_patches/tim/common.yaml
+ - ../peripherals/adc/adc_u5_dual.yaml
  - ../peripherals/dma/dma2d_v2.yaml
  - ../peripherals/exti/exti_u5.yaml
  - ../peripherals/fsmc/fsmc_nand.yaml

--- a/peripherals/adc/adc_u5.yaml
+++ b/peripherals/adc/adc_u5.yaml
@@ -1,0 +1,494 @@
+# ADC as used on U5
+
+ADC[124]:
+  ISR:
+    LDORDY:
+      _read:
+        Disabled: [0, "ADC voltage regulator disabled"]
+        Enabled: [1, "ADC voltage regulator enabled"]
+    AWD?:
+      _read:
+        NoEvent: [0, "No analog watchdog x event occurred (or the flag event was already acknowledged and cleared by software)"]
+        Event: [1, "Analog watchdog x event occurred"]
+      _write:
+        Clear: [1, "Clear the analog watchdog x event flag"]
+    OVR:
+      _read:
+        NoOverrun: [0, "No overrun occurred (or the flag event was already acknowledged and cleared by software)"]
+        Overrun: [1, "Overrun has occurred"]
+      _write:
+        Clear: [1, "Clear the overrun flag"]
+    EOS:
+      _read:
+        NotComplete: [0, "Regular conversions sequence not complete (or the flag event was already acknowledged and cleared by software)"]
+        Complete: [1, "Regular conversions sequence complete"]
+      _write:
+        Clear: [1, "Clear the regular conversion sequence flag"]
+    EOC:
+      _read:
+        NotComplete: [0, "Regular channel conversion not complete (or the flag event was already acknowledged and cleared by software)"]
+        Complete: [1, "Regular channel conversion complete"]
+      _write:
+        Clear: [1, "Clear the regular channel conversion flag"]
+    EOSMP:
+      _read:
+        NotAtEnd: [0, "Not at the end of the sampling phase (or the flag event was already acknowledged and cleared by software)"]
+        AtEnd: [1, "End of sampling phase reached"]
+      _write:
+        Clear: [1, "Clear the sampling phase flag"]
+    ADRDY:
+      _read:
+        NotReady: [0, "ADC not yet ready to start conversion (or the flag event was already acknowledged and cleared by software)"]
+        Ready: [1, "ADC is ready to start conversion"]
+      _write:
+        Clear: [1, "Clear the ADC ready flag"]
+  IER:
+    AWD?IE:
+      Disabled: [0, "Analog watchdog x interrupt disabled"]
+      Enabled: [1, "Analog watchdog x interrupt enabled"]
+    OVRIE:
+      Disabled: [0, "Overrun interrupt disabled"]
+      Enabled: [1, "Overrun interrupt enabled. An interrupt is generated when the OVR bit is set."]
+    EOSIE:
+      Disabled: [0, "EOS interrupt disabled"]
+      Enabled: [1, "EOS interrupt enabled. An interrupt is generated when the EOS bit is set."]
+    EOCIE:
+      Disabled: [0, "EOC interrupt disabled"]
+      Enabled: [1, "EOC interrupt enabled. An interrupt is generated when the EOC bit is set."]
+    EOSMPIE:
+      Disabled: [0, "EOSMP interrupt disabled"]
+      Enabled: [1, "EOSMP interrupt enabled. An interrupt is generated when the EOSMP bit is set."]
+    ADRDYIE:
+      Disabled: [0, "ADRDY interrupt disabled"]
+      Enabled: [1, "ADRDY interrupt enabled. An interrupt is generated when the ADRDY bit is set."]
+  CR:
+    ADCAL:
+      _read:
+        NotCalibrating: [0, "Calibration complete"]
+        Calibrating: [1, "Calibration in progress"]
+      _write:
+        StartCalibration: [1, "Calibrate the ADC"]
+    ADVREGEN:
+      Disabled: [0, "ADC voltage regulator disabled"]
+      Enabled: [1, "ADC voltage regulator enabled"]
+    ADSTP:
+      _read:
+        NotStopping: [0, "No ADC stop regular conversion command ongoing"]
+        Stopping: [1, "ADSTP command is in progress"]
+      _write:
+        StopConversion: [1, "Stop regular conversions ongoing"]
+    ADSTART:
+      _read:
+        NotActive: [0, "No ADC regular conversion is ongoing"]
+        Active: [1, "ADC is operating and eventually converting a regular channel"]
+      _write:
+        Start: [1, "Start regular conversions"]
+    ADDIS:
+      _read:
+        NotOngoing: [0, "No ADDIS command ongoing"]
+        InProgress: [1, "An ADDIS command is in progress"]
+      _write:
+        Disable: [1, "Disable the ADC"]
+    ADEN:
+      _read:
+        Disabled: [0, "ADC is disabled"]
+        Enabled: [1, "ADC is enabled"]
+      _write:
+        Enabled: [1, "Enable the ADC"]
+  CFGR1:
+    AWD1CH: [0, 19]
+    AWD1EN:
+      Disabled: [0, "Analog watchdog 1 disabled on regular channels"]
+      Enabled: [1, "Analog watchdog 1 enabled on regular channels"]
+    AWD1SGL:
+      AllChannels: [0, "Analog watchdog 1 enabled on all channels"]
+      SingleChannel: [1, "Analog watchdog 1 enabled on a single channel"]
+    DISCEN:
+      Disabled: [0, "Discontinuous mode for regular channels disabled"]
+      Enabled: [1, "Discontinuous mode for regular channels enabled"]
+    CONT:
+      Single: [0, "Single conversion mode"]
+      Continuous: [1, "Continuous conversion mode"]
+    OVRMOD:
+      Preserve: [0, "ADC_DR register is preserved with the old data when an overrun is detected"]
+      Overwrite: [1, "ADC_DR register is overwritten with the last conversion result when an overrun is detected"]
+    EXTEN:
+      Disabled: [0, "Hardware trigger detection disabled (conversions can be launched by software)"]
+      RisingEdge: [1, "Hardware trigger detection on the rising edge"]
+      FallingEdge: [2, "Hardware trigger detection on the falling edge"]
+      BothEdges: [3, "Hardware trigger detection on both the rising and falling edges"]
+  CFGR2:
+    LFTRIG:
+      Disabled: [0, "Low-frequency trigger mode disabled"]
+      Enabled: [1, "Low-frequency trigger mode enabled"]
+    TROVS,TOVS:
+      Automatic: [0, "All oversampled conversions for a channel are done consecutively following a trigger"]
+      Triggered: [1, "Each oversampled conversion for a channel needs a new trigger"]
+  AWD?CR:
+    AWD?CH*:
+      Disabled: [0, "ADC analog input channel x is not monitored by AWDy"]
+      Enabled: [1, "ADC analog input channel x is monitored by AWDy"]
+
+ADC[12]:
+  ISR:
+    JEOS:
+      _read:
+        NotComplete: [0, "Injected conversion sequence not complete (or the flag event was already acknowledged and cleared by software)"]
+        Complete: [1, "Injected conversions sequence complete"]
+      _write:
+        Clear: [1, "Clear the injected conversion sequence flag"]
+    JEOC:
+      _read:
+        NotComplete: [0, "Injected channel conversion not complete (or the flag event was already acknowledged and cleared by software)"]
+        Complete: [1, "Injected channel conversion complete"]
+      _write:
+        Clear: [1, "Clear the injected channel conversion flag"]
+  IER:
+    JEOSIE:
+      Disabled: [0, "JEOS interrupt disabled"]
+      Enabled: [1, "JEOS interrupt enabled. An interrupt is generated when the JEOS bit is set."]
+    JEOCIE:
+      Disabled: [0, "JEOC interrupt disable"]
+      Enabled: [1, "JEOC interrupt enabled. An interrupt is generated when the JEOC bit is set."]
+  CR:
+    DEEPPWD:
+      Disabled: [0, "ADC not in deep-power down"]
+      Enabled: [1, "ADC in deep-power down"]
+    CALINDEX:
+      OffsetCalFactor: [0, "Offset calibration factor"]
+      CalFactor1: [1, "Calibration factor 1"]
+      CalFactor2: [2, "Calibration factor 2"]
+      CalFactor3: [3, "Calibration factor 3"]
+      CalFactor4: [4, "Calibration factor 4"]
+      CalFactor5: [5, "Calibration factor 5"]
+      CalFactor6: [6, "Calibration factor 6"]
+      CalFactor7: [7, "Calibration factor 7 and (write access only) internal offset"]
+      InternalOffset: [8, "Internal offset (read access only)"]
+      CalibrationMode: [9, "Calibration mode selection"]
+    ADCALLIN:
+      Disabled: [0, "Writing ADCAL launches a calibration without the linearity calibration"]
+      Enabled: [1, "Writing ADCAL launches a calibration with he linearity calibration"]
+    JADSTP:
+      _read:
+        NotStopped: [0, "No ADC stop injected conversion command ongoing"]
+        Stopped: [1, "ADSTP command is in progress"]
+      _write:
+        Stop: [1, "Stop injected conversions ongoing"]
+    JADSTART:
+      _read:
+        NotActive: [0, "No ADC injected conversion is ongoing"]
+        Active: [1, "ADC is operating and eventually converting an injected channel"]
+      _write:
+        Start: [1, "Start injected conversions"]
+  CFGR1:
+    JAUTO:
+      Disabled: [0, "Automatic injected group conversion disabled"]
+      Enabled: [1, "Automatic injected group conversion enabled"]
+    JAWD1EN:
+      Disabled: [0, "Analog watchdog 1 disabled on injected channels"]
+      Enabled: [1, "Analog watchdog 1 enabled on injected channels"]
+    JDISCEN:
+      Disabled: [0, "Discontinuous mode on injected channels disabled"]
+      Enabled: [1, "Discontinuous mode on injected channels enabled"]
+    DISCNUM:
+      n1: [0, "1 channel"]
+      n2: [1, "2 channels"]
+      n3: [2, "3 channels"]
+      n4: [3, "4 channels"]
+      n5: [4, "5 channels"]
+      n6: [5, "6 channels"]
+      n7: [6, "7 channels"]
+      n8: [7, "8 channels"]
+    AUTDLY:
+      Disabled: [0, "Auto-delayed conversion mode off"]
+      Enabled: [1, "Auto-delayed conversion mode on"]
+    DMNGT:
+      DR: [0, "Store output data in DR only"]
+      DMA_OneShot: [1, "DMA One Shot Mode selected"]
+      DFSDM: [2, "DFSDM mode selected"]
+      DMA_Circular: [3, "DMA Circular Mode selected"]
+    EXTSEL:
+      TIM1_OC1: [0, "tim1_oc1"]
+      TIM1_OC2: [1, "tim1_oc2"]
+      TIM1_OC3: [2, "tim1_oc3"]
+      TIM2_OC2: [3, "tim2_oc2"]
+      TIM3_TRGO: [4, "tim3_trgo"]
+      TIM4_OC4: [5, "tim4_oc4"]
+      EXTI11: [6, "exti11"]
+      TIM8_TRGO: [7, "tim8_trgo"]
+      TIM8_TRGO2: [8, "tim8_trgo2"]
+      TIM1_TRGO: [9, "tim1_trgo"]
+      TIM1_TRGO2: [10, "tim1_trgo2"]
+      TIM2_TRGO: [11, "tim2_trgo"]
+      TIM4_TRGO: [12, "tim4_trgo"]
+      TIM6_TRGO: [13, "tim6_trgo"]
+      TIM15_TRGO: [14, "tim15_trgo"]
+      TIM3_OC4: [15, "tim3_oc4"]
+      EXTI15: [16, "exti15"]
+      LPTIM1_CH1: [18, "lptim1_ch1"]
+      LPTIM2_CH1: [19, "lptim2_ch1"]
+      LPTIM3_CH1: [20, "lptim3_ch1"]
+      LPTIM4_OUT: [21, "lptim4_out"]
+    RES:
+      FourteenBit: [0, "14 bits"]
+      TwelveBit: [1, "12 bits"]
+      TenBit: [2, "10 bits"]
+      EightBit: [3, "8 bits"]
+  CFGR2:
+    LSHIFT: [0, 15]
+    OSR: [0, 1023]
+    SMPTRIG:
+      Disabled: [0, "Sampling time control trigger mode disabled"]
+      Enabled: [1, "Sampling time control trigger mode enabled"]
+    SWTRIG:
+      Disabled: [0, "Software trigger starts the conversion for sampling time control trigger mode"]
+      Enabled: [1, "Software trigger starts the sampling for sampling time control trigger mode"]
+    BULB:
+      Disabled: [0, "Bulb sampling mode disabled"]
+      Enabled: [1, "Bulb sampling mode enabled. The sampling period starts just after the previous end of the conversion."]
+    ROVSM:
+      Continued: [0, "When injected conversions are triggered, the oversampling is temporary stopped and continued after the injection sequence (oversampling buffer is maintained during injected sequence)"]
+      Resumed: [1, "When injected conversions are triggered, the current oversampling is aborted and resumed from start after the injection sequence (oversampling buffer is zeroed by injected sequence start)"]
+    OVSS: [0, 11]
+    JOVSE:
+      Disabled: [0, "Injected oversampling disabled"]
+      Enabled: [1, "Injected oversampling enabled"]
+    ROVSE:
+      Disabled: [0, "Regular oversampling disabled"]
+      Enabled: [1, "Regular oversampling enabled"]
+  SMPR?:
+    SMP*:
+      Cycles5: [0, "5 ADC clock cycles"]
+      Cycles6: [1, "6 ADC clock cycles"]
+      Cycles12: [2, "12 ADC clock cycles"]
+      Cycles20: [3, "20 ADC clock cycles"]
+      Cycles36: [4, "36 ADC clock cycles"]
+      Cycles68: [5, "68 ADC clock cycles"]
+      Cycles391: [6, "391 ADC clock cycles"]
+      Cycles814: [7, "814 ADC clock cycles"]
+  PCSEL:
+    "PCSEL*":
+      NotPreselected: [0, "Input channel x is not preselected for conversion, the ADC conversion of this channel shows a wrong result."]
+      Preselected: [1, "Input channel x is preselected for conversion"]
+  SQR?,JSQR:
+    SQ*,JSQ*: [0, 31]
+  SQR1:
+    L: [0, 15]
+  JSQR:
+    JEXTEN:
+      Disabled: [0, "Hardware trigger detection disabled (conversions can be launched by software)"]
+      RisingEdge: [1, "Hardware trigger detection on the rising edge"]
+      FallingEdge: [2, "Hardware trigger detection on the falling edge"]
+      BothEdges: [3, "Hardware trigger detection on both the rising and falling edges"]
+    JEXTSEL:
+      TIM1_TRGO: [0, "tim1_trgo"]
+      TIM1_OC4: [1, "tim1_oc4"]
+      TIM2_TRGO: [2, "tim2_trgo"]
+      TIM2_OC1: [3, "tim2_oc1"]
+      TIM3_OC4: [4, "tim3_oc4"]
+      TIM4_TRGO: [5, "tim4_trgo"]
+      EXTI15: [6, "exti15"]
+      TIM8_OC4: [7, "tim8_oc4"]
+      TIM1_TRGO2: [8, "tim1_trgo2"]
+      TIM8_TRGO: [9, "tim8_trgo"]
+      TIM8_TRGO2: [10, "tim8_trgo2"]
+      TIM3_OC3: [11, "tim3_oc3"]
+      TIM3_TRGO: [12, "tim3_trgo"]
+      TIM3_OC1: [13, "tim3_oc1"]
+      TIM6_TRGO: [14, "tim6_trgo"]
+      TIM15_TRGO: [15, "tim15_trgo"]
+      LPTIM1_CH2: [16, "lptim1_ch2"]
+      LPTIM2_CH2: [17, "lptim2_ch2"]
+      LPTIM3_CH1: [18, "lptim3_ch1"]
+      LPTIM4_OUT1: [19, "lptim4_out1"]
+    JL: [0, 3]
+  OFR?:
+    OFFSET_CH: [0, 0x1F]
+    SSAT:
+      Disabled: [0, "Offset is subtracted maintaining data integrity and extending converted data size (9-bit and 15-bit signed format)"]
+      Enabled: [1, "Offset is subtracted and result is saturated to maintain converted data size"]
+    USAT:
+      Disabled: [0, "Offset is subtracted maintaining data integrity and keeping converted data size"]
+      Enabled: [1, "Offset is subtracted and result is saturated to maintain converted data size"]
+    POSOFF:
+      Negative: [0, "Negative offset"]
+      Positive: [1, "Positive offset"]
+    OFFSET: [0, 0xFFFFFF]
+  GCOMP:
+    GCOMP:
+      Disabled: [0, Regular ADC operating mode]
+      Enabled: [1, Gain compensation enabled and applied to all channels]
+    GCOMPCOEFF: [0, 0x3FFF]
+  JDR?:
+    JDATA: [0, 0xFFFFFFFF]
+  LTR?:
+    LTR?: [0, 0x1FFFFFF]
+  HTR?:
+    HTR?: [0, 0x1FFFFFF]
+  HTR1:
+    AWDFILT1:
+      NoFiltering: [0, "No filtering"]
+      Detections2: [1, "Two consecutive detections generates an AWDx flag or an interrupt"]
+      Detections3: [2, "Three consecutive detections generates an AWDx flag or an interrupt"]
+      Detections4: [3, "Four consecutive detections generates an AWDx flag or an interrupt"]
+      Detections5: [4, "Five consecutive detections generates an AWDx flag or an interrupt"]
+      Detections6: [5, "Six consecutive detections generates an AWDx flag or an interrupt"]
+      Detections7: [6, "Seven consecutive detections generates an AWDx flag or an interrupt"]
+      Detections8: [7, "Eight consecutive detections generates an AWDx flag or an interrupt"]
+  DIFSEL:
+    DIFSEL*:
+      SingleEnded: [0, "ADC analog input channel x is configured in single-ended mode"]
+      Differential: [1, "ADC analog input channel x is configured in differential mode"]
+  CALFACT:
+    CAPTURE_COEF:
+      Disabled: [0, "Calibration factor not captured"]
+      Enabled: [1, "Calibration factor available in CALFACT[31:0] bits, the calibration factor index being defined by CALINDEX[3:0] bits"]
+    LATCH_COEF:
+      NoEffect: [0, "No effect"]
+      Latch: [1, "Calibration factor latched in the analog block on LATCH_COEF bit transition from 0 to 1. Prior to latching the calibration factor, CALFACT[31:0] bits must be programmed with the content of CALINDEX[3:0] bits."]
+    VALIDITY:
+      _read:
+        InProgress: [0, "Operation still in progress"]
+        Complete: [1, "Operation complete"]
+    I_APB_DATA: [0, 0xFF]
+    I_APB_ADDR: [0, 0xFF]
+  CALFACT2:
+    CALFACT: [0, 0xFFFFFFFF]
+
+ADC4:
+  ISR:
+    EOCAL:
+      _read:
+        NotComplete: [0, "Calibration is not complete"]
+        Complete: [1, "Calibration is complete"]
+      _write:
+        Clear: [1, "Clear the end of calibration flag"]
+  IER:
+    LDORDYIE:
+      Disabled: [0, "LDO ready interrupt disabled"]
+      Enabled: [1, "LDO ready interrupt enabled. An interrupt is generated when the LDO output is ready."]
+    EOCALIE:
+      Disabled: [0, "End of calibration interrupt disabled"]
+      Enabled: [1, "End of calibration interrupt enabled"]
+  CFGR1:
+    CHSELRMOD:
+      BitPerInput: [0, "Each bit of the ADC_CHSELR register enables an input"]
+      Sequence: [1, "ADC_CHSELR register is able to sequence up to 8 channels"]
+    WAIT:
+      Disabled: [0, "Wait conversion mode off"]
+      Enabled: [1, "Wait conversion mode on"]
+    EXTSEL:
+      TIM1_TRGO2: [0, "tim1_trgo2"]
+      TIM1_OC4: [1, "tim1_oc4"]
+      TIM2_TRGO: [2, "tim2_trgo"]
+      TIM15_TRGO: [3, "tim15_trgo"]
+      TIM6_TRGO: [4, "tim6_trgo"]
+      LPTIM1_CH1: [5, "lptim1_ch1"]
+      LPTIM3_CH2: [6, "lptim3_ch2"]
+      EXTI15: [7, "exti15"]
+    ALIGN:
+      Right: [0, "Right alignment"]
+      Left: [1, "Left alignment"]
+    SCANDIR:
+      Upward: [0, "Upward scan sequence (from CHSEL0 to CHSEL23)"]
+      Downward: [1, "Downward scan sequence (from CHSEL23 to CHSEL0)"]
+    RES:
+      TwelveBit: [0, "12 bits"]
+      TenBit: [1, "10 bits"]
+      EightBit: [2, "8 bits"]
+      SixBit: [3, "6 bits"]
+    DMACFG:
+      OneShot: [0, "One-shot mode selected"]
+      Circular: [1, "Circular mode selected"]
+    DMAEN:
+      Disabled: [0, "DMA disabled"]
+      Enabled: [1, "DMA enabled"]
+  CFGR2:
+    OVSS: [0, 8]
+    OVSR: [0, 7]
+    OVSE:
+      Disabled: [0, "Oversampler disabled"]
+      Enabled: [1, "Oversampler enabled"]
+  SMPR:
+    SMPSEL*:
+      SMP1: [0, "Sampling time of channel x uses the setting of SMP1 register."]
+      SMP2: [1, "Sampling time of channel x uses the setting of SMP2 register."]
+    SMP1,SMP2:
+      Cycles1_5: [0, "1.5 ADC clock cycles"]
+      Cycles3_5: [1, "3.5 ADC clock cycles"]
+      Cycles7_5: [2, "7.5 ADC clock cycles"]
+      Cycles12_5: [3, "12.5 ADC clock cycles"]
+      Cycles19_5: [4, "19.5 ADC clock cycles"]
+      Cycles39_5: [5, "39.5 ADC clock cycles"]
+      Cycles79_5: [6, "79.5 ADC clock cycles"]
+      Cycles814_5: [7, "814.5 ADC clock cycles"]
+  AWD?TR:
+    HT?: [0, 0xFFF]
+    LT?: [0, 0xFFF]
+  CHSELRMOD0:
+    _split: [CHSEL]
+    CHSEL*:
+      Disabled: [0, "Input channel x is not selected for conversion"]
+      Enabled: [1, "Input channel x is selected for conversion"]
+  CHSELRMOD1:
+    SQ*:
+      Channel0: [0, "CH0"]
+      Channel1: [1, "CH1"]
+      Channel2: [2, "CH2"]
+      Channel3: [3, "CH3"]
+      Channel4: [4, "CH4"]
+      Channel5: [5, "CH5"]
+      Channel6: [6, "CH6"]
+      Channel7: [7, "CH7"]
+      Channel8: [8, "CH8"]
+      Channel9: [9, "CH9"]
+      Channel10: [10, "CH10"]
+      Channel11: [11, "CH11"]
+      Channel12: [12, "CH12"]
+      Channel13: [13, "CH13"]
+      Channel14: [14, "CH14"]
+      NoChannel: [15, "No channel selected (End of sequence)"]
+  PWRR:
+    VREFSECSMP:
+      Disabled: [0, "VREF+ second sample disabled"]
+      Enabled: [1, "VREF+ second sample enabled"]
+    VREFPROT:
+      Disabled: [0, "VREF+ protection disabled"]
+      Enabled: [1, "VREF+ protection enabled"]
+    DPD:
+      Disabled: [0, "Deep-power-down mode disabled"]
+      Enabled: [1, "Deep-power-down mode enabled"]
+    AUTOFF:
+      Disabled: [0, "Auto-off mode disabled"]
+      Enabled: [1, "Auto-off mode enabled"]
+  CALFACT:
+    CALFACT: [0, 0x7F]
+  OR:
+    CHN21SEL:
+      Out1: [0, "dac1_out1 selected"]
+      Out2: [1, "dac1_out2 selected"]
+
+ADC12_Common,ADC4:
+  CCR:
+    VBATEN:
+      Disabled: [0, "VBAT channel disabled"]
+      Enabled: [1, "VBAT channel enabled"]
+    VSENSESEL:
+      Disabled: [0, "Temperature sensor channel disabled"]
+      Enabled: [1, "Temperature sensor channel enabled"]
+    VREFEN:
+      Disabled: [0, "VREFINT channel disabled"]
+      Enabled: [1, "VREFINT channel enabled"]
+    PRESC:
+      Div1: [0, "Input ADC clock not divided"]
+      Div2: [1, "Input ADC clock divided by 2"]
+      Div4: [2, "Input ADC clock divided by 4"]
+      Div6: [3, "Input ADC clock divided by 6"]
+      Div8: [4, "Input ADC clock divided by 8"]
+      Div10: [5, "Input ADC clock divided by 10"]
+      Div12: [6, "Input ADC clock divided by 12"]
+      Div16: [7, "Input ADC clock divided by 16"]
+      Div32: [8, "Input ADC clock divided by 32"]
+      Div64: [9, "Input ADC clock divided by 64"]
+      Div128: [10, "Input ADC clock divided by 128"]
+      Div256: [11, "Input ADC clock divided by 256"]

--- a/peripherals/adc/adc_u5_dual.yaml
+++ b/peripherals/adc/adc_u5_dual.yaml
@@ -1,0 +1,21 @@
+# only on U59x, U5Ax, U5Fx, U5Gx
+
+_include:
+  - "adc_u5.yaml"
+
+ADC12_Common:
+  CCR:
+    DAMDF:
+      NoPacking: [0, "Dual ADC mode without data packing"]
+      Format32_to_10: [2, "Data formatting mode for 32 down to 10-bit resolution"]
+      Format8: [3, "Data formatting mode for 8-bit resolution"]
+    DELAY: [0, 0xF]
+    DUAL:
+      Independent: [0, "Independent mode"]
+      RegularSimultaneousInjectedSimultaneous: [1, "Combined regular simultaneous + injected simultaneous mode"]
+      RegularSimultaneousAlternateTrigger: [2, "Combined regular simultaneous + alternate trigger mode"]
+      InterleavedInjectedSimultaneous: [3, "Combined interleaved mode + injected simultaneous mode"]
+      InjectedSimultaneous: [5, "Injected simultaneous mode only"]
+      RegularSimultaneous: [6, "Regular simultaneous mode only"]
+      Interleaved: [7, "Interleaved mode only"]
+      AlternateTrigger: [9, "Alternate trigger mode only"]


### PR DESCRIPTION
Originally part of #974.

Will double-check the cycle count numbers, trigger identifiers etc. with the datasheet again tomorrow since I haven't touched this code in quite some time.