### PR TITLE
STM32F7[45]: add SYSCFG fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 Family-specific:
 
 * F7:
-  * F74, F75: Add fields to DBGMCU.CR (#1260)
+  * F74, F75: Add fields to DBGMCU.CR (#1260) and SYSCFG (#1265)
 
 * G4:
   * UART: remove missing fields, derive UART/LPUART from USART (#1247)

--- a/devices/fields/syscfg/syscfg_f74_f75.yaml
+++ b/devices/fields/syscfg/syscfg_f74_f75.yaml
@@ -1,0 +1,33 @@
+_include:
+  - ../exti/derive.yaml
+  - f4/cmpcr.yaml
+
+MEMRMP:
+  SWP_FMC:
+    NoSwap: [0, No FMC memory mapping swap]
+    Swapped: [1, SDRAM banks and NOR/RAM mapping are swapped]
+  MEM_BOOT:
+    Add0: [0, Boot memory base address is defined by FLASH.OPTCR1.BOOT_ADD0]
+    Add1: [1, Boot memory base address is defined by FLASH.OPTCR1.BOOT_ADD1]
+
+PMC:
+  MII_RMII_SEL:
+    MII: [0, MII interface is selected]
+    RMII_PHY: [1, RMII PHY interface is selected]
+  ADC3DC2: [0, 1]
+  ADC2DC2: [0, 1]
+  ADC1DC2: [0, 1]
+
+EXTICR1:
+  EXTI0:
+    PA: [0, Select PAx as the source input for the EXTIx external interrupt]
+    PB: [1, Select PBx as the source input for the EXTIx external interrupt]
+    PC: [2, Select PCx as the source input for the EXTIx external interrupt]
+    PD: [3, Select PDx as the source input for the EXTIx external interrupt]
+    PE: [4, Select PEx as the source input for the EXTIx external interrupt]
+    PF: [5, Select PFx as the source input for the EXTIx external interrupt]
+    PG: [6, Select PGx as the source input for the EXTIx external interrupt]
+    PH: [7, Select PHx as the source input for the EXTIx external interrupt]
+    PI: [8, Select PIx as the source input for the EXTIx external interrupt]
+    PJ: [9, Select PJx as the source input for the EXTIx external interrupt]
+    PK: [10, Select PKx as the source input for the EXTIx external interrupt]

--- a/devices/stm32f745.yaml
+++ b/devices/stm32f745.yaml
@@ -311,6 +311,7 @@ SYSCFG:
       - FB_MODE
   _include:
     - patches/syscfg/f745_f750_f765_f7x6_f7x7_f7x9.yaml
+    - fields/syscfg/syscfg_f74_f75.yaml
 
 TIM1:
   _include:

--- a/devices/stm32f746.yaml
+++ b/devices/stm32f746.yaml
@@ -286,6 +286,7 @@ SYSCFG:
       - FB_MODE
   _include:
     - patches/syscfg/f745_f750_f765_f7x6_f7x7_f7x9.yaml
+    - fields/syscfg/syscfg_f74_f75.yaml
 
 TIM1:
   _include:

--- a/devices/stm32f750.yaml
+++ b/devices/stm32f750.yaml
@@ -268,6 +268,7 @@ SYSCFG:
       - FB_MODE
   _include:
     - patches/syscfg/f745_f750_f765_f7x6_f7x7_f7x9.yaml
+    - fields/syscfg/syscfg_f74_f75.yaml
 
 TIM1:
   _include:

--- a/devices/stm32f756.yaml
+++ b/devices/stm32f756.yaml
@@ -294,6 +294,7 @@ SYSCFG:
       - FB_MODE
   _include:
     - patches/syscfg/f745_f750_f765_f7x6_f7x7_f7x9.yaml
+    - fields/syscfg/syscfg_f74_f75.yaml
 
 TIM1:
   _include:


### PR DESCRIPTION
There are quite a few similarities with STM32F427 et al.; major differences include MEM_BOOT instead of MEM_MODE in MEMRMP.