### PR TITLE
Add TIM12 peripheral for STM32H523

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Family-specific:
 
 * H5:
   * Update archive to v1.9
+  * TIM: Add missing TIM12 peripheral to STM32H523
 
 * H7:
   * Update archive to v2.8

--- a/devices/stm32h523.yaml
+++ b/devices/stm32h523.yaml
@@ -1,5 +1,10 @@
 _svd: ../svd/stm32h523.svd
 
+# TIM12 is omitted from stm32h523.svd
+_copy:
+    TIM12:
+        from: ../svd/stm32h533.svd:TIM12
+
 _clear_fields: "*"
 
 _derive:
@@ -314,6 +319,16 @@ TIM4:
 TIM6:
   _include:
     - fields/tim/v3/tim6.yaml
+
+TIM12:
+  _include:
+    - patches/tim/sms.yaml
+    - patches/tim/ts.yaml
+    - patches/tim/mms.yaml
+    - patches/tim/v2/oc1m.yaml
+    - patches/tim/v2/oc2m.yaml
+    - fields/tim/v3/tim9.yaml
+    - collect/tim/ccr.yaml
 
 TIM15:
   _include:


### PR DESCRIPTION
The TIM12 peripheral is entirely missing from the STM32H523 SVD, but is included on the chip per the datasheet. I've generated the TIM12 entry from the STM32H533 SVD using svdtools, and included the patch in stm32h523.yaml. I've confirmed that the generated rust code is the same as that for the STM32H533 crate.