### PR TITLE
Update field definitions in USB ISTR, USB CHEPR and EXTICR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,7 @@
 * doc on `SYSCFG` peripheral for STM32F4 ([#852])
 * LCD: fix and unify RAM registers
 * G0: mark interrupt flags in USB ISTR as W0C
+* G0: add value enums for EXTICR[2-4]
 
 Family-specific:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,7 @@
 * G0: describe USB CHEP?R register
 * doc on `SYSCFG` peripheral for STM32F4 ([#852])
 * LCD: fix and unify RAM registers
+* G0: mark interrupt flags in USB ISTR as W0C
 
 Family-specific:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,7 @@
 * doc on `SYSCFG` peripheral for STM32F4 ([#852])
 * LCD: fix and unify RAM registers
 * G0: mark interrupt flags in USB ISTR as W0C
+* G0: mark flags in USB CHEPR as W0C/W1T
 * G0: add value enums for EXTICR[2-4]
 
 Family-specific:

--- a/devices/fields/afio/derive.yaml
+++ b/devices/fields/afio/derive.yaml
@@ -5,4 +5,4 @@ EXTICR1:
 EXTICR[2-4]:
   _modify:
     "EXTI?,EXTI1?":
-      derivedFrom: EXTI.EXTICR1.EXTI0
+      derivedFrom: AFIO.EXTICR1.EXTI0

--- a/devices/fields/exti/exti_g0.yaml
+++ b/devices/fields/exti/exti_g0.yaml
@@ -3,7 +3,7 @@ _include:
   - derive.yaml
 
 EXTICR1:
-  "EXTI*":
+  EXTI0:
     PA: [0, "Select PAx as the source input for the EXTIx external interrupt"]
     PB: [1, "Select PBx as the source input for the EXTIx external interrupt"]
     PC: [2, "Select PCx as the source input for the EXTIx external interrupt"]

--- a/devices/fields/syscfg/derive.yaml
+++ b/devices/fields/syscfg/derive.yaml
@@ -5,4 +5,4 @@ EXTICR1:
 EXTICR[2-4]:
   _modify:
     "EXTI?,EXTI1?":
-      derivedFrom: EXTI.EXTICR1.EXTI0
+      derivedFrom: SYSCFG.EXTICR1.EXTI0

--- a/devices/fields/syscfg/f4/syscfg_f401_f411.yaml
+++ b/devices/fields/syscfg/f4/syscfg_f401_f411.yaml
@@ -1,5 +1,5 @@
 _include:
-  - ../../exti/derive.yaml
+  - ../derive.yaml
   - cmpcr.yaml
 
 MEMRMP:

--- a/devices/fields/syscfg/f4/syscfg_f405.yaml
+++ b/devices/fields/syscfg/f4/syscfg_f405.yaml
@@ -1,5 +1,5 @@
 _include:
-  - ../../exti/derive.yaml
+  - ../derive.yaml
   - cmpcr.yaml
 
 MEMRMP:

--- a/devices/fields/syscfg/f4/syscfg_f410.yaml
+++ b/devices/fields/syscfg/f4/syscfg_f410.yaml
@@ -1,5 +1,5 @@
 _include:
-  - ../../exti/derive.yaml
+  - ../derive.yaml
   - cmpcr.yaml
 
 MEMRMP:

--- a/devices/fields/syscfg/f4/syscfg_f412.yaml
+++ b/devices/fields/syscfg/f4/syscfg_f412.yaml
@@ -1,5 +1,5 @@
 _include:
-  - ../../exti/derive.yaml
+  - ../derive.yaml
   - cmpcr.yaml
 
 MEMRMP:

--- a/devices/fields/syscfg/f4/syscfg_f413_f423.yaml
+++ b/devices/fields/syscfg/f4/syscfg_f413_f423.yaml
@@ -1,5 +1,5 @@
 _include:
-  - ../../exti/derive.yaml
+  - ../derive.yaml
   - cmpcr.yaml
 
 MEMRMP:

--- a/devices/fields/syscfg/f4/syscfg_f415_f407_f417.yaml
+++ b/devices/fields/syscfg/f4/syscfg_f415_f407_f417.yaml
@@ -1,5 +1,5 @@
 _include:
-  - ../../exti/derive.yaml
+  - ../derive.yaml
   - cmpcr.yaml
 
 MEMRMP:

--- a/devices/fields/syscfg/f4/syscfg_f427_f437_f429_f439.yaml
+++ b/devices/fields/syscfg/f4/syscfg_f427_f437_f429_f439.yaml
@@ -1,5 +1,5 @@
 _include:
-  - ../../exti/derive.yaml
+  - ../derive.yaml
   - cmpcr.yaml
 
 MEMRMP:

--- a/devices/fields/syscfg/f4/syscfg_f446.yaml
+++ b/devices/fields/syscfg/f4/syscfg_f446.yaml
@@ -1,5 +1,5 @@
 _include:
-  - ../../exti/derive.yaml
+  - ../derive.yaml
   - cmpcr.yaml
 
 MEMRMP:

--- a/devices/fields/syscfg/f4/syscfg_f469_f479.yaml
+++ b/devices/fields/syscfg/f4/syscfg_f469_f479.yaml
@@ -1,5 +1,5 @@
 _include:
-  - ../../exti/derive.yaml
+  - ../derive.yaml
   - cmpcr.yaml
 
 MEMRMP:

--- a/devices/fields/syscfg/syscfg_f0x128.yaml
+++ b/devices/fields/syscfg/syscfg_f0x128.yaml
@@ -1,6 +1,6 @@
 _include:
   - ./syscfg_f0.yaml
-  - ../exti/derive.yaml
+  - derive.yaml
 
 CFGR1:
   IR_MOD:

--- a/devices/fields/usb/g0_usb.yaml
+++ b/devices/fields/usb/g0_usb.yaml
@@ -29,11 +29,73 @@ USB:
         Stall: [1, "Device mode: the endpoint is stalled and all reception requests result in a STALL handshake.\nHost mode: this indicates that the device has STALLed the channel."]
         Nak: [2, "Device mode: the endpoint is NAKed and all reception requests result in a NAK handshake.\nHost mode: this indicates that the device has NAKed the reception request."]
         Valid: [3, "This endpoint/channel is enabled for reception."]
-      _W1T: {}
+      _W1T:
+        Keep: [0, "Do not change bits"]
     STATTX:
       _read:
         Disabled: [0, "All transmission requests addressed to this endpoint/channel are ignored."]
         Stall: [1, "Device mode: the endpoint is stalled and all transmission requests result in a STALL handshake.\nHost mode: this indicates that the device has STALLed the channel."]
         Nak: [2, "Device mode: the endpoint is NAKed and all transmission requests result in a NAK handshake.\nHost mode: this indicates that the device has NAKed the transmission request."]
         Valid: [3, "This endpoint/channel is enabled for transmission."]
-      _W1T: {}
+      _W1T:
+        Keep: [0, "Do not change bits"]
+  ISTR:
+    THR512:
+      _read:
+        NotReached: [0, "512 bytes threshold not reached"]
+        Reached: [1, "512 bytes have been transmitted or received during isochronous transfers"]
+      _W0C:
+        Clear: [0, "Clear flag"]
+    CTR:
+      Completed: [1, "Endpoint has successfully completed a transaction"]
+    PMAOVR:
+      _read:
+        NotOverrun: [0, "Overrun is not occurred"]
+        Overrun: [1, "Microcontroller has not been able to respond in time to an USB memory request"]
+      _W0C:
+        Clear: [0, "Clear flag"]
+    ERR:
+      _read:
+        NotError: [0, "Errors are not occurred"]
+        Error: [1, "One of No ANSwer, Cyclic Redundancy Check, Bit Stuffing or Framing format Violation error occurred"]
+      _W0C:
+        Clear: [0, "Clear flag"]
+    WKUP:
+      _read:
+        NotWakeup: [0, "NotWakeup"]
+        Wakeup: [1, "Activity is detected that wakes up the USB peripheral"]
+      _W0C:
+        Clear: [0, "Clear flag"]
+    SUSP:
+      _read:
+        NotSuspend: [0, "NotSuspend"]
+        Suspend: [1, "No traffic has been received for 3 ms, indicating a suspend mode request from the USB bus"]
+      _W0C:
+        Clear: [0, "Clear flag"]
+    RST_DCON:
+      _read:
+        NotReset: [0, "NotReset"]
+        Reset: [1, "Peripheral detects an active USB RESET signal at its inputs"]
+      _W0C:
+        Clear: [0, "Clear flag"]
+    SOF:
+      _read:
+        NotStartOfFrame: [0, "NotStartOfFrame"]
+        StartOfFrame: [1, "A SOF packet arrived through the USB bus"]
+      _W0C:
+        Clear: [0, "Clear flag"]
+    ESOF:
+      _read:
+        NotExpectedStartOfFrame: [0, "NotExpectedStartOfFrame"]
+        ExpectedStartOfFrame: [1, "An SOF packet is expected but not received"]
+      _W0C:
+        Clear: [0, "Clear flag"]
+    L1REQ:
+      _read:
+        NotL1State: [0, "NotL1State"]
+        L1State: [1, "LPM command to enter the L1 state is successfully received and acknowledged"]
+      _W0C:
+        Clear: [0, "Clear flag"]
+    DIR:
+      To: [0, "Data transmitted by the USB peripheral to the host PC"]
+      From: [1, "Data received by the USB peripheral from the host PC"]

--- a/devices/fields/usb/g0_usb.yaml
+++ b/devices/fields/usb/g0_usb.yaml
@@ -18,6 +18,20 @@ USB:
     _modify:
       "STATRX,STATTX":
         access: read-write
+    STATTX:
+      _read:
+        Disabled: [0, "All transmission requests addressed to this endpoint/channel are ignored."]
+        Stall: [1, "Device mode: the endpoint is stalled and all transmission requests result in a STALL handshake.\nHost mode: this indicates that the device has STALLed the channel."]
+        Nak: [2, "Device mode: the endpoint is NAKed and all transmission requests result in a NAK handshake.\nHost mode: this indicates that the device has NAKed the transmission request."]
+        Valid: [3, "This endpoint/channel is enabled for transmission."]
+      _W1T:
+        Keep: [0, "Do not change bits"]
+    DTOGTX:
+      _W1T:
+        Toggle: [1, "Flip bit"]
+    VTTX:
+      _W0C:
+        Clear: [0, "Clear flag"]
     UTYPE:
         Bulk: [0, "Bulk endpoint"]
         Control: [1, "Control endpoint"]
@@ -31,14 +45,21 @@ USB:
         Valid: [3, "This endpoint/channel is enabled for reception."]
       _W1T:
         Keep: [0, "Do not change bits"]
-    STATTX:
-      _read:
-        Disabled: [0, "All transmission requests addressed to this endpoint/channel are ignored."]
-        Stall: [1, "Device mode: the endpoint is stalled and all transmission requests result in a STALL handshake.\nHost mode: this indicates that the device has STALLed the channel."]
-        Nak: [2, "Device mode: the endpoint is NAKed and all transmission requests result in a NAK handshake.\nHost mode: this indicates that the device has NAKed the transmission request."]
-        Valid: [3, "This endpoint/channel is enabled for transmission."]
+    DTOGRX:
       _W1T:
-        Keep: [0, "Do not change bits"]
+        Toggle: [1, "Flip bit"]
+    VTRX:
+      _W0C:
+        Clear: [0, "Clear flag"]
+    NAK:
+      _W0C:
+        Clear: [0, "Clear flag"]
+    ERR_TX:
+      _W0C:
+        Clear: [0, "Clear flag"]
+    ERR_RX:
+      _W0C:
+        Clear: [0, "Clear flag"]
   ISTR:
     THR512:
       _read:

--- a/devices/stm32f0x0.yaml
+++ b/devices/stm32f0x0.yaml
@@ -42,7 +42,7 @@ SYSCFG:
   _include:
     - patches/syscfg/f0.yaml
     - fields/syscfg/syscfg_f0.yaml
-    - fields/exti/derive.yaml
+    - fields/syscfg/derive.yaml
 
   EXTICR1:
     EXTI0:

--- a/devices/stm32f100.yaml
+++ b/devices/stm32f100.yaml
@@ -5,7 +5,7 @@ _derive:
 
 AFIO:
   _include:
-    - fields/exti/derive.yaml
+    - fields/afio/derive.yaml
     - fields/exti/abcdefg.yaml
 
 EXTI:

--- a/devices/stm32f101.yaml
+++ b/devices/stm32f101.yaml
@@ -27,7 +27,7 @@ ADC[23]:
 
 AFIO:
   _include:
-    - fields/exti/derive.yaml
+    - fields/afio/derive.yaml
     - fields/exti/abcdefg.yaml
 
 EXTI:

--- a/devices/stm32f102.yaml
+++ b/devices/stm32f102.yaml
@@ -31,7 +31,7 @@ ADC1:
 
 AFIO:
   _include:
-    - fields/exti/derive.yaml
+    - fields/afio/derive.yaml
     - fields/exti/abcdefg.yaml
 
 EXTI:

--- a/devices/stm32f103.yaml
+++ b/devices/stm32f103.yaml
@@ -31,7 +31,7 @@ AFIO:
       CAN_REMAP:
         description: CAN remapping
   _include:
-    - fields/exti/derive.yaml
+    - fields/afio/derive.yaml
     - fields/exti/abcdefg.yaml
 
 DBGMCU:

--- a/devices/stm32f107.yaml
+++ b/devices/stm32f107.yaml
@@ -23,7 +23,7 @@ _modify:
 
 AFIO:
   _include:
-    - fields/exti/derive.yaml
+    - fields/afio/derive.yaml
     - fields/exti/abcdefg.yaml
 
 Ethernet_MAC:


### PR DESCRIPTION
Marking USB bits to avoid accidental flips.
EXTI only had human-readable enums in CR1 until this change.