### PR TITLE
stm32mp15x: Strip register prefixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+* MP15x: Strip prefixes from peripherals
 * MP15x: Fix DIGBYP bit access in RCC_BDCR
 * Fix yaml parsing errors
 * H7: add bit TRBUFF of DMA_SxCR of H747 cm4

--- a/devices/common_patches/mpu_unprefix_registers.yaml
+++ b/devices/common_patches/mpu_unprefix_registers.yaml
@@ -1,0 +1,166 @@
+ADC:
+  _strip: "ADC_"
+
+ADC?:
+  _strip:
+    - "ADC_"
+    - "ADC?_"
+
+AXIMC_Mx:
+  _strip: "AXIMC_"
+
+BSEC:
+  _strip: "BSEC_"
+
+CCU:
+  _strip: "FCCAN_CCU_"
+
+CRC?:
+  _strip: "CRC_"
+
+CRYP?:
+  _strip: "CRYP_"
+
+DAC?:
+  _strip: "DAC_"
+
+DCMI:
+  _strip: "DCMI_"
+
+DDRCTRL:
+  _strip: "DDRCTRL_"
+
+DDRPERFM:
+  _strip: "DDRPERFM_"
+
+DDRPHYC:
+  _strip: "DDRPHYC_"
+
+DFSDM?:
+  _strip: "DFSDM_"
+
+DLYB*:
+  _strip: "DLYB_"
+
+DMA?:
+  _strip: "DMA_"
+
+DMAMUX?:
+  _strip: "DMAMUX_"
+
+DTS:
+  _strip: "DTS_"
+
+ETH_DMA:
+  _strip: "ETH_"
+
+ETH_MAC_MMC:
+  _strip: "ETH_"
+
+ETH_MTL:
+  _strip: "ETH_"
+
+ETZPC:
+  _strip: "ETZPC_"
+
+EXTI:
+  _strip: "EXTI_"
+
+FDCAN?:
+  _strip: "FDCAN_"
+
+FMC:
+  _strip: "FMC_"
+
+GIC?:
+  _strip: "GIC?_"
+
+GPIO?:
+  _strip: "GPIO?_"
+
+HASH?:
+  _strip: "HASH_"
+
+HDMI_CEC:
+  _strip: "CEC_"
+
+HDP:
+  _strip: "HDP_"
+
+HSEM:
+  _strip: "HSEM_"
+
+I2C?:
+  _strip: "I2C_"
+
+IPCC:
+  _strip: "IPCC_"
+
+IWDG?:
+  _strip: "IWDG_"
+
+LPTIM?:
+  _strip: "LPTIM_"
+
+LTDC:
+  _strip: "LTDC_"
+
+MDIOS:
+  _strip: "MDIOS_"
+
+MDMA:
+  _strip: "MDMA_"
+
+OTG:
+  _strip: "OTG_"
+
+PWR:
+  _strip: "PWR_"
+
+QUADSPI:
+  _strip: "QUADSPI_"
+
+RCC:
+  _strip: "RCC_"
+
+RNG?:
+  _strip: "RNG_"
+
+RTC:
+  _strip: "RTC_"
+
+SAI?:
+  _strip: "SAI_"
+
+SDMMC?:
+  _strip: "SDMMC_"
+
+SPDIFRX:
+  _strip: "SPDIFRX_"
+
+SPI?:
+  _strip: "SPI_"
+
+STGEN?:
+  _strip: "STGEN?_"
+
+SYSCFG:
+  _strip: "SYSCFG_"
+
+TAMP:
+  _strip: "TAMP_"
+
+TIM*:
+  _strip: "TIM*_"
+
+TZC:
+  _strip: "TZC_"
+
+USBPHYC:
+  _strip: "USBPHYC_"
+
+VREFBUF:
+  _strip: "VREFBUF_"
+
+WWDG?:
+  _strip: "WWDG_"

--- a/devices/stm32mp153.yaml
+++ b/devices/stm32mp153.yaml
@@ -11,24 +11,17 @@ _modify:
     nvicPrioBits: 4
     vendorSystickConfig: "false"
 
-RTC:
-  _strip:
-    - "RTC_"
-
 SPI?:
   _include: common_patches/spi/rxtxdr.yaml
 
-TAMP:
-  _strip:
-    - "TAMP_"
-
 RCC:
-  RCC_BDCR:
+  BDCR:
     _modify:
       DIGBYP:
         access: read-write
 
 _include:
+ - common_patches/mpu_unprefix_registers.yaml
  - common_patches/rtc/alarm.yaml
  - collect/rtc/tamp_bkpr.yaml
  - collect/rtc/alarm.yaml

--- a/devices/stm32mp157.yaml
+++ b/devices/stm32mp157.yaml
@@ -17,24 +17,17 @@ DSI:
   _strip:
     - "DSI_"
 
-RTC:
-  _strip:
-    - "RTC_"
-
 SPI?:
   _include: common_patches/spi/rxtxdr.yaml
 
-TAMP:
-  _strip:
-    - "TAMP_"
-
 RCC:
-  RCC_BDCR:
+  BDCR:
     _modify:
       DIGBYP:
         access: read-write
 
 _include:
+ - common_patches/mpu_unprefix_registers.yaml
  - collect/dsi/isr.yaml
  - common_patches/rtc/alarm.yaml
  - collect/rtc/tamp_bkpr.yaml


### PR DESCRIPTION
As promised in the discourse captured on #1011, strip the prefixes from the registers of nearly all the peripherals on these parts.