### PR TITLE
H5: Cluster GPDMA channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,7 @@
 * G0: mark interrupt flags in USB ISTR as W0C
 * G0: mark flags in USB CHEPR as W0C/W1T
 * G0: add value enums for EXTICR[2-4]
+* H5: Add cluster definitions for H5 GPDMA channels
 
 Family-specific:
 

--- a/devices/collect/dma/h5_gpdma.yaml
+++ b/devices/collect/dma/h5_gpdma.yaml
@@ -1,0 +1,51 @@
+GPDMA*:
+  _cluster:
+    CH%s:
+      description: Channel cluster
+      "C[0-5]LBAR":
+        name: LBAR
+      "C[0-5]FCR":
+        name: FCR
+      "C[0-5]SR":
+        name: SR
+      "C[0-5]CR":
+        name: CR
+      "C[0-5]TR1":
+        name: TR1
+      "C[0-5]TR2":
+        name: TR2
+      "C[0-5]BR1":
+        name: BR1
+      "C[0-5]SAR":
+        name: SAR
+      "C[0-5]DAR":
+        name: DAR
+      "C[0-5]LLR":
+        name: LLR
+
+    CH2D%s:
+      description: 2D-addressing channel cluster
+      "C[6-7]LBAR":
+        name: LBAR
+      "C[6-7]FCR":
+        name: FCR
+      "C[6-7]SR":
+        name: SR
+      "C[6-7]CR":
+        name: CR
+      "C[6-7]TR1":
+        name: TR1
+      "C[6-7]TR2":
+        name: TR2
+      "C[6-7]BR1":
+        name: BR1
+      "C[6-7]SAR":
+        name: SAR
+      "C[6-7]DAR":
+        name: DAR
+      "C[6-7]TR3":
+        name: TR3
+      "C[6-7]BR2":
+        name: BR2
+      "C[6-7]LLR":
+        name: LLR

--- a/devices/stm32h503.yaml
+++ b/devices/stm32h503.yaml
@@ -133,3 +133,4 @@ _include:
   - fields/rcc/rcc_h503.yaml
   - collect/usb/chepr.yaml
   - collect/gpio/v2r.yaml
+  - collect/dma/h5_gpdma.yaml

--- a/devices/stm32h562.yaml
+++ b/devices/stm32h562.yaml
@@ -163,3 +163,4 @@ _include:
   - fields/gpdma/gpdma.yaml
   - collect/usb/chepr.yaml
   - collect/gpio/v2r.yaml
+  - collect/dma/h5_gpdma.yaml

--- a/devices/stm32h563.yaml
+++ b/devices/stm32h563.yaml
@@ -162,3 +162,4 @@ _include:
   - fields/gpdma/gpdma.yaml
   - collect/usb/chepr.yaml
   - collect/gpio/v2r.yaml
+  - collect/dma/h5_gpdma.yaml

--- a/devices/stm32h573.yaml
+++ b/devices/stm32h573.yaml
@@ -167,3 +167,4 @@ _include:
   - fields/gpdma/gpdma.yaml
   - collect/usb/chepr.yaml
   - collect/gpio/v2r.yaml
+  - collect/dma/h5_gpdma.yaml


### PR DESCRIPTION
Adds cluster definitions for H5 GPDMA channels. Differentiate 0-5 from 6-7 based on 2D addressing features present in 6-7.