### PR TITLE
F2, F4, F7: Add definitions for OPTCRx register of FLASH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,7 @@
 * G0: mark flags in USB CHEPR as W0C/W1T
 * G0: add value enums for EXTICR[2-4]
 * H5, U5: Add cluster definitions for GPDMA channels
+* F2, F4, F7: Add definitions for OPTCR, OPTCR1 and OPTCR2 registers of FLASH peripheral
 
 Family-specific:
 

--- a/devices/collect/flash/optcr1_nwrp.yaml
+++ b/devices/collect/flash/optcr1_nwrp.yaml
@@ -1,0 +1,3 @@
+OPTCR1:
+  _array:
+    nWRP*: {}

--- a/devices/collect/flash/optcr2_pcrop.yaml
+++ b/devices/collect/flash/optcr2_pcrop.yaml
@@ -1,0 +1,3 @@
+OPTCR2:
+  _array:
+    PCROP?: {}

--- a/devices/collect/flash/optcr_nwrp.yaml
+++ b/devices/collect/flash/optcr_nwrp.yaml
@@ -1,0 +1,3 @@
+OPTCR:
+  _array:
+    nWRP*: {}

--- a/devices/fields/flash/flash_optcr.yaml
+++ b/devices/fields/flash/flash_optcr.yaml
@@ -1,0 +1,32 @@
+# Description of OPTCR register with nWRP only.
+OPTCR:
+  nWRP*:
+    Active: [0, Write protection active on sector %s]
+    Inactive: [1, Write protection inactive on sector %s]
+  RDP:
+    Level0: [0xAA, Read protection not active]
+    Level2: [0xCC, Chip read protection active]
+    Level1: [-1, Read protection of memories active]
+  nRST_STDBY:
+    Reset: [0, Reset generated when entering Standby mode]
+    NoReset: [1, No reset generated]
+  nRST_STOP:
+    Reset: [0, Reset generated when entering Stop mode]
+    NoReset: [1, No reset generated]
+  BOR_LEV:
+    BOR_Off: [0, Reset threshold level for POR/PDR (around 1.7V)]
+    BOR_Level1: [1, Reset threshold level for VBOR1 (around 2.2 V)]
+    BOR_Level2: [2, Reset threshold level for VBOR2 (around 2.5 V)]
+    BOR_Level3: [3, Reset threshold level for VBOR3 (around 2.8 V)]
+  OPTSTRT:
+    _write:
+      Set: [1, This bit triggers an options operation when set]
+    _read:
+      Complete: [0, Cleared when BSY bit is cleared in SR]
+      Requested: [1, Options modification requested]
+  OPTLOCK:
+    _write:
+      Set: [1, Lock the FLASH_OPTCR register]
+    _read:
+      Unlocked: [0, The write and erase operations in the Option bytes area are disabled]
+      Locked: [1, The write and erase operations in the Option bytes area are enabled]

--- a/devices/fields/flash/flash_optcr1_boot.yaml
+++ b/devices/fields/flash/flash_optcr1_boot.yaml
@@ -1,0 +1,19 @@
+OPTCR1:
+  BOOT_ADD1:
+    ItcmRam: [0x0000, Boot from ITCM RAM (0x0000 0000)]
+    SystemMemoryBootloader: [0x0040, Boot from System memory bootloader (0x0010 0000)]
+    FlashItcmInterface: [0x0080, Boot from Flash on ITCM interface (0x0020 0000)]
+    FlashAximInterface: [0x2000, Boot from Flash on AXIM interface (0x0800 0000)]
+    DtcmRam: [0x8000, Boot from DTCM RAM (0x2000 0000)]
+    Sram1: [0x8004, Boot from SRAM1 (0x2001 0000)]
+    Sram2: [0x8013, Boot from SRAM2 (0x2003 C000)]
+    BootAddress: [-1, Boot from specified address (granularity of 16KB)]
+  BOOT_ADD0:
+    ItcmRam: [0x0000, Boot from ITCM RAM (0x0000 0000)]
+    SystemMemoryBootloader: [0x0040, Boot from System memory bootloader (0x0010 0000)]
+    FlashItcmInterface: [0x0080, Boot from Flash on ITCM interface (0x0020 0000)]
+    FlashAximInterface: [0x2000, Boot from Flash on AXIM interface (0x0800 0000)]
+    DtcmRam: [0x8000, Boot from DTCM RAM (0x2000 0000)]
+    Sram1: [0x8004, Boot from SRAM1 (0x2001 0000)]
+    Sram2: [0x8013, Boot from SRAM2 (0x2003 C000)]
+    BootAddress: [-1, Boot from specified address (granularity of 16KB)]

--- a/devices/fields/flash/flash_optcr1_nwrp.yaml
+++ b/devices/fields/flash/flash_optcr1_nwrp.yaml
@@ -1,0 +1,5 @@
+# Description of OPTCR1 register with nWRP only.
+OPTCR1:
+  nWRP*:
+    Active: [0, Write protection active on sector %s (bank 2)]
+    Inactive: [1, Write protection inactive on sector %s (bank 2)]

--- a/devices/fields/flash/flash_optcr2.yaml
+++ b/devices/fields/flash/flash_optcr2.yaml
@@ -1,0 +1,7 @@
+OPTCR2:
+  PCROP_RDP:
+    PcropKept: [0, "PCROP zone is kept when RDP is decreased: Partial mass erase is done"]
+    PcropErased: [1, "PCROP zone is erased when RDP is decreased: Full mass erase is done"]
+  PCROP*:
+    Inactive: [0, PCROP protection inactive on sector %s]
+    Active: [1, PCROP protection active on sector %s]

--- a/devices/fields/flash/flash_optcr_bfb2.yaml
+++ b/devices/fields/flash/flash_optcr_bfb2.yaml
@@ -1,0 +1,4 @@
+OPTCR:
+  BFB2:
+    Disabled: [0, Dual-bank boot disabled]
+    Enabled: [1, Dual-bank boot enabled]

--- a/devices/fields/flash/flash_optcr_db1m.yaml
+++ b/devices/fields/flash/flash_optcr_db1m.yaml
@@ -1,0 +1,4 @@
+OPTCR:
+  DB1M:
+    SingleBank: [0, Single bank with contiguous addresses in bank 1]
+    DualBank: [1, Dual bank with two banks of 512kB]

--- a/devices/fields/flash/flash_optcr_iwdg_wwdg.yaml
+++ b/devices/fields/flash/flash_optcr_iwdg_wwdg.yaml
@@ -1,0 +1,13 @@
+OPTCR:
+  IWDG_STOP:
+    Inactive: [0, IWDG counter frozen in Stop mode]
+    Active: [1, IWDG counter active in Stop mode]
+  IWDG_STDBY:
+    Inactive: [0, IWDG counter frozen in Standby mode]
+    Active: [1, IWDG counter active in Standby mode]
+  IWDG_SW:
+    Hardware: [0, Hardware independant watchdog]
+    Software: [1, Software independant watchdog]
+  WWDG_SW:
+    Hardware: [0, Hardware window watchdog]
+    Software: [1, Software window watchdog]

--- a/devices/fields/flash/flash_optcr_ndbank_ndboot.yaml
+++ b/devices/fields/flash/flash_optcr_ndbank_ndboot.yaml
@@ -1,0 +1,7 @@
+OPTCR:
+  nDBANK:
+    DualBank: [0, The Flash user area is seen as a single bank with 256 bits read access]
+    SingleBank: [1, The Flash user area is seen as a dual bank with 128 bits read access (dual bank mode feature active)]
+  nDBOOT:
+    Enabled: [0, "Boot always from system memory if boot address is in flash (Dual bank Boot mode), or RAM if Boot address option in RAM"]
+    Disabled: [1, Boot according to boot address option]

--- a/devices/fields/flash/flash_optcr_sprmod.yaml
+++ b/devices/fields/flash/flash_optcr_sprmod.yaml
@@ -1,0 +1,4 @@
+OPTCR:
+  SPRMOD:
+    Disabled: [0, nWPRi bits used for Write protection on sector i]
+    Enabled: [1, nWPRi bits used for PCROP protection on sector i]

--- a/devices/fields/flash/flash_optcr_wdg.yaml
+++ b/devices/fields/flash/flash_optcr_wdg.yaml
@@ -1,0 +1,4 @@
+OPTCR:
+  WDG_SW:
+    Hardware: [0, Hardware watchdog]
+    Software: [1, Software watchdog]

--- a/devices/patches/flash/optcr1_nwrp.yaml
+++ b/devices/patches/flash/optcr1_nwrp.yaml
@@ -1,0 +1,4 @@
+OPTCR1:
+  _split: 
+    nWRP:
+      name: nWRP%s

--- a/devices/patches/flash/optcr2_pcrop.yaml
+++ b/devices/patches/flash/optcr2_pcrop.yaml
@@ -1,0 +1,4 @@
+OPTCR2:
+  _split: 
+    PCROP:
+      name: PCROP%s

--- a/devices/patches/flash/optcr_nwrp.yaml
+++ b/devices/patches/flash/optcr_nwrp.yaml
@@ -1,0 +1,4 @@
+OPTCR:
+  _split: 
+    nWRP:
+      name: nWRP%s

--- a/devices/patches/flash/optcr_sprmod.yaml
+++ b/devices/patches/flash/optcr_sprmod.yaml
@@ -1,0 +1,6 @@
+OPTCR:
+  _add:
+    SPRMOD:
+      description: Selection of Protection Mode of nWPR bits
+      bitOffset: 31
+      bitWidth: 1

--- a/devices/stm32f215.yaml
+++ b/devices/stm32f215.yaml
@@ -53,6 +53,15 @@ EXTI:
     - fields/exti/common.yaml
     - collect/exti/farray.yaml
 
+FLASH:
+  _include:
+    - patches/flash/optcr_nwrp.yaml
+    - fields/flash/flash_v1.yaml
+    - fields/flash/flash_latency8.yaml
+    - fields/flash/flash_optcr.yaml
+    - fields/flash/flash_optcr_wdg.yaml
+    - collect/flash/optcr_nwrp.yaml
+
 FSMC:
   _include:
     - patches/fsmc/fsmc_sramfix_v3.yaml

--- a/devices/stm32f217.yaml
+++ b/devices/stm32f217.yaml
@@ -53,6 +53,15 @@ EXTI:
     - fields/exti/common.yaml
     - collect/exti/farray.yaml
 
+FLASH:
+  _include:
+    - patches/flash/optcr_nwrp.yaml
+    - fields/flash/flash_v1.yaml
+    - fields/flash/flash_latency8.yaml
+    - fields/flash/flash_optcr.yaml
+    - fields/flash/flash_optcr_wdg.yaml
+    - collect/flash/optcr_nwrp.yaml
+
 FSMC:
   _include:
     - patches/fsmc/fsmc_sramfix_v3.yaml

--- a/devices/stm32f401.yaml
+++ b/devices/stm32f401.yaml
@@ -51,8 +51,13 @@ EXTI:
 FLASH:
   _include:
     - patches/flash/latency_4b.yaml
+    - patches/flash/optcr_nwrp.yaml
     - fields/flash/flash_v1.yaml
     - fields/flash/flash_latency16.yaml
+    - fields/flash/flash_optcr.yaml
+    - fields/flash/flash_optcr_sprmod.yaml
+    - fields/flash/flash_optcr_wdg.yaml
+    - collect/flash/optcr_nwrp.yaml
 
 GPIOC:
   _delete:

--- a/devices/stm32f401.yaml
+++ b/devices/stm32f401.yaml
@@ -52,6 +52,7 @@ FLASH:
   _include:
     - patches/flash/latency_4b.yaml
     - patches/flash/optcr_nwrp.yaml
+    - patches/flash/optcr_sprmod.yaml
     - fields/flash/flash_v1.yaml
     - fields/flash/flash_latency16.yaml
     - fields/flash/flash_optcr.yaml

--- a/devices/stm32f405.yaml
+++ b/devices/stm32f405.yaml
@@ -74,8 +74,12 @@ EXTI:
 
 FLASH:
   _include:
+    - patches/flash/optcr_nwrp.yaml
     - fields/flash/flash_v1.yaml
     - fields/flash/flash_latency8.yaml
+    - fields/flash/flash_optcr.yaml
+    - fields/flash/flash_optcr_wdg.yaml
+    - collect/flash/optcr_nwrp.yaml
 
 FSMC:
   _modify:

--- a/devices/stm32f407.yaml
+++ b/devices/stm32f407.yaml
@@ -67,8 +67,12 @@ EXTI:
 
 FLASH:
   _include:
+    - patches/flash/optcr_nwrp.yaml
     - fields/flash/flash_v1.yaml
     - fields/flash/flash_latency8.yaml
+    - fields/flash/flash_optcr.yaml
+    - fields/flash/flash_optcr_wdg.yaml
+    - collect/flash/optcr_nwrp.yaml
 
 FSMC:
   _modify:

--- a/devices/stm32f410.yaml
+++ b/devices/stm32f410.yaml
@@ -80,8 +80,13 @@ EXTI:
 FLASH:
   _include:
     - patches/flash/latency_4b.yaml
+    - patches/flash/optcr_nwrp.yaml
     - fields/flash/flash_v1.yaml
     - fields/flash/flash_latency16.yaml
+    - fields/flash/flash_optcr.yaml
+    - fields/flash/flash_optcr_sprmod.yaml
+    - fields/flash/flash_optcr_wdg.yaml
+    - collect/flash/optcr_nwrp.yaml
 
 FMPI2C?:
   _include:

--- a/devices/stm32f411.yaml
+++ b/devices/stm32f411.yaml
@@ -52,6 +52,7 @@ FLASH:
   _include:
     - patches/flash/latency_4b.yaml
     - patches/flash/optcr_nwrp.yaml
+    - patches/flash/optcr_sprmod.yaml
     - fields/flash/flash_v1.yaml
     - fields/flash/flash_latency16.yaml
     - fields/flash/flash_optcr.yaml

--- a/devices/stm32f411.yaml
+++ b/devices/stm32f411.yaml
@@ -51,8 +51,13 @@ EXTI:
 FLASH:
   _include:
     - patches/flash/latency_4b.yaml
+    - patches/flash/optcr_nwrp.yaml
     - fields/flash/flash_v1.yaml
     - fields/flash/flash_latency16.yaml
+    - fields/flash/flash_optcr.yaml
+    - fields/flash/flash_optcr_sprmod.yaml
+    - fields/flash/flash_optcr_wdg.yaml
+    - collect/flash/optcr_nwrp.yaml
 
 GPIO?:
   _include:

--- a/devices/stm32f412.yaml
+++ b/devices/stm32f412.yaml
@@ -75,8 +75,13 @@ EXTI:
 FLASH:
   _include:
     - patches/flash/latency_4b.yaml
+    - patches/flash/optcr_nwrp.yaml
     - fields/flash/flash_v1.yaml
     - fields/flash/flash_latency16.yaml
+    - fields/flash/flash_optcr.yaml
+    - fields/flash/flash_optcr_sprmod.yaml
+    - fields/flash/flash_optcr_wdg.yaml
+    - collect/flash/optcr_nwrp.yaml
 
 FMPI2C1:
   _add:

--- a/devices/stm32f412.yaml
+++ b/devices/stm32f412.yaml
@@ -76,6 +76,7 @@ FLASH:
   _include:
     - patches/flash/latency_4b.yaml
     - patches/flash/optcr_nwrp.yaml
+    - patches/flash/optcr_sprmod.yaml
     - fields/flash/flash_v1.yaml
     - fields/flash/flash_latency16.yaml
     - fields/flash/flash_optcr.yaml

--- a/devices/stm32f413.yaml
+++ b/devices/stm32f413.yaml
@@ -118,8 +118,13 @@ DMA?:
 FLASH:
   _include:
     - patches/flash/latency_4b.yaml
+    - patches/flash/optcr_nwrp.yaml
     - fields/flash/flash_v1.yaml
     - fields/flash/flash_latency16.yaml
+    - fields/flash/flash_optcr.yaml
+    - fields/flash/flash_optcr_sprmod.yaml
+    - fields/flash/flash_optcr_wdg.yaml
+    - collect/flash/optcr_nwrp.yaml
 
 FMPI2C1:
   OAR1:

--- a/devices/stm32f413.yaml
+++ b/devices/stm32f413.yaml
@@ -119,6 +119,7 @@ FLASH:
   _include:
     - patches/flash/latency_4b.yaml
     - patches/flash/optcr_nwrp.yaml
+    - patches/flash/optcr_sprmod.yaml
     - fields/flash/flash_v1.yaml
     - fields/flash/flash_latency16.yaml
     - fields/flash/flash_optcr.yaml

--- a/devices/stm32f427.yaml
+++ b/devices/stm32f427.yaml
@@ -75,8 +75,17 @@ EXTI:
 FLASH:
   _include:
     - patches/flash/latency_4b.yaml
+    - patches/flash/optcr_nwrp.yaml
+    - patches/flash/optcr1_nwrp.yaml
     - fields/flash/flash_v1.yaml
     - fields/flash/flash_latency16.yaml
+    - fields/flash/flash_optcr.yaml
+    - fields/flash/flash_optcr_bfb2.yaml
+    - fields/flash/flash_optcr_db1m.yaml
+    - fields/flash/flash_optcr_wdg.yaml
+    - fields/flash/flash_optcr1_nwrp.yaml
+    - collect/flash/optcr_nwrp.yaml
+    - collect/flash/optcr1_nwrp.yaml
 
 # Offset of BWTR3 and BWTR4 is incorrect
 FSMC:

--- a/devices/stm32f429.yaml
+++ b/devices/stm32f429.yaml
@@ -70,8 +70,17 @@ EXTI:
 FLASH:
   _include:
     - patches/flash/latency_4b.yaml
+    - patches/flash/optcr_nwrp.yaml
+    - patches/flash/optcr1_nwrp.yaml
     - fields/flash/flash_v1.yaml
     - fields/flash/flash_latency16.yaml
+    - fields/flash/flash_optcr.yaml
+    - fields/flash/flash_optcr_bfb2.yaml
+    - fields/flash/flash_optcr_db1m.yaml
+    - fields/flash/flash_optcr_wdg.yaml
+    - fields/flash/flash_optcr1_nwrp.yaml
+    - collect/flash/optcr_nwrp.yaml
+    - collect/flash/optcr1_nwrp.yaml
 
 # Offset of BWTR3 and BWTR4 is incorrect
 FMC:

--- a/devices/stm32f446.yaml
+++ b/devices/stm32f446.yaml
@@ -77,8 +77,13 @@ DMA?:
 FLASH:
   _include:
     - patches/flash/latency_4b.yaml
+    - patches/flash/optcr_nwrp.yaml
     - fields/flash/flash_v1.yaml
     - fields/flash/flash_latency16.yaml
+    - fields/flash/flash_optcr.yaml
+    - fields/flash/flash_optcr_sprmod.yaml
+    - fields/flash/flash_optcr_wdg.yaml
+    - collect/flash/optcr_nwrp.yaml
 
 FMC:
   _include:

--- a/devices/stm32f469.yaml
+++ b/devices/stm32f469.yaml
@@ -103,8 +103,18 @@ EXTI:
 FLASH:
   _include:
     - patches/flash/latency_4b.yaml
+    - patches/flash/optcr_nwrp.yaml
+    - patches/flash/optcr1_nwrp.yaml
     - fields/flash/flash_v1.yaml
     - fields/flash/flash_latency16.yaml
+    - fields/flash/flash_optcr.yaml
+    - fields/flash/flash_optcr_bfb2.yaml
+    - fields/flash/flash_optcr_db1m.yaml
+    - fields/flash/flash_optcr_sprmod.yaml
+    - fields/flash/flash_optcr_wdg.yaml
+    - fields/flash/flash_optcr1_nwrp.yaml
+    - collect/flash/optcr_nwrp.yaml
+    - collect/flash/optcr1_nwrp.yaml
 
 FMC:
   _include:

--- a/devices/stm32f722.yaml
+++ b/devices/stm32f722.yaml
@@ -62,8 +62,16 @@ EXTI:
 
 FLASH:
   _include:
-    - fields/flash/flash_v2.yaml
     - patches/flash/latency.yaml
+    - patches/flash/optcr_nwrp.yaml
+    - patches/flash/optcr2_pcrop.yaml
+    - fields/flash/flash_v2.yaml
+    - fields/flash/flash_optcr.yaml
+    - fields/flash/flash_optcr_iwdg_wwdg.yaml
+    - fields/flash/flash_optcr1_boot.yaml
+    - fields/flash/flash_optcr2.yaml
+    - collect/flash/optcr_nwrp.yaml
+    - collect/flash/optcr2_pcrop.yaml
 
 FMC:
   _include:

--- a/devices/stm32f723.yaml
+++ b/devices/stm32f723.yaml
@@ -62,8 +62,16 @@ EXTI:
 
 FLASH:
   _include:
-    - fields/flash/flash_v2.yaml
     - patches/flash/latency.yaml
+    - patches/flash/optcr_nwrp.yaml
+    - patches/flash/optcr2_pcrop.yaml
+    - fields/flash/flash_v2.yaml
+    - fields/flash/flash_optcr.yaml
+    - fields/flash/flash_optcr_iwdg_wwdg.yaml
+    - fields/flash/flash_optcr1_boot.yaml
+    - fields/flash/flash_optcr2.yaml
+    - collect/flash/optcr_nwrp.yaml
+    - collect/flash/optcr2_pcrop.yaml
 
 FMC:
   _include:

--- a/devices/stm32f730.yaml
+++ b/devices/stm32f730.yaml
@@ -66,6 +66,10 @@ EXTI:
         name: IM9
 
 FLASH:
+  OPTCR2:
+    _modify:
+      PCROPi:
+        name: PCROP
   _include:
     - patches/flash/latency.yaml
     - patches/flash/optcr_nwrp.yaml

--- a/devices/stm32f730.yaml
+++ b/devices/stm32f730.yaml
@@ -67,7 +67,16 @@ EXTI:
 
 FLASH:
   _include:
+    - patches/flash/latency.yaml
+    - patches/flash/optcr_nwrp.yaml
+    - patches/flash/optcr2_pcrop.yaml
     - fields/flash/flash_v2.yaml
+    - fields/flash/flash_optcr.yaml
+    - fields/flash/flash_optcr_iwdg_wwdg.yaml
+    - fields/flash/flash_optcr1_boot.yaml
+    - fields/flash/flash_optcr2.yaml
+    - collect/flash/optcr_nwrp.yaml
+    - collect/flash/optcr2_pcrop.yaml
 
 FMC:
   _include:

--- a/devices/stm32f732.yaml
+++ b/devices/stm32f732.yaml
@@ -62,8 +62,16 @@ EXTI:
 
 FLASH:
   _include:
-    - fields/flash/flash_v2.yaml
     - patches/flash/latency.yaml
+    - patches/flash/optcr_nwrp.yaml
+    - patches/flash/optcr2_pcrop.yaml
+    - fields/flash/flash_v2.yaml
+    - fields/flash/flash_optcr.yaml
+    - fields/flash/flash_optcr_iwdg_wwdg.yaml
+    - fields/flash/flash_optcr1_boot.yaml
+    - fields/flash/flash_optcr2.yaml
+    - collect/flash/optcr_nwrp.yaml
+    - collect/flash/optcr2_pcrop.yaml
 
 FMC:
   _include:

--- a/devices/stm32f733.yaml
+++ b/devices/stm32f733.yaml
@@ -62,8 +62,16 @@ EXTI:
 
 FLASH:
   _include:
-    - fields/flash/flash_v2.yaml
     - patches/flash/latency.yaml
+    - patches/flash/optcr_nwrp.yaml
+    - patches/flash/optcr2_pcrop.yaml
+    - fields/flash/flash_v2.yaml
+    - fields/flash/flash_optcr.yaml
+    - fields/flash/flash_optcr_iwdg_wwdg.yaml
+    - fields/flash/flash_optcr1_boot.yaml
+    - fields/flash/flash_optcr2.yaml
+    - collect/flash/optcr_nwrp.yaml
+    - collect/flash/optcr2_pcrop.yaml
 
 FMC:
   _include:

--- a/devices/stm32f745.yaml
+++ b/devices/stm32f745.yaml
@@ -128,7 +128,13 @@ FLASH:
       OPTKEY:
         name: OPTKEYR
   _include:
+    - patches/flash/latency.yaml
+    - patches/flash/optcr_nwrp.yaml
     - fields/flash/flash_v2.yaml
+    - fields/flash/flash_optcr.yaml
+    - fields/flash/flash_optcr_iwdg_wwdg.yaml
+    - fields/flash/flash_optcr1_boot.yaml
+    - collect/flash/optcr_nwrp.yaml
 
 FMC:
   _include:

--- a/devices/stm32f746.yaml
+++ b/devices/stm32f746.yaml
@@ -107,13 +107,19 @@ EXTI:
     - collect/exti/farray.yaml
 
 FLASH:
-  _include:
-    - patches/flash/erserr.yaml
-    - fields/flash/flash_v2.yaml
   OPTKEYR:
     _modify:
       OPTKEY:
         name: OPTKEYR
+  _include:
+    - patches/flash/erserr.yaml
+    - patches/flash/latency.yaml
+    - patches/flash/optcr_nwrp.yaml
+    - fields/flash/flash_v2.yaml
+    - fields/flash/flash_optcr.yaml
+    - fields/flash/flash_optcr_iwdg_wwdg.yaml
+    - fields/flash/flash_optcr1_boot.yaml
+    - collect/flash/optcr_nwrp.yaml
 
 FMC:
   _include:

--- a/devices/stm32f750.yaml
+++ b/devices/stm32f750.yaml
@@ -80,13 +80,19 @@ EXTI:
     - collect/exti/farray.yaml
 
 FLASH:
-  _include:
-    - patches/flash/erserr.yaml
-    - fields/flash/flash_v2.yaml
   OPTKEYR:
     _modify:
       OPTKEY:
         name: OPTKEYR
+  _include:
+    - patches/flash/erserr.yaml
+    - patches/flash/latency.yaml
+    - patches/flash/optcr_nwrp.yaml
+    - fields/flash/flash_v2.yaml
+    - fields/flash/flash_optcr.yaml
+    - fields/flash/flash_optcr_iwdg_wwdg.yaml
+    - fields/flash/flash_optcr1_boot.yaml
+    - collect/flash/optcr_nwrp.yaml
 
 FMC:
   _include:

--- a/devices/stm32f756.yaml
+++ b/devices/stm32f756.yaml
@@ -115,13 +115,19 @@ EXTI:
     - collect/exti/farray.yaml
 
 FLASH:
-  _include:
-    - patches/flash/erserr.yaml
-    - fields/flash/flash_v2.yaml
   OPTKEYR:
     _modify:
       OPTKEY:
         name: OPTKEYR
+  _include:
+    - patches/flash/erserr.yaml
+    - patches/flash/latency.yaml
+    - patches/flash/optcr_nwrp.yaml
+    - fields/flash/flash_v2.yaml
+    - fields/flash/flash_optcr.yaml
+    - fields/flash/flash_optcr_iwdg_wwdg.yaml
+    - fields/flash/flash_optcr1_boot.yaml
+    - collect/flash/optcr_nwrp.yaml
 
 FMC:
   _include:

--- a/devices/stm32f765.yaml
+++ b/devices/stm32f765.yaml
@@ -121,13 +121,19 @@ EXTI:
         value: 1
 
 FLASH:
-  _include:
-    - patches/flash/f7_dual_bank.yaml
-    - fields/flash/flash_v2_dual_bank.yaml
   OPTKEYR:
     _modify:
       OPTKEY:
         name: OPTKEYR
+  _include:
+    - patches/flash/f7_dual_bank.yaml
+    - patches/flash/optcr_nwrp.yaml
+    - fields/flash/flash_v2_dual_bank.yaml
+    - fields/flash/flash_optcr.yaml
+    - fields/flash/flash_optcr_iwdg_wwdg.yaml
+    - fields/flash/flash_optcr_ndbank_ndboot.yaml
+    - fields/flash/flash_optcr1_boot.yaml
+    - collect/flash/optcr_nwrp.yaml
 
 FMC:
   _include:

--- a/devices/stm32f767.yaml
+++ b/devices/stm32f767.yaml
@@ -128,14 +128,20 @@ EXTI:
     - collect/exti/farray.yaml
 
 FLASH:
-  _include:
-    - patches/flash/f7_dual_bank.yaml
-    - patches/flash/erserr.yaml
-    - fields/flash/flash_v2_dual_bank.yaml
   OPTKEYR:
     _modify:
       OPTKEY:
         name: OPTKEYR
+  _include:
+    - patches/flash/erserr.yaml
+    - patches/flash/f7_dual_bank.yaml
+    - patches/flash/optcr_nwrp.yaml
+    - fields/flash/flash_v2_dual_bank.yaml
+    - fields/flash/flash_optcr.yaml
+    - fields/flash/flash_optcr_iwdg_wwdg.yaml
+    - fields/flash/flash_optcr_ndbank_ndboot.yaml
+    - fields/flash/flash_optcr1_boot.yaml
+    - collect/flash/optcr_nwrp.yaml
 
 FMC:
   _include:

--- a/devices/stm32f769.yaml
+++ b/devices/stm32f769.yaml
@@ -125,14 +125,20 @@ EXTI:
     - collect/exti/farray.yaml
 
 FLASH:
-  _include:
-    - patches/flash/f7_dual_bank.yaml
-    - patches/flash/erserr.yaml
-    - fields/flash/flash_v2_dual_bank.yaml
   OPTKEYR:
     _modify:
       OPTKEY:
         name: OPTKEYR
+  _include:
+    - patches/flash/erserr.yaml
+    - patches/flash/f7_dual_bank.yaml
+    - patches/flash/optcr_nwrp.yaml
+    - fields/flash/flash_v2_dual_bank.yaml
+    - fields/flash/flash_optcr.yaml
+    - fields/flash/flash_optcr_iwdg_wwdg.yaml
+    - fields/flash/flash_optcr_ndbank_ndboot.yaml
+    - fields/flash/flash_optcr1_boot.yaml
+    - collect/flash/optcr_nwrp.yaml
 
 FMC:
   _include:

--- a/devices/stm32f777.yaml
+++ b/devices/stm32f777.yaml
@@ -128,14 +128,20 @@ EXTI:
     - collect/exti/farray.yaml
 
 FLASH:
-  _include:
-    - patches/flash/f7_dual_bank.yaml
-    - patches/flash/erserr.yaml
-    - fields/flash/flash_v2_dual_bank.yaml
   OPTKEYR:
     _modify:
       OPTKEY:
         name: OPTKEYR
+  _include:
+    - patches/flash/erserr.yaml
+    - patches/flash/f7_dual_bank.yaml
+    - patches/flash/optcr_nwrp.yaml
+    - fields/flash/flash_v2_dual_bank.yaml
+    - fields/flash/flash_optcr.yaml
+    - fields/flash/flash_optcr_iwdg_wwdg.yaml
+    - fields/flash/flash_optcr_ndbank_ndboot.yaml
+    - fields/flash/flash_optcr1_boot.yaml
+    - collect/flash/optcr_nwrp.yaml
 
 FMC:
   _include:

--- a/devices/stm32f778.yaml
+++ b/devices/stm32f778.yaml
@@ -125,14 +125,20 @@ EXTI:
     - collect/exti/farray.yaml
 
 FLASH:
-  _include:
-    - patches/flash/f7_dual_bank.yaml
-    - patches/flash/erserr.yaml
-    - fields/flash/flash_v2_dual_bank.yaml
   OPTKEYR:
     _modify:
       OPTKEY:
         name: OPTKEYR
+  _include:
+    - patches/flash/erserr.yaml
+    - patches/flash/f7_dual_bank.yaml
+    - patches/flash/optcr_nwrp.yaml
+    - fields/flash/flash_v2_dual_bank.yaml
+    - fields/flash/flash_optcr.yaml
+    - fields/flash/flash_optcr_iwdg_wwdg.yaml
+    - fields/flash/flash_optcr_ndbank_ndboot.yaml
+    - fields/flash/flash_optcr1_boot.yaml
+    - collect/flash/optcr_nwrp.yaml
 
 FMC:
   _include:

--- a/devices/stm32f779.yaml
+++ b/devices/stm32f779.yaml
@@ -125,14 +125,20 @@ EXTI:
     - collect/exti/farray.yaml
 
 FLASH:
-  _include:
-    - patches/flash/f7_dual_bank.yaml
-    - patches/flash/erserr.yaml
-    - fields/flash/flash_v2_dual_bank.yaml
   OPTKEYR:
     _modify:
       OPTKEY:
         name: OPTKEYR
+  _include:
+    - patches/flash/erserr.yaml
+    - patches/flash/f7_dual_bank.yaml
+    - patches/flash/optcr_nwrp.yaml
+    - fields/flash/flash_v2_dual_bank.yaml
+    - fields/flash/flash_optcr.yaml
+    - fields/flash/flash_optcr_iwdg_wwdg.yaml
+    - fields/flash/flash_optcr_ndbank_ndboot.yaml
+    - fields/flash/flash_optcr1_boot.yaml
+    - collect/flash/optcr_nwrp.yaml
 
 FMC:
   _include:


### PR DESCRIPTION
This PR adds definitions for OPTCR, OPTCR1 and OPTCR2 registers for all F2, F4 and F7 devices.

## Patch structure

Most of the fields are implemented the same way across the target devices, but there are still differences between models. Taking the whole range of devices, there are at least 7 OPTCR variants, 2 OPTCR1 variants and 1 OPTCR2 variant.

To share as much code as possible while enabling a lean composition in the device yaml, the added patch files are organised like this:

- common fields are described in `devices/fields/flash/flash_optcr.yaml`
- specific fields are described in their specific yaml file `devices/fields/flash/flash_optcr_*field*.yaml`

Register `OPTCR1` doesn't really have a default variant so it is just split between `devices/fields/flash/flash_optcr1_boot.yaml` or `devices/fields/flash/flash_optcr1_nwrp.yaml`.

Register `OPTCR2` only has 1 variant, written in `devices/fields/flash/flash_optcr2.yaml`.

## Bit fields management

There are 2 peculiar fields in these registers, `nWRP` and `PCROP`, which are not enums but bit fields (or flags).

To enable a dedicated read/write access to each bit of the fields, there are split in N fields using the _split_ command in `devices/patches/flash/optcr_*.yaml`, then collected as an array in `devices/collect/flash/optcr*_*.yaml`.

### nWRP

This technic is especially usefull for the `nWRP` field, as it doesn't have the same size across F2, F4 and F7 devices (it can be 5, 8, 12, 15 bits long). Using the `*` wildcard character ensures the _split_ and _collect_ methods covers all these sizes.

Using `?` doesn't work in this case, as it only counts for a single character, thus limiting the array index to 9.

### PCROP

On the other hand, the `PCROP` register uses `?` as its index is limited to 8, and the pattern `PCROP*` would conflict with another field named `PCROP_MOD` in the same register.

## Miscellaneous

During testing I noticed some issues with SVDs for 401, 411, 412, 413 and 730 devices. A patch has been created here while the issue is handled upstream by ST developpers.

I also noticed inconsistencies in the `nWRP` bit size between SVD and reference manuals, I didn't create a patch as I didn't feel it was a major issue, but I'll report this upstream anyway.

Closes #1154.