### PR TITLE
Flash H7 - Make naming consistent with single core devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -214,6 +214,7 @@ Family-specific:
   * Add H723/25/30/33/42/50/55/A3/B0 (#1107)
   * RAMECC fixes & collect
   * RCC - Unify usbotg field naming and remove invalid fields (#1219)
+  * Flash - Make dual core devices naming consistent with single core devices (#1222)
 
 * L0:
   * Update vendor SVD bundle to v1.4 (#1081)

--- a/devices/patches/flash/h7_dualcore.yaml
+++ b/devices/patches/flash/h7_dualcore.yaml
@@ -32,7 +32,7 @@ _add:
         resetValue: 0x00000000
         access: write-only
         fields:
-          KEYR:
+          KEY1R:
             description: Bank access configuration unlock key
             bitOffset: 0
             bitWidth: 32


### PR DESCRIPTION
* [H747_CM7 - KEYR](https://stm32-rs.github.io/stm32-rs/STM32H747_CM7.html#FLASH:KEYR%20[1]:KEYR)
* [H743 - KEY1R](https://stm32-rs.github.io/stm32-rs/STM32H743.html#FLASH:KEYR%20[1]:KEY1R)