### PR TITLE
stm32mp1: Fix RCC.RCC_BDCR.DIGBYP Access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+* MP15x: Fix DIGBYP bit access in RCC_BDCR
 * Fix yaml parsing errors
 * H7: add bit TRBUFF of DMA_SxCR of H747 cm4
 * Fix inconsistencies for HRTIM_TIMF - stm32g4x4

--- a/devices/stm32mp153.yaml
+++ b/devices/stm32mp153.yaml
@@ -22,6 +22,12 @@ TAMP:
   _strip:
     - "TAMP_"
 
+RCC:
+  RCC_BDCR:
+    _modify:
+      DIGBYP:
+        access: read-write
+
 _include:
  - common_patches/rtc/alarm.yaml
  - collect/rtc/tamp_bkpr.yaml

--- a/devices/stm32mp157.yaml
+++ b/devices/stm32mp157.yaml
@@ -28,6 +28,12 @@ TAMP:
   _strip:
     - "TAMP_"
 
+RCC:
+  RCC_BDCR:
+    _modify:
+      DIGBYP:
+        access: read-write
+
 _include:
  - collect/dsi/isr.yaml
  - common_patches/rtc/alarm.yaml


### PR DESCRIPTION
Previously, this bitfield was created with read-only access, though it's supposed to be writable by software. Fixes #1010.