### PR TITLE
modify reset value TIM12_ARR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Fix bug in GPIO AFSEL collect
 * Fix groupNames
 * Add GPIO for WB0/N6/MP1
+* Modified stm32f100 TIM12_ARR reset value
 
 Family-specific:
 

--- a/devices/stm32f100.yaml
+++ b/devices/stm32f100.yaml
@@ -138,6 +138,9 @@ TIM12:
     - patches/tim/tim9_ic1f.yaml
     - fields/tim/v1/tim9.yaml
     - collect/tim/ccr.yaml
+  _modify:
+    ARR:
+      resetValue: 0xFFFF
 
 TIM13:
   _include:


### PR DESCRIPTION
In the rm0041 manual, the reset value of the TIM12_ARR register is given as 0xFFFF, not 0x0000.