### PR TITLE
updated reset values for multiple registers in the stm32f100

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Add `V` to device name of `STM32H743/53` v-series
 * Add GPIO for WB0/N6/MP1
 * Modified stm32f100 TIM12_ARR reset value
+* Modified reset values for multiple registers in stm32f100.svd
 
 Family-specific:
 

--- a/devices/stm32f100.yaml
+++ b/devices/stm32f100.yaml
@@ -64,6 +64,23 @@ FSMC:
     - patches/fsmc/sramfix_v3.yaml
     - fields/fsmc/sram.yaml
     - collect/fsmc/sram.yaml
+  _modify:
+    BCR1:
+      resetValue: 0x30DB
+    BCR2:
+      resetValue: 0x30D2
+    BCR3:
+      resetValue: 0x30D2
+    BCR4:
+      resetValue: 0x30D2
+    BTR1:
+      resetValue: 0x0FFFFFFF
+    BTR2:
+      resetValue: 0x0FFFFFFF
+    BTR3:
+      resetValue: 0x0FFFFFFF
+    BTR4:
+      resetValue: 0x0FFFFFFF
 
 FSM[C]:
   _include:
@@ -122,16 +139,25 @@ TIM1:
     - fields/tim/tim_mms_ts_sms.yaml
     - fields/tim/v1/tim1.yaml
     - collect/tim/ccr.yaml
+  _modify:
+    ARR:
+      resetValue: 0xFFFF
 
 TIM2:
   _include:
     - fields/tim/tim_mms_ts_sms.yaml
     - fields/tim/v1/tim3.yaml
     - collect/tim/ccr.yaml
+  _modify:
+    ARR:
+      resetValue: 0xFFFF
 
 TIM6:
   _include:
     - fields/tim/v1/tim6.yaml
+  _modify:
+    ARR:
+      resetValue: 0xFFFF
 
 TIM12:
   _include:
@@ -147,6 +173,9 @@ TIM13:
     - patches/tim/tim10_14_missing_opm.yaml
     - fields/tim/v1/tim13.yaml
     - collect/tim/ccr.yaml
+  _modify:
+    ARR:
+      resetValue: 0xFFFF
 
 TIM15:
   _include:


### PR DESCRIPTION
In the rm0041 manual, the reset value of the following registers is different than what's in the SVD file.
- FSMC_BCR1 = 0x30DB not 0x30D0
- FSMC_BCR2 = 0x30D2 not 0x30D0
- FSMC_BCR3 = 0x30D2 not 0x30D0
- FSMC_BCR4 = 0x30D2 not 0x30D0
- FSMC_BTR1 = 0x0FFF_FFFF not 0xFFFF_FFFF
- FSMC_BTR2 = 0x0FFF_FFFF not 0xFFFF_FFFF
- FSMC_BTR3 = 0x0FFF_FFFF not 0xFFFF_FFFF
- FSMC_BTR4 = 0x0FFF_FFFF not 0xFFFF_FFFF
- TIM1_ARR = 0xFFFF not 0x0
- TIM2_ARR = 0xFFFF not 0x0
- TIM6_ARR = 0xFFFF not 0x0
- TIM13_ARR = 0xFFFF not 0x0
 