### PR TITLE
USBSEL 0x2: PLL2Q for H503, PLL3Q for rest of H5

### DIFF
--- a/devices/fields/rcc/v3/h5.yaml
+++ b/devices/fields/rcc/v3/h5.yaml
@@ -48,11 +48,6 @@ CCIPR1:
     Disabled: [0, No internal clock available for timers input capture]
     Enabled: [1, "hsi_ker_ck/1024, hsi_ker_ck/8 and csi_ker_ck/128 selected for timers input capture"]
 CCIPR4:
-  USBSEL:
-    DISABLE: [0, Disable the clock]
-    PLL1_Q: [1, PLL1 Q clock selected as clock source (pll1_q_ck)]
-    PLL2_Q: [2, PLL2 Q clock selected as clock source (pll2_q_ck)]
-    HSI48: [3, HSI48 clock selected as clock source (hsi48_ker_ck)]
   SYSTICKSEL:
     HCLK_DIV8: [0, RCC HLCK divided by 8 selected as clock source (rcc_hclk / 8)]
     LSI_KER: [1, LSI kernel selected as clock source (lsi_ker_ck)]

--- a/devices/fields/rcc/v3/h503.yaml
+++ b/devices/fields/rcc/v3/h503.yaml
@@ -40,6 +40,11 @@ CCIPR4:
     PLL2_R: [1, PLL2 R Clock selected as clock source (pll2_r_ck)]
     HSI_KER: [2, HSI kernel clock selected as clock source (hsi_ker_ck)]
     CSI_KER: [3, CSI kernel clock selected as clock source (csi_ker_ck)]
+  USBSEL:
+    DISABLE: [0, Disable the clock]
+    PLL1_Q: [1, PLL1 Q clock selected as clock source (pll1_q_ck)]
+    PLL2_Q: [2, PLL2 Q clock selected as clock source (pll2_q_ck)]
+    HSI48: [3, HSI48 clock selected as clock source (hsi48_ker_ck)]
 CCIPR5:
   DAC1SEL:
     LSE: [0, LSE selected as clock source (lse_ck)]

--- a/devices/fields/rcc/v3/h56x_h57x.yaml
+++ b/devices/fields/rcc/v3/h56x_h57x.yaml
@@ -40,6 +40,11 @@ CCIPR3:
     AUDIOCLK: [3, AUDIOCLK clock selected as clock source]
     PER_CK: [4, per_ck clock selected as clock source]
 CCIPR4:
+  USBSEL:
+    DISABLE: [0, Disable the clock]
+    PLL1_Q: [1, PLL1 Q clock selected as clock source (pll1_q_ck)]
+    PLL3_Q: [2, PLL3 Q clock selected as clock source (pll3_q_ck)]
+    HSI48: [3, HSI48 clock selected as clock source (hsi48_ker_ck)]
   I3C*SEL:
     _name: I3CSEL
     PCLK: [0, Peripheral bus clock used as selected as clock source (rcc_pclk_x)]


### PR DESCRIPTION
From what I can tell only [H503](https://stm32-rs.github.io/stm32-rs/STM32H503.html#RCC:CCIPR4:USBSEL) should have PLL2Q as option for USBSEL with value 0x2. The rest of the timers should be [PLL3Q](https://stm32-rs.github.io/stm32-rs/STM32H533.html#RCC:CCIPR4:USBSEL)