### PR TITLE
STM32F745: pull in dbg_trace fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 
 Family-specific:
 
+* F7:
+  * F74, F75: Add fields to DBGMCU.CR (#1260)
+
 * G4:
   * UART: remove missing fields, derive UART/LPUART from USART (#1247)
 

--- a/devices/stm32f745.yaml
+++ b/devices/stm32f745.yaml
@@ -434,6 +434,7 @@ _include:
   - patches/ethernet/mac_regs.yaml
   - patches/ethernet/mmc.yaml
   - patches/adc/adc_common_group_name.yaml
+  - fields/dbg/dbg_trace.yaml
   - fields/eth/eth_dma_common.yaml
   - fields/eth/eth_dma_mb_edfe_dmarswtr.yaml
   - fields/eth/eth_mac_common.yaml

--- a/devices/stm32f746.yaml
+++ b/devices/stm32f746.yaml
@@ -409,6 +409,7 @@ _include:
   - patches/ethernet/mac_regs.yaml
   - patches/ethernet/mmc.yaml
   - patches/adc/adc_common_group_name.yaml
+  - fields/dbg/dbg_trace.yaml
   - fields/eth/eth_dma_common.yaml
   - fields/eth/eth_dma_mb_edfe_dmarswtr.yaml
   - fields/eth/eth_mac_common.yaml

--- a/devices/stm32f750.yaml
+++ b/devices/stm32f750.yaml
@@ -390,6 +390,7 @@ _include:
   - patches/ethernet/mac_regs.yaml
   - patches/ethernet/mmc.yaml
   - patches/ethernet/f2_f4.yaml
+  - fields/dbg/dbg_trace.yaml
   - fields/eth/eth_dma_common.yaml
   - fields/eth/eth_dma_mb_edfe_dmarswtr.yaml
   - fields/eth/eth_mac_common.yaml

--- a/devices/stm32f756.yaml
+++ b/devices/stm32f756.yaml
@@ -417,6 +417,7 @@ _include:
   - patches/ethernet/mac_regs.yaml
   - patches/ethernet/mmc.yaml
   - patches/adc/adc_common_group_name.yaml
+  - fields/dbg/dbg_trace.yaml
   - fields/eth/eth_dma_common.yaml
   - fields/eth/eth_dma_mb_edfe_dmarswtr.yaml
   - fields/eth/eth_mac_common.yaml


### PR DESCRIPTION
dbg_common.yaml might also be useful, but would require renaming the freeze registers like in
devices/patches/dbgmcu/l4_apb_fzr_rename.yaml