### PR TITLE
H5: gpdma: Restore PAM_1, PAM_2 enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+* H5: gpdma: Restore PAM_1, PAM_2 enums
 * Refactor timers, add enums
 * STM32H5xx: Add H533 (#1129)
 * G4: Fix swapped reset values for SPI4 CR1 and CR2 by deriving SPI4 from SPI1 (#957)

--- a/devices/fields/dma/gpdma/h5.yaml
+++ b/devices/fields/dma/gpdma/h5.yaml
@@ -76,22 +76,22 @@ C?TR1:
       Word: [2, Word (4 bytes)]
       Error: [3, User setting error]
   PAM: [0, 3]
-  #PAM_1:
-  #  RightAlignedZeroPadded:
-  #    [0, "Source data is transferred as right aligned, padded with 0s up to the destination data width"]
-  #  RightAlignedSignExtended:
-  #    [1, "Source data is transferred as right aligned, sign extended up to the destination data width"]
-  #  Fifo:
-  #    [
-  #      2,
-  #      "Source data are FIFO queued and packed at the destination data width, in little endian order, before a destination transfer",
-  #    ]
-  #PAM_2:
-  #  RightAlignedLeftTruncated:
-  #    [0, "Source data is transferred as right aligned, left-truncated down to the destination data width"]
-  #  LeftAlignedRightTruncated:
-  #    [1, "Source data is transferred as left-aligned, right-truncated down to the destination data width"]
-  #  Fifo: [2, "Source data are FIFO queued and unpacked at the destination data width, in little endian order"]
+  PAM_1:
+   RightAlignedZeroPadded:
+     [0, "Source data is transferred as right aligned, padded with 0s up to the destination data width"]
+   RightAlignedSignExtended:
+     [1, "Source data is transferred as right aligned, sign extended up to the destination data width"]
+   Fifo:
+     [
+       2,
+       "Source data are FIFO queued and packed at the destination data width, in little endian order, before a destination transfer",
+     ]
+  PAM_2:
+   RightAlignedLeftTruncated:
+     [0, "Source data is transferred as right aligned, left-truncated down to the destination data width"]
+   LeftAlignedRightTruncated:
+     [1, "Source data is transferred as left-aligned, right-truncated down to the destination data width"]
+   Fifo: [2, "Source data are FIFO queued and unpacked at the destination data width, in little endian order"]
 
 C[0-5]TR2:
   TCEM:

--- a/devices/patches/dma/gpdma/h5.yaml
+++ b/devices/patches/dma/gpdma/h5.yaml
@@ -1,0 +1,13 @@
+# Modifications to the GPDMA peripheral used on the H5 family, at least
+C?TR1:
+  # The PAM field can mean different things under different contexts. Add the different contexts
+  # to simplify enumeration definitions
+  _add:
+    PAM_1:
+      bitWidth: 2
+      bitOffset: 11
+      description: PAM value when destination data width is higher than source data width
+    PAM_2:
+      bitWidth: 2
+      bitOffset: 11
+      description: PAM value when source data width is higher than destination data width

--- a/devices/stm32h503.yaml
+++ b/devices/stm32h503.yaml
@@ -24,6 +24,7 @@ EXTI:
 GPDMA?:
   _strip: GPDMA_
   _include:
+    - patches/dma/gpdma/h5.yaml
     - fields/dma/gpdma/h5.yaml
     - collect/dma/gpdma/h5.yaml
 

--- a/devices/stm32h523.yaml
+++ b/devices/stm32h523.yaml
@@ -69,6 +69,7 @@ EXTI:
 GPDMA?:
   _strip: GPDMA_
   _include:
+    - patches/dma/gpdma/h5.yaml
     - fields/dma/gpdma/h5.yaml
     - collect/dma/gpdma/h5.yaml
 

--- a/devices/stm32h533.yaml
+++ b/devices/stm32h533.yaml
@@ -73,6 +73,7 @@ EXTI:
 GPDMA?:
   _strip: GPDMA_
   _include:
+    - patches/dma/gpdma/h5.yaml
     - fields/dma/gpdma/h5.yaml
     - collect/dma/gpdma/h5.yaml
 

--- a/devices/stm32h562.yaml
+++ b/devices/stm32h562.yaml
@@ -30,6 +30,7 @@ EXTI:
 GPDMA?:
   _strip: GPDMA_
   _include:
+    - patches/dma/gpdma/h5.yaml
     - fields/dma/gpdma/h5.yaml
     - collect/dma/gpdma/h5.yaml
 

--- a/devices/stm32h563.yaml
+++ b/devices/stm32h563.yaml
@@ -33,6 +33,7 @@ EXTI:
 GPDMA?:
   _strip: GPDMA_
   _include:
+    - patches/dma/gpdma/h5.yaml
     - fields/dma/gpdma/h5.yaml
     - collect/dma/gpdma/h5.yaml
 

--- a/devices/stm32h573.yaml
+++ b/devices/stm32h573.yaml
@@ -37,6 +37,7 @@ EXTI:
 GPDMA?:
   _strip: GPDMA_
   _include:
+    - patches/dma/gpdma/h5.yaml
     - fields/dma/gpdma/h5.yaml
     - collect/dma/gpdma/h5.yaml
 


### PR DESCRIPTION
This fixes a regression in #1121 which removed the PAM_1 and PAM_2 definitions.