### PR TITLE
Patches for stm32c0xx SVD files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Family-specific:
 
 * C0:
   * Update archive to v1.5
+  * Updated reset values for multiple regsiters in stm32c011/31/71
+  * Updated bit widths for multiple flash register subfields in stm32c011/31/71
 
 * F0:
   * Updated reset values for multiple registers in the stm32f0x1/2/8 SVD files (#1274)

--- a/devices/patches/flash/c0_bit_width.yaml
+++ b/devices/patches/flash/c0_bit_width.yaml
@@ -1,0 +1,32 @@
+WRP1AR:
+  _modify:
+    WRP1A_STRT:
+      bitWidth: 7
+    WRP1A_END:
+      bitWidth: 7
+WRP1BR:
+  _modify:
+    WRP1B_STRT:
+      bitWidth: 7
+    WRP1B_END:
+      bitWidth: 7
+SECR:
+  _modify:
+    SEC_SIZE:
+      bitWidth: 7
+PCROP1BER:
+  _modify:
+    PCROP1B_END:
+      bitWidth: 9
+PCROP1BSR:
+  _modify:
+    PCROP1B_STRT:
+      bitWidth: 9
+PCROP1ASR:
+  _modify:
+    PCROP1A_STRT:
+      bitWidth: 9
+PCROP1AER:
+  _modify:
+    PCROP1A_END:
+      bitWidth: 9

--- a/devices/patches/flash/c0_bit_width.yaml
+++ b/devices/patches/flash/c0_bit_width.yaml
@@ -1,14 +1,8 @@
-WRP1AR:
+WRP1[AB]R:
   _modify:
-    WRP1A_STRT:
+    WRP1[AB]_STRT:
       bitWidth: 7
-    WRP1A_END:
-      bitWidth: 7
-WRP1BR:
-  _modify:
-    WRP1B_STRT:
-      bitWidth: 7
-    WRP1B_END:
+    WRP1[AB]_END:
       bitWidth: 7
 SECR:
   _modify:

--- a/devices/patches/flash/c0_bit_width.yaml
+++ b/devices/patches/flash/c0_bit_width.yaml
@@ -8,19 +8,11 @@ SECR:
   _modify:
     SEC_SIZE:
       bitWidth: 7
-PCROP1BER:
+PCROP1[AB]SR:
   _modify:
-    PCROP1B_END:
+    PCROP1[AB]_STRT:
       bitWidth: 9
-PCROP1BSR:
+PCROP1[AB]ER:
   _modify:
-    PCROP1B_STRT:
-      bitWidth: 9
-PCROP1ASR:
-  _modify:
-    PCROP1A_STRT:
-      bitWidth: 9
-PCROP1AER:
-  _modify:
-    PCROP1A_END:
+    PCROP1[AB]_END:
       bitWidth: 9

--- a/devices/patches/rcc/c0_bit_width.yaml
+++ b/devices/patches/rcc/c0_bit_width.yaml
@@ -1,0 +1,4 @@
+CSR1:
+  _modify:
+    LSEDRV:
+      bitWidth: 1

--- a/devices/patches/rcc/c0_rst_val.yaml
+++ b/devices/patches/rcc/c0_rst_val.yaml
@@ -1,0 +1,9 @@
+_modify:
+  IOPSMENR:
+    resetValue: 0x2F
+  CR:
+    resetValue: 0x1540
+  AHBSMENR:
+    resetValue: 0x1301
+  APBSMENR1:
+    resetValue: 0x186F7C03

--- a/devices/stm32c011.yaml
+++ b/devices/stm32c011.yaml
@@ -44,6 +44,8 @@ EXTI:
 
 FLASH:
   _strip: FLASH_
+  _include:
+    - patches/flash/c0_bit_width.yaml
 
 GPIO?:
   _strip: GPIO?_
@@ -72,6 +74,9 @@ PWR:
 
 RCC:
   _strip: RCC_
+  _include:
+    - patches/rcc/c0_rst_val.yaml
+    - patches/rcc/c0_bit_width.yaml
 
 RTC:
   _strip: RTC_

--- a/devices/stm32c031.yaml
+++ b/devices/stm32c031.yaml
@@ -48,6 +48,8 @@ EXTI:
 
 FLASH:
   _strip: FLASH_
+  _include:
+    - patches/flash/c0_bit_width.yaml
 
 GPIO?:
   _strip: GPIO?_
@@ -76,6 +78,8 @@ PWR:
 
 RCC:
   _strip: RCC_
+  _include:
+    - patches/rcc/c0_rst_val.yaml
 
 RTC:
   _strip: RTC_

--- a/devices/stm32c051.yaml
+++ b/devices/stm32c051.yaml
@@ -1,0 +1,12 @@
+_svd: ../svd/stm32c051.svd
+
+DBG:
+  _strip: DBG_
+  _modify:
+    IDCODE:
+      resetValue: 0x1000044C
+
+FLASH:
+  _strip: FLASH_
+  _include:
+    - patches/flash/c0_bit_width.yaml

--- a/devices/stm32c051.yaml
+++ b/devices/stm32c051.yaml
@@ -5,6 +5,7 @@ DBG:
   _modify:
     IDCODE:
       resetValue: 0x1000044C
+      resetMask: 0xFFFFFFFF
 
 FLASH:
   _strip: FLASH_

--- a/devices/stm32c071.yaml
+++ b/devices/stm32c071.yaml
@@ -38,6 +38,7 @@ DBG:
   _modify:
     IDCODE:
       resetValue: 0x10000493
+      resetMask: 0xFFFFFFFF
 
 DMA:
   _strip: DMA_

--- a/devices/stm32c071.yaml
+++ b/devices/stm32c071.yaml
@@ -35,6 +35,9 @@ CRS:
 
 DBG:
   _strip: DBG_
+  _modify:
+    IDCODE:
+      resetValue: 0x10000493
 
 DMA:
   _strip: DMA_
@@ -58,6 +61,8 @@ EXTI:
 
 FLASH:
   _strip: FLASH_
+  _include:
+    - patches/flash/c0_bit_width.yaml
 
 GPIO?:
   _strip: GPIO?_
@@ -86,6 +91,8 @@ PWR:
 
 RCC:
   _strip: RCC_
+  _include:
+    - patches/rcc/c0_rst_val.yaml
 
 RTC:
   _strip: RTC_

--- a/devices/stm32c091.yaml
+++ b/devices/stm32c091.yaml
@@ -1,0 +1,12 @@
+_svd: ../svd/stm32c091.svd
+
+DBG:
+  _strip: DBG_
+  _modify:
+    IDCODE:
+      resetValue: 0x1000044D
+
+FLASH:
+  _strip: FLASH_
+  _include:
+    - patches/flash/c0_bit_width.yaml

--- a/devices/stm32c091.yaml
+++ b/devices/stm32c091.yaml
@@ -5,6 +5,7 @@ DBG:
   _modify:
     IDCODE:
       resetValue: 0x1000044D
+      resetMask: 0xFFFFFFFF
 
 FLASH:
   _strip: FLASH_

--- a/devices/stm32c092.yaml
+++ b/devices/stm32c092.yaml
@@ -1,0 +1,12 @@
+_svd: ../svd/stm32c092.svd
+
+DBG:
+  _strip: DBG_
+  _modify:
+    IDCODE:
+      resetValue: 0x1000044D
+
+FLASH:
+  _strip: FLASH_
+  _include:
+    - patches/flash/c0_bit_width.yaml

--- a/devices/stm32c092.yaml
+++ b/devices/stm32c092.yaml
@@ -5,6 +5,7 @@ DBG:
   _modify:
     IDCODE:
       resetValue: 0x1000044D
+      resetMask: 0xFFFFFFFF
 
 FLASH:
   _strip: FLASH_


### PR DESCRIPTION
Updated reset values for registers in the RCC and DBG peripherals, and bit widths in the FLASH peripheral. The new values are taken from the RM0490 reference manual.