### PR TITLE
G4A1 - Add missing FDCAN2, rename USB peripheral

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@
 * WB: add `RCC`, `SYSCFG` enums
 * G4: fix FDCAN interrupt numbers being swapped
 * G0X1, G4, H5, H7R/S, L5, U5: Add UCPD peripheral
+* G4A1: Add FDCAN2 and rename USB peripheral
 
 Family-specific:
 

--- a/devices/stm32g4a1.yaml
+++ b/devices/stm32g4a1.yaml
@@ -10,7 +10,7 @@ _derive:
     baseAddress: 0x40006800
 
 FDCAN2:
-  add:
+  _add:
     _interrupts:
       FDCAN2_intr0:
         description: FDCAN2_intr0

--- a/devices/stm32g4a1.yaml
+++ b/devices/stm32g4a1.yaml
@@ -1,5 +1,24 @@
 _svd: ../svd/stm32g4a1.svd
 
+_modify:
+  USB_FS_device:
+    name: USB
+
+_derive:
+  FDCAN2:
+    _from: FDCAN
+    baseAddress: 0x40006800
+
+FDCAN2:
+  add:
+    _interrupts:
+      FDCAN2_intr0:
+        description: FDCAN2_intr0
+        value: 86
+      FDCAN2_intr1:
+        description: FDCAN2_intr1
+        value: 87
+
 OPAMP:
   _copy:
     OPAMP6_CSR:


### PR DESCRIPTION
Similar to #915