### PR TITLE
Make TIM4 16-bit on stm32g0b1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@
 * G471: Add OPAMP6
 * G0: fix typo in HSIDIV (Div3 -> Div4)
 * C071: Update svd zip to v1.2, add c071 and cleanup c0xx
+* G0B1: make TIM4 16-bit timer
 
 Family-specific:
 

--- a/devices/stm32g0b1.yaml
+++ b/devices/stm32g0b1.yaml
@@ -10,6 +10,9 @@ _copy:
     from: TIM2
     baseAddress: 0x40000400
 
+_derive:
+  TIM4: TIM3
+
 "FDCAN?":
   _strip: "FDCAN_"
 


### PR DESCRIPTION
Currently it is incorrectly implemented as 32-bit timer.