### PR TITLE
H503: Add missing RNG register definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+* STM32H503: Add missing RNG_NSCR register
 * Refactor timers, add enums
 * STM32H5xx: Add H533 (#1129)
 * G4: Fix swapped reset values for SPI4 CR1 and CR2 by deriving SPI4 from SPI1 (#957)

--- a/devices/patches/rng/h503.yaml
+++ b/devices/patches/rng/h503.yaml
@@ -1,0 +1,30 @@
+_add:
+  NSCR:
+    description: RNG noise source control register
+    addressOffset: 0x0C
+    resetValue: 0x0003FFFF
+    fields:
+      EN_OSC1:
+        description: Each bit drives one oscillator enable signal input of instance number 1, gated with the RNGEN bit in RNG_CR (set bit to enable the oscillator).
+        bitOffset: 0
+        bitWidth: 3
+      EN_OSC2:
+        description: Each bit drives one oscillator enable signal input of instance number 2, gated with the RNGEN bit in RNG_CR (set bit to enable the oscillator).
+        bitOffset: 3
+        bitWidth: 3
+      EN_OSC3:
+        description: Each bit drives one oscillator enable signal input of instance number 3, gated with the RNGEN bit in RNG_CR (set bit to enable the oscillator).
+        bitOffset: 6
+        bitWidth: 3
+      EN_OSC4:
+        description: Each bit drives one oscillator enable signal input of instance number 4, gated with the RNGEN bit in RNG_CR (set bit to enable the oscillator).
+        bitOffset: 9
+        bitWidth: 3
+      EN_OSC5:
+        description: Each bit drives one oscillator enable signal input of instance number 5, gated with the RNGEN bit in RNG_CR (set bit to enable the oscillator).
+        bitOffset: 12
+        bitWidth: 3
+      EN_OSC6:
+        description: Each bit drives one oscillator enable signal input of instance number 6, gated with the RNGEN bit in RNG_CR (set bit to enable the oscillator).
+        bitOffset: 15
+        bitWidth: 3

--- a/devices/stm32h503.yaml
+++ b/devices/stm32h503.yaml
@@ -71,6 +71,10 @@ RCC:
     - patches/rcc/h503.yaml
     - fields/rcc/v3/h503.yaml
 
+RNG:
+  _include:
+    - patches/rng/h503.yaml
+
 RTC:
   _include:
     - patches/rtc/alarm.yaml


### PR DESCRIPTION
This is missing in the SVD, but documented in RM0492