### PR TITLE
Move settings creation into shell script to fix invocation on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,8 +76,7 @@ $(1)/src/%/mod.rs: svd/%.svd.patched settings/%.yaml $(1)/Cargo.toml
 
 settings/%.yaml: svd/%.svd.patched
 	mkdir -p settings
-	echo "html_url: https://stm32-rs.github.io/stm32-rs/`svdtools info $$< device-name --input-format xml`.html" > $$@
-	echo "crate_path: crate::`echo $$< | sed -E 's|svd/(\w*)\.svd\.patched|\1|g'`" >> $$@
+	scripts/makesettings.sh $$< $$@
 
 $(1)/src/%/.form: $(1)/src/%/mod.rs
 	form -f -i $$< -o $$(@D)

--- a/scripts/makesettings.sh
+++ b/scripts/makesettings.sh
@@ -1,0 +1,6 @@
+set -euxo pipefail
+
+NAME=$(svdtools info $1 device-name --input-format xml)
+CRATE_PATH=$(echo $(basename $1) | sed -E 's|(\w*)\.svd\.patched|\1|g')
+echo "html_url: https://stm32-rs.github.io/stm32-rs/${NAME}.html" > $2
+echo "crate_path: crate::${CRATE_PATH}" >> $2


### PR DESCRIPTION
The Makefile invocation for creating the settings files isn't compatible with macOS's version of make. This moves the logic into separate script and calls the script from the Makefile.