### PR TITLE
Unify g49a and g4a1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@
 * G4: fix FDCAN interrupt numbers being swapped
 * G0X1, G4, H5, H7R/S, L5, U5: Add UCPD peripheral
 * G4A1: Add FDCAN2 and rename USB peripheral
+* G4A1: Add BCDR and adjust to be closer to G491
 
 Family-specific:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@
 * G0X1, G4, H5, H7R/S, L5, U5: Add UCPD peripheral
 * G4A1: Add FDCAN2 and rename USB peripheral
 * G4A1: Add BCDR and adjust to be closer to G491
+* G491 and G4A1: Add TIM20
 
 Family-specific:
 

--- a/devices/stm32g491.yaml
+++ b/devices/stm32g491.yaml
@@ -4,6 +4,9 @@ _derive:
   FDCAN2:
     _from: FDCAN
     baseAddress: 0x40006800
+  TIM20:
+    _from: TIM1
+    baseAddress: 0x40015000
 
 FDCAN2:
   _add:

--- a/devices/stm32g4a1.yaml
+++ b/devices/stm32g4a1.yaml
@@ -4,6 +4,9 @@ _derive:
   FDCAN2:
     _from: FDCAN
     baseAddress: 0x40006800
+  TIM20:
+    _from: TIM1
+    baseAddress: 0x40015000
 
 FDCAN2:
   _add:

--- a/devices/stm32g4a1.yaml
+++ b/devices/stm32g4a1.yaml
@@ -1,9 +1,5 @@
 _svd: ../svd/stm32g4a1.svd
 
-_modify:
-  USB_FS_device:
-    name: USB
-
 _derive:
   FDCAN2:
     _from: FDCAN
@@ -42,6 +38,13 @@ SPI?:
   _include:
     - common_patches/16bit.yaml
     - common_patches/spi/dr8.yaml
+
+UCPD1:
+  _include:
+    - common_patches/ucpd/rxordseten_split.yaml
+    - common_patches/ucpd/cfgr_missing_r.yaml
+    - common_patches/ucpd/tx_rx_missing_r.yaml
+    - ../peripherals/ucpd/ucpd_v1.yaml
 
 VREFBUF:
   _strip:
@@ -87,7 +90,11 @@ _include:
  - ../peripherals/gpio/v2/common.yaml
  - collect/gpio/v2.yaml
  - ../peripherals/usart/usart_v2C.yaml
- - common_patches/tim/v2/g4.yaml
+ - ./common_patches/usb/rename_USB_FS_peripheral_to_USB.yaml
+ - ./common_patches/usb/g4.yaml
+ - ../peripherals/rcc/rcc_g4.yaml
  - common_patches/tim/common.yaml
+ - common_patches/tim/v2/g4.yaml
  - ../peripherals/tim/v2/ccm.yaml
  - collect/tim/ccr.yaml
+ - ../peripherals/flash/flash_g4.yaml


### PR DESCRIPTION
I just had a closer look at `devices/stm32g491.yaml` and  `devices/stm32g4a1.yaml` they seem to have diverged quite a bit. However looking in the [RM](https://www.st.com/resource/en/reference_manual/rm0440-stm32g4-series-advanced-armbased-32bit-mcus-stmicroelectronics.pdf#page=75) they are even in the same column under available peripherals so should be pretty much identical, I think, with AES being the only difference.

Also adds TIM20 to both devices