### PR TITLE
H5: Add RCC register patches and field definitions for the for H56x/H573 processors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+* H5: Add RCC defitions for H56x/H573
 * MP15x: Strip prefixes from peripherals
 * MP15x: Fix DIGBYP bit access in RCC_BDCR
 * Fix yaml parsing errors

--- a/devices/common_patches/rcc/h56x_h57x.yaml
+++ b/devices/common_patches/rcc/h56x_h57x.yaml
@@ -1,0 +1,85 @@
+RCC:
+  PLL3CFGR:
+    _modify:
+      DIVM3:
+        name: PLL3M
+  CCIPR2:
+    _modify:
+      USART12SEL:
+        name: UART12SEL
+  CCIPR4:
+    _add:
+      I3C2SEL:
+        description: I3C2 kernel clock source selection
+        bitOffset: 26
+        bitWidth: 2
+        access: read-write
+  AHB2ENR:
+    _modify:
+      DAC12EN:
+        name: DAC1EN
+        description: DAC clock enable
+      ADC12EN:
+        name: ADCEN
+        description: ADC1 and 2 peripherals clock enable
+  AHB2LPENR:
+    _modify:
+      DAC12LPEN:
+        name: DAC1LPEN
+        description: DAC clock enable during sleep mode
+      ADC12LPEN:
+        name: ADCLPEN
+        description: ADC1 and 2 peripherals clock enable during sleep mode
+  AHB2RSTR:
+    _modify:
+      DAC12RST:
+        name: DAC1RST
+        description: DAC block reset
+      ADC12RST:
+        name: ADCRST
+        description: ADC1 and 2 blocks reset
+  APB1HENR:
+    _modify:
+      UCPDEN:
+        name: UCPD1EN
+        description: UCPD1 clock enable
+      FDCAN12EN:
+        name: FDCANEN
+        description: FDCAN1 and FDCAN2 peripheral clock enable
+  APB1HLPENR:
+    _modify:
+      UCPDLPEN:
+        name: UCPD1LPEN
+        description: UCPD1 clock enable during sleep mode
+      FDCAN12LPEN:
+        name: FDCANLPEN
+        description: FDCAN1 and FDCAN2 peripheral clock enable during sleep mode
+  APB1HRSTR:
+    _modify:
+      UCPDRST:
+        name: UCPD1RST
+        description: UCPD1 block reset
+      FDCAN12RST:
+        name: FDCANRST
+        description: FDCAN1 and FDCAN2 blocks reset
+  APB3ENR:
+    _add:
+      I3C2EN:
+        description: I3C2 clock enable
+        bitOffset: 9
+        bitWidth: 1
+        access: read-write
+  APB3LPENR:
+    _add:
+      I3C2LPEN:
+        description: I3C2 clock enable during sleep mode
+        bitOffset: 9
+        bitWidth: 1
+        access: read-write
+  APB3RSTR:
+    _add:
+      I3C2RST:
+        description: I3C2 block reset
+        bitOffset: 9
+        bitWidth: 1
+        access: read-write

--- a/devices/stm32h562.yaml
+++ b/devices/stm32h562.yaml
@@ -28,7 +28,9 @@ _include:
   - ../peripherals/gpio/gpio_with_brr.yaml
   - ../peripherals/gpio/gpio_with_hslvr.yaml
 
+  - common_patches/rcc/h56x_h57x.yaml
   - ../peripherals/rcc/rcc_h5.yaml
+  - ../peripherals/rcc/rcc_h56x_h57x.yaml
 
   - common_patches/rtc/alarm.yaml
   - common_patches/rtc/rtc_cr.yaml

--- a/devices/stm32h563.yaml
+++ b/devices/stm32h563.yaml
@@ -27,7 +27,10 @@ _include:
   - ../peripherals/gpio/gpio_with_brr.yaml
   - ../peripherals/gpio/gpio_with_hslvr.yaml
 
+  - common_patches/rcc/h56x_h57x.yaml
   - ../peripherals/rcc/rcc_h5.yaml
+  - ../peripherals/rcc/rcc_h56x_h57x.yaml
+  - ../peripherals/rcc/rcc_h563_h573.yaml
 
   - common_patches/rtc/alarm.yaml
   - common_patches/rtc/rtc_cr.yaml

--- a/devices/stm32h563.yaml
+++ b/devices/stm32h563.yaml
@@ -30,7 +30,6 @@ _include:
   - common_patches/rcc/h56x_h57x.yaml
   - ../peripherals/rcc/rcc_h5.yaml
   - ../peripherals/rcc/rcc_h56x_h57x.yaml
-  - ../peripherals/rcc/rcc_h563_h573.yaml
 
   - common_patches/rtc/alarm.yaml
   - common_patches/rtc/rtc_cr.yaml

--- a/devices/stm32h573.yaml
+++ b/devices/stm32h573.yaml
@@ -27,7 +27,10 @@ _include:
   - ../peripherals/gpio/gpio_with_brr.yaml
   - ../peripherals/gpio/gpio_with_hslvr.yaml
 
+  - common_patches/rcc/h56x_h57x.yaml
   - ../peripherals/rcc/rcc_h5.yaml
+  - ../peripherals/rcc/rcc_h56x_h57x.yaml
+  - ../peripherals/rcc/rcc_h563_h573.yaml
 
   - common_patches/rtc/alarm.yaml
   - common_patches/rtc/rtc_cr.yaml

--- a/devices/stm32h573.yaml
+++ b/devices/stm32h573.yaml
@@ -30,7 +30,6 @@ _include:
   - common_patches/rcc/h56x_h57x.yaml
   - ../peripherals/rcc/rcc_h5.yaml
   - ../peripherals/rcc/rcc_h56x_h57x.yaml
-  - ../peripherals/rcc/rcc_h563_h573.yaml
 
   - common_patches/rtc/alarm.yaml
   - common_patches/rtc/rtc_cr.yaml

--- a/peripherals/rcc/rcc_h5.yaml
+++ b/peripherals/rcc/rcc_h5.yaml
@@ -45,6 +45,20 @@ RCC:
       _read:
         NoInterrupt: [ 0, "No clock security interrupt caused by HSE clock failure" ]
         Interrupt: [ 1, "Clock security interrupt caused by HSE clock failure" ]
+  CCIPR1:
+    TIMICSEL:
+      Disabled: [0, "No internal clock available for timers input capture"]
+      Enabled: [1, "hsi_ker_ck/1024, hsi_ker_ck/8 and csi_ker_ck/128 selected for timers input capture"]
+  CCIPR4:
+    USBSEL:
+      DISABLE: [0, "Disable the clock"]
+      PLL1_Q: [1, "PLL1 Q clock selected as clock source (pll1_q_ck)"]
+      PLL2_Q: [2, "PLL2 Q clock selected as clock source (pll2_q_ck)"]
+      HSI48: [3, "HSI48 clock selected as clock source (hsi48_ker_ck)"]
+    SYSTICKSEL:
+      HCLK_DIV8: [0, "RCC HLCK divided by 8 selected as clock source (rcc_hclk / 8)"]
+      LSI_KER: [1, "LSI kernel selected as clock source (lsi_ker_ck)"]
+      LSE: [2, "LSE selected as clock source (lse_ck)"]
   CCIPR5:
     CKPERSEL:
       HSI_KER: [0, "HSI kernel clock selected as clock source (hsi_ker_ck)"]

--- a/peripherals/rcc/rcc_h503.yaml
+++ b/peripherals/rcc/rcc_h503.yaml
@@ -1,6 +1,4 @@
-# Common RCC patches for H5 chips
-# The H562/3 and H573 chips are typically a superset of H503, so additional fields
-# need to be specified for those chips.
+# RCC patches specifically for H503
 
 
 _include:
@@ -56,7 +54,7 @@ RCC:
       PER_CK: [4, "per_ck clock selected as clock source"]
     SPI2SEL:
       PLL1_Q: [0, "PLL1 Q clock selected as clock source (pll1_q_ck)"]
-      PLL2_P: [1, "PLL2 QP clock selected as clock source (pll2_p_ck)"]
+      PLL2_P: [1, "PLL2 P clock selected as clock source (pll2_p_ck)"]
       AUDIOCLK: [3, "AUDIOCLK clock selected as clock source"]
       PER_CK: [4, "per_ck clock selected as clock source"]
     SPI3SEL:

--- a/peripherals/rcc/rcc_h503.yaml
+++ b/peripherals/rcc/rcc_h503.yaml
@@ -6,90 +6,43 @@ _include:
 
 RCC:
   CCIPR1:
-    TIMICSEL:
-      Disabled: [0, "No internal clock available for timers input capture"]
-      Enabled: [1, "hsi_ker_ck/1024, hsi_ker_ck/8 and csi_ker_ck/128 selected for timers input capture"]
-    USART3SEL:
-      RCC_PCLK1: [0, "PCLK1 selected as clock source (rcc_pclk1)"]
-      PLL2_Q: [1, "PLL2 Q clock selected as clock source (pll2_q_ck)"]
-      HSI_KER: [3, "HSI kernel clock selected as clock source (hsi_ker_ck)"]
-      CSI_KER: [4, "CSI kernel clock selected as clock source (csi_ker_ck)"]
-      LSE: [5, "LSE clock selected as clock source (lse_ck)"]
-    USART2SEL:
-      RCC_PCLK1: [0, "PCLK1 selected as clock source (rcc_pclk1)"]
-      PLL2_Q: [1, "PLL2 Q clock selected as clock source (pll2_q_ck)"]
-      HSI_KER: [3, "HSI kernel clock selected as clock source (hsi_ker_ck)"]
-      CSI_KER: [4, "CSI kernel clock selected as clock source (csi_ker_ck)"]
-      LSE: [5, "LSE clock selected as clock source (lse_ck)"]
-    USART1SEL:
-      RCC_PCLK2: [0, "PCLK2 selected as clock source (rcc_pclk2)"]
+    USART*SEL:
+      _name: USARTSEL
+      PCLK: [0, "Peripheral bus clock used as selected as clock source (rcc_pclk_x)"]
       PLL2_Q: [1, "PLL2 Q clock selected as clock source (pll2_q_ck)"]
       HSI_KER: [3, "HSI kernel clock selected as clock source (hsi_ker_ck)"]
       CSI_KER: [4, "CSI kernel clock selected as clock source (csi_ker_ck)"]
       LSE: [5, "LSE clock selected as clock source (lse_ck)"]
   CCIPR2:
-    LPTIM2SEL:
-      RCC_PCLK1: [0, "PCLK1 selected as clock source (rcc_pclk1)"]
-      PLL2_P: [1, "PLL2 P clock selected as clock source (pll2_p_ck)"]
-      LSE_KER: [3, "LSE kernel selected as clock source (lse_ck)"]
-      LSI_KER: [4, "LSI kernel selected as clock source (lsi_ker_ck)"]
-      PER_CK: [5, "per_ck clock selected as clock source"]
-    LPTIM1SEL:
-      RCC_PCLK3: [0, "PCLK3 selected as clock source (rcc_pclk3)"]
+    LPTIM*SEL:
+      _name: LPTIMSEL
+      PCLK: [0, "Peripheral bus clock used as selected as clock source (rcc_pclk_x)"]
       PLL2_P: [1, "PLL2 P clock selected as clock source (pll2_p_ck)"]
       LSE_KER: [3, "LSE kernel selected as clock source (lse_ck)"]
       LSI_KER: [4, "LSI kernel selected as clock source (lsi_ker_ck)"]
       PER_CK: [5, "per_ck clock selected as clock source"]
   CCIPR3:
-    LPUART1SEL:
-      RCC_PCLK3: [0, "PCLK3 selected as clock source (rcc_pclk3)"]
-      PLL2_Q: [1, "PLL2 Q clock selected as clock source (pll2_q_ck)"]
-      HSI_KER: [3, "HSI kernel clock selected as clock source (hsi_ker_ck)"]
-      CSI_KER: [4, "CSI kernel clock selected as clock source (csi_ker_ck)"]
-      LSE: [5, "LSE selected as clock source (lse_ck)"]
-    SPI1SEL:
-      PLL1_Q: [0, "PLL1 Q clock selected as clock source (pll1_q_ck)"]
-      PLL2_P: [1, "PLL2 P clock selected as clock source (pll2_p_ck)"]
-      AUDIOCLK: [3, "AUDIOCLK clock selected as clock source"]
-      PER_CK: [4, "per_ck clock selected as clock source"]
-    SPI2SEL:
-      PLL1_Q: [0, "PLL1 Q clock selected as clock source (pll1_q_ck)"]
-      PLL2_P: [1, "PLL2 P clock selected as clock source (pll2_p_ck)"]
-      AUDIOCLK: [3, "AUDIOCLK clock selected as clock source"]
-      PER_CK: [4, "per_ck clock selected as clock source"]
-    SPI3SEL:
+    _modify:
+      LPUART1SEL:
+        derivedFrom: RCC.CCIPR1.USART1SEL
+    SPI*SEL:
+      _name: SPI123SEL
       PLL1_Q: [0, "PLL1 Q clock selected as clock source (pll1_q_ck)"]
       PLL2_P: [1, "PLL2 P clock selected as clock source (pll2_p_ck)"]
       AUDIOCLK: [3, "AUDIOCLK clock selected as clock source"]
       PER_CK: [4, "per_ck clock selected as clock source"]
   CCIPR4:
-    I3C2SEL:
-      RCC_PCLK3: [0, "PCLK3 selected as clock source (rcc_pclk3)"]
+    I3C*SEL:
+      _name: I3CSEL
+      PCLK: [0, "Peripheral bus clock used as selected as clock source (rcc_pclk_x)"]
       PLL2_R: [1, "PLL2 R clock selected as clock source (pll2_r_ck)"]
       HSI_KER: [2, "HSI kernel clock selected as clock source (hsi_ker_ck)"]
-    I3C1SEL:
-      RCC_PCLK1: [0, "PCLK1 selected as clock source (rcc_pclk1)"]
-      PLL2_R: [1, "PLL2 R Clock selected as clock source (pll2_r_ck)"]
-      HSI_KER: [2, "HSI kernel clock selected as clock source (hsi_ker_ck)"]
-    I2C1SEL:
-      RCC_PCLK1: [0, "PCLK1 selected as clock source (rcc_pclk1)"]
+    I2C*SEL:
+      _name: I2CSEL
+      PCLK: [0, "Peripheral bus clock used as selected as clock source (rcc_pclk_x)"]
       PLL2_R: [1, "PLL2 R Clock selected as clock source (pll2_r_ck)"]
       HSI_KER: [2, "HSI kernel clock selected as clock source (hsi_ker_ck)"]
       CSI_KER: [3, "CSI kernel clock selected as clock source (csi_ker_ck)"]
-    I2C2SEL:
-      RCC_PCLK1: [0, "PCLK1 selected as clock source (rcc_pclk1)"]
-      PLL2_R: [1, "PLL2 R Clock selected as clock source (pll2_r_ck)"]
-      HSI_KER: [2, "HSI kernel clock selected as clock source (hsi_ker_ck)"]
-      CSI_KER: [3, "CSI kernel clock selected as clock source (csi_ker_ck)"]
-    USBSEL:
-      DISABLE: [0, "Disable the clock"]
-      PLL1_Q: [1, "PLL1 Q clock selected as clock source (pll1_q_ck)"]
-      PLL2_Q: [2, "PLL2 Q clock selected as clock source (pll2_q_ck)"]
-      HSI48: [3, "HSI48 clock selected as clock source (hsi48_ker_ck)"]
-    SYSTICKSEL:
-      HCLK_DIV8: [0, "RCC HLCK divided by 8 selected as clock source (rcc_hclk / 8)"]
-      LSI_KER: [1, "LSI kernel selected as clock source (lsi_ker_ck)"]
-      LSE: [2, "LSE selected as clock source (lse_ck)"]
   CCIPR5:
     DAC1SEL:
       LSE: [0, "LSE selected as clock source (lse_ck)"]

--- a/peripherals/rcc/rcc_h563_h573.yaml
+++ b/peripherals/rcc/rcc_h563_h573.yaml
@@ -1,0 +1,5 @@
+RCC:
+  CCIPR4:
+    SDMMC2SEL:
+      PLL1_Q: [0, "PLL1 Q clock selected as clock source (pll1_q_ck)"]
+      PLL2_R: [1, "PLL2 R clock selected as clock source (pll2_r_ck)"]

--- a/peripherals/rcc/rcc_h563_h573.yaml
+++ b/peripherals/rcc/rcc_h563_h573.yaml
@@ -1,5 +1,0 @@
-RCC:
-  CCIPR4:
-    SDMMC2SEL:
-      PLL1_Q: [0, "PLL1 Q clock selected as clock source (pll1_q_ck)"]
-      PLL2_R: [1, "PLL2 R clock selected as clock source (pll2_r_ck)"]

--- a/peripherals/rcc/rcc_h56x_h57x.yaml
+++ b/peripherals/rcc/rcc_h56x_h57x.yaml
@@ -3,237 +3,69 @@ _include:
 
 RCC:
   CCIPR1:
-    TIMICSEL:
-      Disabled: [0, "No internal clock available for timers input capture"]
-      Enabled: [1, "hsi_ker_ck/1024, hsi_ker_ck/8 and csi_ker_ck/128 selected for timers input capture"]
-    USART10SEL:
-      RCC_PCLK1: [0, "PCLK1 selected as clock source (rcc_pclk1)"]
-      PLL2_Q: [1, "PLL2 Q clock selected as clock source (pll2_q_ck)"]
-      PLL3_Q: [2, "PLL3 Q clock selected as clock source (pll3_q_ck)"]
-      HSI_KER: [3, "HSI kernel clock selected as clock source (hsi_ker_ck)"]
-      CSI_KER: [4, "CSI kernel clock selected as clock source (csi_ker_ck)"]
-      LSE: [5, "LSE clock selected as clock source (lse_ck)"]
-    UART9SEL:
-      RCC_PCLK1: [0, "PCLK1 selected as clock source (rcc_pclk1)"]
-      PLL2_Q: [1, "PLL2 Q clock selected as clock source (pll2_q_ck)"]
-      PLL3_Q: [2, "PLL3 Q clock selected as clock source (pll3_q_ck)"]
-      HSI_KER: [3, "HSI kernel clock selected as clock source (hsi_ker_ck)"]
-      CSI_KER: [4, "CSI kernel clock selected as clock source (csi_ker_ck)"]
-      LSE: [5, "LSE clock selected as clock source (lse_ck)"]
-    UART8SEL:
-      RCC_PCLK1: [0, "PCLK1 selected as clock source (rcc_pclk1)"]
-      PLL2_Q: [1, "PLL2 Q clock selected as clock source (pll2_q_ck)"]
-      PLL3_Q: [2, "PLL3 Q clock selected as clock source (pll3_q_ck)"]
-      HSI_KER: [3, "HSI kernel clock selected as clock source (hsi_ker_ck)"]
-      CSI_KER: [4, "CSI kernel clock selected as clock source (csi_ker_ck)"]
-      LSE: [5, "LSE clock selected as clock source (lse_ck)"]
-    UART7SEL:
-      RCC_PCLK2: [0, "PCLK2 selected as clock source (rcc_pclk2)"]
-      PLL2_Q: [1, "PLL2 Q clock selected as clock source (pll2_q_ck)"]
-      PLL3_Q: [2, "PLL3 Q clock selected as clock source (pll3_q_ck)"]
-      HSI_KER: [3, "HSI kernel clock selected as clock source (hsi_ker_ck)"]
-      CSI_KER: [4, "CSI kernel clock selected as clock source (csi_ker_ck)"]
-      LSE: [5, "LSE clock selected as clock source (lse_ck)"]
-    USART6SEL:
-      RCC_PCLK1: [0, "PCLK1 selected as clock source (rcc_pclk1)"]
-      PLL2_Q: [1, "PLL2 Q clock selected as clock source (pll2_q_ck)"]
-      PLL3_Q: [2, "PLL3 Q clock selected as clock source (pll3_q_ck)"]
-      HSI_KER: [3, "HSI kernel clock selected as clock source (hsi_ker_ck)"]
-      CSI_KER: [4, "CSI kernel clock selected as clock source (csi_ker_ck)"]
-      LSE: [5, "LSE clock selected as clock source (lse_ck)"]
-    UART5SEL:
-      RCC_PCLK1: [0, "PCLK1 selected as clock source (rcc_pclk1)"]
-      PLL2_Q: [1, "PLL2 Q clock selected as clock source (pll2_q_ck)"]
-      PLL3_Q: [2, "PLL3 Q clock selected as clock source (pll3_q_ck)"]
-      HSI_KER: [3, "HSI kernel clock selected as clock source (hsi_ker_ck)"]
-      CSI_KER: [4, "CSI kernel clock selected as clock source (csi_ker_ck)"]
-      LSE: [5, "LSE clock selected as clock source (lse_ck)"]
-    UART4SEL:
-      RCC_PCLK2: [0, "PCLK2 selected as clock source (rcc_pclk2)"]
-      PLL2_Q: [1, "PLL2 Q clock selected as clock source (pll2_q_ck)"]
-      PLL3_Q: [2, "PLL3 Q clock selected as clock source (pll3_q_ck)"]
-      HSI_KER: [3, "HSI kernel clock selected as clock source (hsi_ker_ck)"]
-      CSI_KER: [4, "CSI kernel clock selected as clock source (csi_ker_ck)"]
-      LSE: [5, "LSE clock selected as clock source (lse_ck)"]
-    USART3SEL:
-      RCC_PCLK1: [0, "PCLK1 selected as clock source (rcc_pclk1)"]
-      PLL2_Q: [1, "PLL2 Q clock selected as clock source (pll2_q_ck)"]
-      PLL3_Q: [2, "PLL3 Q clock selected as clock source (pll3_q_ck)"]
-      HSI_KER: [3, "HSI kernel clock selected as clock source (hsi_ker_ck)"]
-      CSI_KER: [4, "CSI kernel clock selected as clock source (csi_ker_ck)"]
-      LSE: [5, "LSE clock selected as clock source (lse_ck)"]
-    USART2SEL:
-      RCC_PCLK1: [0, "PCLK1 selected as clock source (rcc_pclk1)"]
-      PLL2_Q: [1, "PLL2 Q clock selected as clock source (pll2_q_ck)"]
-      PLL3_Q: [2, "PLL3 Q clock selected as clock source (pll3_q_ck)"]
-      HSI_KER: [3, "HSI kernel clock selected as clock source (hsi_ker_ck)"]
-      CSI_KER: [4, "CSI kernel clock selected as clock source (csi_ker_ck)"]
-      LSE: [5, "LSE clock selected as clock source (lse_ck)"]
-    USART1SEL:
-      RCC_PCLK2: [0, "PCLK2 selected as clock source (rcc_pclk2)"]
+    USART*SEL,UART*SEL:
+      _name: USARTSEL
+      PCLK: [0, "Peripheral bus clock used as selected as clock source (rcc_pclk_x)"]
       PLL2_Q: [1, "PLL2 Q clock selected as clock source (pll2_q_ck)"]
       PLL3_Q: [2, "PLL3 Q clock selected as clock source (pll3_q_ck)"]
       HSI_KER: [3, "HSI kernel clock selected as clock source (hsi_ker_ck)"]
       CSI_KER: [4, "CSI kernel clock selected as clock source (csi_ker_ck)"]
       LSE: [5, "LSE clock selected as clock source (lse_ck)"]
   CCIPR2:
-    LPTIM6SEL:
-      RCC_PCLK3: [0, "PCLK3 selected as clock source (rcc_pclk3)"]
+    LPTIM*SEL:
+      _name: LPTIMSEL
+      PCLK: [0, "Peripheral bus clock used as selected as clock source (rcc_pclk_x)"]
       PLL2_P: [1, "PLL2 P clock selected as clock source (pll2_p_ck)"]
       PLL3_R: [2, "PLL3 R clock selected as clock source (pll3_r_ck)"]
       LSE_KER: [3, "LSE kernel selected as clock source (lse_ck)"]
       LSI_KER: [4, "LSI kernel selected as clock source (lsi_ker_ck)"]
       PER_CK: [5, "per_ck clock selected as clock source"]
-    LPTIM5SEL:
-      RCC_PCLK3: [0, "PCLK3 selected as clock source (rcc_pclk3)"]
-      PLL2_P: [1, "PLL2 P clock selected as clock source (pll2_p_ck)"]
-      PLL3_R: [2, "PLL3 R clock selected as clock source (pll3_r_ck)"]
-      LSE_KER: [3, "LSE kernel selected as clock source (lse_ck)"]
-      LSI_KER: [4, "LSI kernel selected as clock source (lsi_ker_ck)"]
-      PER_CK: [5, "per_ck clock selected as clock source"]
-    LPTIM4SEL:
-      RCC_PCLK3: [0, "PCLK3 selected as clock source (rcc_pclk3)"]
-      PLL2_P: [1, "PLL2 P clock selected as clock source (pll2_p_ck)"]
-      PLL3_R: [2, "PLL3 R clock selected as clock source (pll3_r_ck)"]
-      LSE_KER: [3, "LSE kernel selected as clock source (lse_ck)"]
-      LSI_KER: [4, "LSI kernel selected as clock source (lsi_ker_ck)"]
-      PER_CK: [5, "per_ck clock selected as clock source"]
-    LPTIM3SEL:
-      RCC_PCLK3: [0, "PCLK3 selected as clock source (rcc_pclk3)"]
-      PLL2_P: [1, "PLL2 P clock selected as clock source (pll2_p_ck)"]
-      PLL3_R: [2, "PLL3 R clock selected as clock source (pll3_r_ck)"]
-      LSE_KER: [3, "LSE kernel selected as clock source (lse_ck)"]
-      LSI_KER: [4, "LSI kernel selected as clock source (lsi_ker_ck)"]
-      PER_CK: [5, "per_ck clock selected as clock source"]
-    LPTIM2SEL:
-      RCC_PCLK1: [0, "PCLK1 selected as clock source (rcc_pclk1)"]
-      PLL2_P: [1, "PLL2 P clock selected as clock source (pll2_p_ck)"]
-      PLL3_R: [2, "PLL3 R clock selected as clock source (pll3_r_ck)"]
-      LSE_KER: [3, "LSE kernel selected as clock source (lse_ck)"]
-      LSI_KER: [4, "LSI kernel selected as clock source (lsi_ker_ck)"]
-      PER_CK: [5, "per_ck clock selected as clock source"]
-    LPTIM1SEL:
-      RCC_PCLK3: [0, "PCLK3 selected as clock source (rcc_pclk3)"]
-      PLL2_P: [1, "PLL2 P clock selected as clock source (pll2_p_ck)"]
-      PLL3_R: [2, "PLL3 R clock selected as clock source (pll3_r_ck)"]
-      LSE_KER: [3, "LSE kernel selected as clock source (lse_ck)"]
-      LSI_KER: [4, "LSI kernel selected as clock source (lsi_ker_ck)"]
-      PER_CK: [5, "per_ck clock selected as clock source"]
-    UART12SEL:
-      RCC_PCLK1: [0, "PCLK1 selected as clock source (rcc_pclk1)"]
-      PLL2_Q: [1, "PLL2 Q clock selected as clock source (pll2_q_ck)"]
-      PLL3_Q: [2, "PLL3 Q clock selected as clock source (pll3_q_ck)"]
-      HSI_KER: [3, "HSI kernel clock selected as clock source (hsi_ker_ck)"]
-      CSI_KER: [4, "CSI kernel clock selected as clock source (csi_ker_ck)"]
-      LSE: [5, "LSE clock selected as clock source (lse_ck)"]
-    USART11SEL:
-      RCC_PCLK1: [0, "PCLK1 selected as clock source (rcc_pclk1)"]
-      PLL2_Q: [1, "PLL2 Q clock selected as clock source (pll2_q_ck)"]
-      PLL3_Q: [2, "PLL3 Q clock selected as clock source (pll3_q_ck)"]
-      HSI_KER: [3, "HSI kernel clock selected as clock source (hsi_ker_ck)"]
-      CSI_KER: [4, "CSI kernel clock selected as clock source (csi_ker_ck)"]
-      LSE: [5, "LSE clock selected as clock source (lse_ck)"]
+    _modify:
+      USART*SEL,UART*SEL:
+        derivedFrom: RCC.CCIPR1.USART1SEL
   CCIPR3:
-    LPUART1SEL:
-      RCC_PCLK3: [0, "PCLK3 selected as clock source (rcc_pclk3)"]
-      PLL2_Q: [1, "PLL2 Q clock selected as clock source (pll2_q_ck)"]
-      PLL3_Q: [2, "PLL3 Q clock selected as clock source (pll3_q_ck)"]
-      HSI_KER: [3, "HSI kernel clock selected as clock source (hsi_ker_ck)"]
-      CSI_KER: [4, "CSI kernel clock selected as clock source (csi_ker_ck)"]
-      LSE: [5, "LSE selected as clock source (lse_ck)"]
-    SPI6SEL:
-      RCC_PCLK2: [0, "PCLK2 selected as clock source (rcc_pclk2)"]
+    _modify:
+      LPUART*SEL:
+        derivedFrom: RCC.CCIPR1.USART1SEL
+    SPI[456]SEL:
+      _name: SPI456SEL
+      PCLK: [0, "Peripheral bus clock used as selected as clock source (rcc_pclk_x)"]
       PLL2_Q: [1, "PLL2 Q clock selected as clock source (pll2_p_ck)"]
       PLL3_Q: [2, "PLL3 Q clock selected as clock source (pll3_p_ck)"]
       HSI_KER: [3, "HSI kernel clock selected as clock source (hsi_ker_ck)"]
       CSI_KER: [4, "CSI kernel clock selected as clock source (csi_ker_ck)"]
       HSE: [5, "HSE clock selected as clock source (hse_ck)"]
-    SPI5SEL:
-      RCC_PCLK3: [0, "PCLK3 selected as clock source (rcc_pclk3)"]
-      PLL2_Q: [1, "PLL2 Q clock selected as clock source (pll2_p_ck)"]
-      PLL3_Q: [2, "PLL3 Q clock selected as clock source (pll3_p_ck)"]
-      HSI_KER: [3, "HSI kernel clock selected as clock source (hsi_ker_ck)"]
-      CSI_KER: [4, "CSI kernel clock selected as clock source (csi_ker_ck)"]
-      HSE: [5, "HSE clock selected as clock source (hse_ck)"]
-    SPI4SEL:
-      RCC_PCLK2: [0, "PCLK2 selected as clock source (rcc_pclk2)"]
-      PLL2_Q: [1, "PLL2 Q clock selected as clock source (pll2_p_ck)"]
-      PLL3_Q: [2, "PLL3 Q clock selected as clock source (pll3_p_ck)"]
-      HSI_KER: [3, "HSI kernel clock selected as clock source (hsi_ker_ck)"]
-      CSI_KER: [4, "CSI kernel clock selected as clock source (csi_ker_ck)"]
-      HSE: [5, "HSE clock selected as clock source (hse_ck)"]
-    SPI3SEL:
-      PLL1_Q: [0, "PLL1 Q clock selected as clock source (pll1_q_ck)"]
-      PLL2_P: [1, "PLL2 P clock selected as clock source (pll2_p_ck)"]
-      PLL3_P: [2, "PLL3 P clock selected as clock source (pll3_p_ck)"]
-      AUDIOCLK: [3, "AUDIOCLK clock selected as clock source"]
-      PER_CK: [4, "per_ck clock selected as clock source"]
-    SPI2SEL:
-      PLL1_Q: [0, "PLL1 Q clock selected as clock source (pll1_q_ck)"]
-      PLL2_P: [1, "PLL2 P clock selected as clock source (pll2_p_ck)"]
-      PLL3_P: [2, "PLL3 P clock selected as clock source (pll3_p_ck)"]
-      AUDIOCLK: [3, "AUDIOCLK clock selected as clock source"]
-      PER_CK: [4, "per_ck clock selected as clock source"]
-    SPI1SEL:
+    SPI[123]SEL:
+      _name: SPI123SEL
       PLL1_Q: [0, "PLL1 Q clock selected as clock source (pll1_q_ck)"]
       PLL2_P: [1, "PLL2 P clock selected as clock source (pll2_p_ck)"]
       PLL3_P: [2, "PLL3 P clock selected as clock source (pll3_p_ck)"]
       AUDIOCLK: [3, "AUDIOCLK clock selected as clock source"]
       PER_CK: [4, "per_ck clock selected as clock source"]
   CCIPR4:
-    I3C2SEL:
-      RCC_PCLK1: [0, "PCLK1 selected as clock source (rcc_pclk1)"]
+    I3C*SEL:
+      _name: I3CSEL
+      PCLK: [0, "Peripheral bus clock used as selected as clock source (rcc_pclk_x)"]
       PLL3_R: [1, "PLL3 R clock selected as clock source (pll3_r_ck)"]
       HSI_KER: [2, "HSI kernel clock selected as clock source (hsi_ker_ck)"]
-    I3C1SEL:
-      RCC_PCLK1: [0, "PCLK1 selected as clock source (rcc_pclk1)"]
-      PLL3_R: [1, "PLL3 R clock selected as clock source (pll3_r_ck)"]
-      HSI_KER: [2, "HSI kernel clock selected as clock source (hsi_ker_ck)"]
-    I2C4SEL:
-      RCC_PCLK3: [0, "PCLK3 selected as clock source (rcc_pclk3)"]
+    I2C*SEL:
+      _name: I2CSEL
+      PCLK: [0, "Peripheral bus clock used as selected as clock source (rcc_pclk_x)"]
       PLL3_R: [1, "PLL3 R Clock selected as clock source (pll3_r_ck)"]
       HSI_KER: [2, "HSI kernel clock selected as clock source (hsi_ker_ck)"]
       CSI_KER: [3, "CSI kernel clock selected as clock source (csi_ker_ck)"]
-    I2C3SEL:
-      RCC_PCLK3: [0, "PCLK3 selected as clock source (rcc_pclk3)"]
-      PLL3_R: [1, "PLL3 R Clock selected as clock source (pll3_r_ck)"]
-      HSI_KER: [2, "HSI kernel clock selected as clock source (hsi_ker_ck)"]
-      CSI_KER: [3, "CSI kernel clock selected as clock source (csi_ker_ck)"]
-    I2C2SEL:
-      RCC_PCLK1: [0, "PCLK1 selected as clock source (rcc_pclk1)"]
-      PLL3_R: [1, "PLL3 R Clock selected as clock source (pll3_r_ck)"]
-      HSI_KER: [2, "HSI kernel clock selected as clock source (hsi_ker_ck)"]
-      CSI_KER: [3, "CSI kernel clock selected as clock source (csi_ker_ck)"]
-    I2C1SEL:
-      RCC_PCLK1: [0, "PCLK1 selected as clock source (rcc_pclk1)"]
-      PLL3_R: [1, "PLL3 R Clock selected as clock source (pll3_r_ck)"]
-      HSI_KER: [2, "HSI kernel clock selected as clock source (hsi_ker_ck)"]
-      CSI_KER: [3, "CSI kernel clock selected as clock source (csi_ker_ck)"]
-    SDMMC1SEL:
+    SDMMC*SEL:
+      _name: SDMMCSEL
       PLL1_Q: [0, "PLL1 Q clock selected as clock source (pll1_q_ck)"]
       PLL2_R: [1, "PLL2 R clock selected as clock source (pll2_r_ck)"]
-    USBSEL:
-      DISABLE: [0, "Disable the clock"]
-      PLL1_Q: [1, "PLL1 Q clock selected as clock source (pll1_q_ck)"]
-      PLL2_Q: [2, "PLL2 Q clock selected as clock source (pll2_q_ck)"]
-      HSI48: [3, "HSI48 clock selected as clock source (hsi48_ker_ck)"]
-    SYSTICKSEL:
-      HCLK_DIV8: [0, "RCC HLCK divided by 8 selected as clock source (rcc_hclk / 8)"]
-      LSI_KER: [1, "LSI kernel selected as clock source (lsi_ker_ck)"]
-      LSE: [2, "LSE selected as clock source (lse_ck)"]
     OCTOSPI1SEL:
       RCC_HCLK4: [0, "HCLK4 selected as clock source (rcc_hclk4)"]
       PLL1_Q: [1, "PLL1 Q clock selected as clock source (pll1_q_ck)"]
       PLL2_R: [2, "PLL2 R clock selected as clock source (pll2_r_ck)"]
       PER_CK: [3, "per_ck clock selected as clock source"]
   CCIPR5:
-    SAI2SEL:
-      PLL1_Q: [0, "PLL1 Q clock selected as clock source (pll1_q_ck)"]
-      PLL2_P: [1, "PLL2 P clock selected as clock source (pll2_p_ck)"]
-      PLL3_P: [2, "PLL3 P clock selected as clock source (pll3_p_ck)"]
-      AUDIOCLK: [3, "AUDIOCLK clock selected as clock source"]
-      PER_CK: [4, "per_ck clock selected as clock source"]
-    SAI1SEL:
+    SAI*SEL:
+      _name: SAISEL
       PLL1_Q: [0, "PLL1 Q clock selected as clock source (pll1_q_ck)"]
       PLL2_P: [1, "PLL2 P clock selected as clock source (pll2_p_ck)"]
       PLL3_P: [2, "PLL3 P clock selected as clock source (pll3_p_ck)"]

--- a/peripherals/rcc/rcc_h56x_h57x.yaml
+++ b/peripherals/rcc/rcc_h56x_h57x.yaml
@@ -1,0 +1,256 @@
+_include:
+  - ./rcc_h5.yaml
+
+RCC:
+  CCIPR1:
+    TIMICSEL:
+      Disabled: [0, "No internal clock available for timers input capture"]
+      Enabled: [1, "hsi_ker_ck/1024, hsi_ker_ck/8 and csi_ker_ck/128 selected for timers input capture"]
+    USART10SEL:
+      RCC_PCLK1: [0, "PCLK1 selected as clock source (rcc_pclk1)"]
+      PLL2_Q: [1, "PLL2 Q clock selected as clock source (pll2_q_ck)"]
+      PLL3_Q: [2, "PLL3 Q clock selected as clock source (pll3_q_ck)"]
+      HSI_KER: [3, "HSI kernel clock selected as clock source (hsi_ker_ck)"]
+      CSI_KER: [4, "CSI kernel clock selected as clock source (csi_ker_ck)"]
+      LSE: [5, "LSE clock selected as clock source (lse_ck)"]
+    UART9SEL:
+      RCC_PCLK1: [0, "PCLK1 selected as clock source (rcc_pclk1)"]
+      PLL2_Q: [1, "PLL2 Q clock selected as clock source (pll2_q_ck)"]
+      PLL3_Q: [2, "PLL3 Q clock selected as clock source (pll3_q_ck)"]
+      HSI_KER: [3, "HSI kernel clock selected as clock source (hsi_ker_ck)"]
+      CSI_KER: [4, "CSI kernel clock selected as clock source (csi_ker_ck)"]
+      LSE: [5, "LSE clock selected as clock source (lse_ck)"]
+    UART8SEL:
+      RCC_PCLK1: [0, "PCLK1 selected as clock source (rcc_pclk1)"]
+      PLL2_Q: [1, "PLL2 Q clock selected as clock source (pll2_q_ck)"]
+      PLL3_Q: [2, "PLL3 Q clock selected as clock source (pll3_q_ck)"]
+      HSI_KER: [3, "HSI kernel clock selected as clock source (hsi_ker_ck)"]
+      CSI_KER: [4, "CSI kernel clock selected as clock source (csi_ker_ck)"]
+      LSE: [5, "LSE clock selected as clock source (lse_ck)"]
+    UART7SEL:
+      RCC_PCLK2: [0, "PCLK2 selected as clock source (rcc_pclk2)"]
+      PLL2_Q: [1, "PLL2 Q clock selected as clock source (pll2_q_ck)"]
+      PLL3_Q: [2, "PLL3 Q clock selected as clock source (pll3_q_ck)"]
+      HSI_KER: [3, "HSI kernel clock selected as clock source (hsi_ker_ck)"]
+      CSI_KER: [4, "CSI kernel clock selected as clock source (csi_ker_ck)"]
+      LSE: [5, "LSE clock selected as clock source (lse_ck)"]
+    USART6SEL:
+      RCC_PCLK1: [0, "PCLK1 selected as clock source (rcc_pclk1)"]
+      PLL2_Q: [1, "PLL2 Q clock selected as clock source (pll2_q_ck)"]
+      PLL3_Q: [2, "PLL3 Q clock selected as clock source (pll3_q_ck)"]
+      HSI_KER: [3, "HSI kernel clock selected as clock source (hsi_ker_ck)"]
+      CSI_KER: [4, "CSI kernel clock selected as clock source (csi_ker_ck)"]
+      LSE: [5, "LSE clock selected as clock source (lse_ck)"]
+    UART5SEL:
+      RCC_PCLK1: [0, "PCLK1 selected as clock source (rcc_pclk1)"]
+      PLL2_Q: [1, "PLL2 Q clock selected as clock source (pll2_q_ck)"]
+      PLL3_Q: [2, "PLL3 Q clock selected as clock source (pll3_q_ck)"]
+      HSI_KER: [3, "HSI kernel clock selected as clock source (hsi_ker_ck)"]
+      CSI_KER: [4, "CSI kernel clock selected as clock source (csi_ker_ck)"]
+      LSE: [5, "LSE clock selected as clock source (lse_ck)"]
+    UART4SEL:
+      RCC_PCLK2: [0, "PCLK2 selected as clock source (rcc_pclk2)"]
+      PLL2_Q: [1, "PLL2 Q clock selected as clock source (pll2_q_ck)"]
+      PLL3_Q: [2, "PLL3 Q clock selected as clock source (pll3_q_ck)"]
+      HSI_KER: [3, "HSI kernel clock selected as clock source (hsi_ker_ck)"]
+      CSI_KER: [4, "CSI kernel clock selected as clock source (csi_ker_ck)"]
+      LSE: [5, "LSE clock selected as clock source (lse_ck)"]
+    USART3SEL:
+      RCC_PCLK1: [0, "PCLK1 selected as clock source (rcc_pclk1)"]
+      PLL2_Q: [1, "PLL2 Q clock selected as clock source (pll2_q_ck)"]
+      PLL3_Q: [2, "PLL3 Q clock selected as clock source (pll3_q_ck)"]
+      HSI_KER: [3, "HSI kernel clock selected as clock source (hsi_ker_ck)"]
+      CSI_KER: [4, "CSI kernel clock selected as clock source (csi_ker_ck)"]
+      LSE: [5, "LSE clock selected as clock source (lse_ck)"]
+    USART2SEL:
+      RCC_PCLK1: [0, "PCLK1 selected as clock source (rcc_pclk1)"]
+      PLL2_Q: [1, "PLL2 Q clock selected as clock source (pll2_q_ck)"]
+      PLL3_Q: [2, "PLL3 Q clock selected as clock source (pll3_q_ck)"]
+      HSI_KER: [3, "HSI kernel clock selected as clock source (hsi_ker_ck)"]
+      CSI_KER: [4, "CSI kernel clock selected as clock source (csi_ker_ck)"]
+      LSE: [5, "LSE clock selected as clock source (lse_ck)"]
+    USART1SEL:
+      RCC_PCLK2: [0, "PCLK2 selected as clock source (rcc_pclk2)"]
+      PLL2_Q: [1, "PLL2 Q clock selected as clock source (pll2_q_ck)"]
+      PLL3_Q: [2, "PLL3 Q clock selected as clock source (pll3_q_ck)"]
+      HSI_KER: [3, "HSI kernel clock selected as clock source (hsi_ker_ck)"]
+      CSI_KER: [4, "CSI kernel clock selected as clock source (csi_ker_ck)"]
+      LSE: [5, "LSE clock selected as clock source (lse_ck)"]
+  CCIPR2:
+    LPTIM6SEL:
+      RCC_PCLK3: [0, "PCLK3 selected as clock source (rcc_pclk3)"]
+      PLL2_P: [1, "PLL2 P clock selected as clock source (pll2_p_ck)"]
+      PLL3_R: [2, "PLL3 R clock selected as clock source (pll3_r_ck)"]
+      LSE_KER: [3, "LSE kernel selected as clock source (lse_ck)"]
+      LSI_KER: [4, "LSI kernel selected as clock source (lsi_ker_ck)"]
+      PER_CK: [5, "per_ck clock selected as clock source"]
+    LPTIM5SEL:
+      RCC_PCLK3: [0, "PCLK3 selected as clock source (rcc_pclk3)"]
+      PLL2_P: [1, "PLL2 P clock selected as clock source (pll2_p_ck)"]
+      PLL3_R: [2, "PLL3 R clock selected as clock source (pll3_r_ck)"]
+      LSE_KER: [3, "LSE kernel selected as clock source (lse_ck)"]
+      LSI_KER: [4, "LSI kernel selected as clock source (lsi_ker_ck)"]
+      PER_CK: [5, "per_ck clock selected as clock source"]
+    LPTIM4SEL:
+      RCC_PCLK3: [0, "PCLK3 selected as clock source (rcc_pclk3)"]
+      PLL2_P: [1, "PLL2 P clock selected as clock source (pll2_p_ck)"]
+      PLL3_R: [2, "PLL3 R clock selected as clock source (pll3_r_ck)"]
+      LSE_KER: [3, "LSE kernel selected as clock source (lse_ck)"]
+      LSI_KER: [4, "LSI kernel selected as clock source (lsi_ker_ck)"]
+      PER_CK: [5, "per_ck clock selected as clock source"]
+    LPTIM3SEL:
+      RCC_PCLK3: [0, "PCLK3 selected as clock source (rcc_pclk3)"]
+      PLL2_P: [1, "PLL2 P clock selected as clock source (pll2_p_ck)"]
+      PLL3_R: [2, "PLL3 R clock selected as clock source (pll3_r_ck)"]
+      LSE_KER: [3, "LSE kernel selected as clock source (lse_ck)"]
+      LSI_KER: [4, "LSI kernel selected as clock source (lsi_ker_ck)"]
+      PER_CK: [5, "per_ck clock selected as clock source"]
+    LPTIM2SEL:
+      RCC_PCLK1: [0, "PCLK1 selected as clock source (rcc_pclk1)"]
+      PLL2_P: [1, "PLL2 P clock selected as clock source (pll2_p_ck)"]
+      PLL3_R: [2, "PLL3 R clock selected as clock source (pll3_r_ck)"]
+      LSE_KER: [3, "LSE kernel selected as clock source (lse_ck)"]
+      LSI_KER: [4, "LSI kernel selected as clock source (lsi_ker_ck)"]
+      PER_CK: [5, "per_ck clock selected as clock source"]
+    LPTIM1SEL:
+      RCC_PCLK3: [0, "PCLK3 selected as clock source (rcc_pclk3)"]
+      PLL2_P: [1, "PLL2 P clock selected as clock source (pll2_p_ck)"]
+      PLL3_R: [2, "PLL3 R clock selected as clock source (pll3_r_ck)"]
+      LSE_KER: [3, "LSE kernel selected as clock source (lse_ck)"]
+      LSI_KER: [4, "LSI kernel selected as clock source (lsi_ker_ck)"]
+      PER_CK: [5, "per_ck clock selected as clock source"]
+    UART12SEL:
+      RCC_PCLK1: [0, "PCLK1 selected as clock source (rcc_pclk1)"]
+      PLL2_Q: [1, "PLL2 Q clock selected as clock source (pll2_q_ck)"]
+      PLL3_Q: [2, "PLL3 Q clock selected as clock source (pll3_q_ck)"]
+      HSI_KER: [3, "HSI kernel clock selected as clock source (hsi_ker_ck)"]
+      CSI_KER: [4, "CSI kernel clock selected as clock source (csi_ker_ck)"]
+      LSE: [5, "LSE clock selected as clock source (lse_ck)"]
+    USART11SEL:
+      RCC_PCLK1: [0, "PCLK1 selected as clock source (rcc_pclk1)"]
+      PLL2_Q: [1, "PLL2 Q clock selected as clock source (pll2_q_ck)"]
+      PLL3_Q: [2, "PLL3 Q clock selected as clock source (pll3_q_ck)"]
+      HSI_KER: [3, "HSI kernel clock selected as clock source (hsi_ker_ck)"]
+      CSI_KER: [4, "CSI kernel clock selected as clock source (csi_ker_ck)"]
+      LSE: [5, "LSE clock selected as clock source (lse_ck)"]
+  CCIPR3:
+    LPUART1SEL:
+      RCC_PCLK3: [0, "PCLK3 selected as clock source (rcc_pclk3)"]
+      PLL2_Q: [1, "PLL2 Q clock selected as clock source (pll2_q_ck)"]
+      PLL3_Q: [2, "PLL3 Q clock selected as clock source (pll3_q_ck)"]
+      HSI_KER: [3, "HSI kernel clock selected as clock source (hsi_ker_ck)"]
+      CSI_KER: [4, "CSI kernel clock selected as clock source (csi_ker_ck)"]
+      LSE: [5, "LSE selected as clock source (lse_ck)"]
+    SPI6SEL:
+      RCC_PCLK2: [0, "PCLK2 selected as clock source (rcc_pclk2)"]
+      PLL2_Q: [1, "PLL2 Q clock selected as clock source (pll2_p_ck)"]
+      PLL3_Q: [2, "PLL3 Q clock selected as clock source (pll3_p_ck)"]
+      HSI_KER: [3, "HSI kernel clock selected as clock source (hsi_ker_ck)"]
+      CSI_KER: [4, "CSI kernel clock selected as clock source (csi_ker_ck)"]
+      HSE: [5, "HSE clock selected as clock source (hse_ck)"]
+    SPI5SEL:
+      RCC_PCLK3: [0, "PCLK3 selected as clock source (rcc_pclk3)"]
+      PLL2_Q: [1, "PLL2 Q clock selected as clock source (pll2_p_ck)"]
+      PLL3_Q: [2, "PLL3 Q clock selected as clock source (pll3_p_ck)"]
+      HSI_KER: [3, "HSI kernel clock selected as clock source (hsi_ker_ck)"]
+      CSI_KER: [4, "CSI kernel clock selected as clock source (csi_ker_ck)"]
+      HSE: [5, "HSE clock selected as clock source (hse_ck)"]
+    SPI4SEL:
+      RCC_PCLK2: [0, "PCLK2 selected as clock source (rcc_pclk2)"]
+      PLL2_Q: [1, "PLL2 Q clock selected as clock source (pll2_p_ck)"]
+      PLL3_Q: [2, "PLL3 Q clock selected as clock source (pll3_p_ck)"]
+      HSI_KER: [3, "HSI kernel clock selected as clock source (hsi_ker_ck)"]
+      CSI_KER: [4, "CSI kernel clock selected as clock source (csi_ker_ck)"]
+      HSE: [5, "HSE clock selected as clock source (hse_ck)"]
+    SPI3SEL:
+      PLL1_Q: [0, "PLL1 Q clock selected as clock source (pll1_q_ck)"]
+      PLL2_P: [1, "PLL2 P clock selected as clock source (pll2_p_ck)"]
+      PLL3_P: [2, "PLL3 P clock selected as clock source (pll3_p_ck)"]
+      AUDIOCLK: [3, "AUDIOCLK clock selected as clock source"]
+      PER_CK: [4, "per_ck clock selected as clock source"]
+    SPI2SEL:
+      PLL1_Q: [0, "PLL1 Q clock selected as clock source (pll1_q_ck)"]
+      PLL2_P: [1, "PLL2 P clock selected as clock source (pll2_p_ck)"]
+      PLL3_P: [2, "PLL3 P clock selected as clock source (pll3_p_ck)"]
+      AUDIOCLK: [3, "AUDIOCLK clock selected as clock source"]
+      PER_CK: [4, "per_ck clock selected as clock source"]
+    SPI1SEL:
+      PLL1_Q: [0, "PLL1 Q clock selected as clock source (pll1_q_ck)"]
+      PLL2_P: [1, "PLL2 P clock selected as clock source (pll2_p_ck)"]
+      PLL3_P: [2, "PLL3 P clock selected as clock source (pll3_p_ck)"]
+      AUDIOCLK: [3, "AUDIOCLK clock selected as clock source"]
+      PER_CK: [4, "per_ck clock selected as clock source"]
+  CCIPR4:
+    I3C2SEL:
+      RCC_PCLK1: [0, "PCLK1 selected as clock source (rcc_pclk1)"]
+      PLL3_R: [1, "PLL3 R clock selected as clock source (pll3_r_ck)"]
+      HSI_KER: [2, "HSI kernel clock selected as clock source (hsi_ker_ck)"]
+    I3C1SEL:
+      RCC_PCLK1: [0, "PCLK1 selected as clock source (rcc_pclk1)"]
+      PLL3_R: [1, "PLL3 R clock selected as clock source (pll3_r_ck)"]
+      HSI_KER: [2, "HSI kernel clock selected as clock source (hsi_ker_ck)"]
+    I2C4SEL:
+      RCC_PCLK3: [0, "PCLK3 selected as clock source (rcc_pclk3)"]
+      PLL3_R: [1, "PLL3 R Clock selected as clock source (pll3_r_ck)"]
+      HSI_KER: [2, "HSI kernel clock selected as clock source (hsi_ker_ck)"]
+      CSI_KER: [3, "CSI kernel clock selected as clock source (csi_ker_ck)"]
+    I2C3SEL:
+      RCC_PCLK3: [0, "PCLK3 selected as clock source (rcc_pclk3)"]
+      PLL3_R: [1, "PLL3 R Clock selected as clock source (pll3_r_ck)"]
+      HSI_KER: [2, "HSI kernel clock selected as clock source (hsi_ker_ck)"]
+      CSI_KER: [3, "CSI kernel clock selected as clock source (csi_ker_ck)"]
+    I2C2SEL:
+      RCC_PCLK1: [0, "PCLK1 selected as clock source (rcc_pclk1)"]
+      PLL3_R: [1, "PLL3 R Clock selected as clock source (pll3_r_ck)"]
+      HSI_KER: [2, "HSI kernel clock selected as clock source (hsi_ker_ck)"]
+      CSI_KER: [3, "CSI kernel clock selected as clock source (csi_ker_ck)"]
+    I2C1SEL:
+      RCC_PCLK1: [0, "PCLK1 selected as clock source (rcc_pclk1)"]
+      PLL3_R: [1, "PLL3 R Clock selected as clock source (pll3_r_ck)"]
+      HSI_KER: [2, "HSI kernel clock selected as clock source (hsi_ker_ck)"]
+      CSI_KER: [3, "CSI kernel clock selected as clock source (csi_ker_ck)"]
+    SDMMC1SEL:
+      PLL1_Q: [0, "PLL1 Q clock selected as clock source (pll1_q_ck)"]
+      PLL2_R: [1, "PLL2 R clock selected as clock source (pll2_r_ck)"]
+    USBSEL:
+      DISABLE: [0, "Disable the clock"]
+      PLL1_Q: [1, "PLL1 Q clock selected as clock source (pll1_q_ck)"]
+      PLL2_Q: [2, "PLL2 Q clock selected as clock source (pll2_q_ck)"]
+      HSI48: [3, "HSI48 clock selected as clock source (hsi48_ker_ck)"]
+    SYSTICKSEL:
+      HCLK_DIV8: [0, "RCC HLCK divided by 8 selected as clock source (rcc_hclk / 8)"]
+      LSI_KER: [1, "LSI kernel selected as clock source (lsi_ker_ck)"]
+      LSE: [2, "LSE selected as clock source (lse_ck)"]
+    OCTOSPI1SEL:
+      RCC_HCLK4: [0, "HCLK4 selected as clock source (rcc_hclk4)"]
+      PLL1_Q: [1, "PLL1 Q clock selected as clock source (pll1_q_ck)"]
+      PLL2_R: [2, "PLL2 R clock selected as clock source (pll2_r_ck)"]
+      PER_CK: [3, "per_ck clock selected as clock source"]
+  CCIPR5:
+    SAI2SEL:
+      PLL1_Q: [0, "PLL1 Q clock selected as clock source (pll1_q_ck)"]
+      PLL2_P: [1, "PLL2 P clock selected as clock source (pll2_p_ck)"]
+      PLL3_P: [2, "PLL3 P clock selected as clock source (pll3_p_ck)"]
+      AUDIOCLK: [3, "AUDIOCLK clock selected as clock source"]
+      PER_CK: [4, "per_ck clock selected as clock source"]
+    SAI1SEL:
+      PLL1_Q: [0, "PLL1 Q clock selected as clock source (pll1_q_ck)"]
+      PLL2_P: [1, "PLL2 P clock selected as clock source (pll2_p_ck)"]
+      PLL3_P: [2, "PLL3 P clock selected as clock source (pll3_p_ck)"]
+      AUDIOCLK: [3, "AUDIOCLK clock selected as clock source"]
+      PER_CK: [4, "per_ck clock selected as clock source"]
+    CECSEL:
+      LSE: [0, "LSE selected as clock source (lse_ck)"]
+      LSI_KER: [1, "LSI kernel selected as clock source (lsi_ker_ck)"]
+      CSI_KER: [2, "CSI kernel clock divided by 122 selected as clock source (csi_ker_ck/122)"]
+    DACSEL:
+      LSE: [0, "LSE selected as clock source (lse_ck)"]
+      LSI_KER: [1, "LSI kernel selected as clock source (lsi_ker_ck)"]
+  SECCFGR:
+    "*SEC":
+      NonSecure: [0, "Non secure"]
+      Secure: [1, "Secure"]
+  PRIVCFGR:
+    "*PRIV":
+      Any: [0, "RCC functions can be modified by privileged or unprivileged access"]
+      PrivilegedOnly: [1, "RCC functions can only be modified by privileged access"]


### PR DESCRIPTION
This adds RCC register patches and field definitions for all processors covered by RM0481 (this includes H523/533 processors, but these haven't yet been added as products, yet).