### PR TITLE
usb v3: make CHEP?R fields DTOGRX, DTOGTX readable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Family-specific:
 * H5:
   * Update archive to v1.9
   * TIM: Add missing TIM12 peripheral to STM32H523
+  * USB: CHEPnR.DTOGRX and DTOGTX are now also readable (#1291)
 
 * H7:
   * Update archive to v2.8

--- a/devices/fields/usb/v3.yaml
+++ b/devices/fields/usb/v3.yaml
@@ -15,6 +15,8 @@ LPMCSR:
     Ack: [1, The valid LPM Token will be ACK / ACK answer]
 CHEP?R:
   _modify:
+    DTOG[RT]X:
+      access: read-write
     STAT[RT]X:
       access: read-write
   STATTX:
@@ -34,6 +36,9 @@ CHEP?R:
     _W1T:
       Keep: [0, Do not change bits]
   DTOGTX:
+    _read:
+      Send0: [0, The next data packet transmitted will have the data toggle bit set to 0.]
+      Send1: [1, The next data packet transmitted will have the data toggle bit set to 1.]
     _W1T:
       Toggle: [1, Flip bit]
   VTTX:
@@ -61,6 +66,9 @@ CHEP?R:
     _W1T:
       Keep: [0, Do not change bits]
   DTOGRX:
+    _read:
+      Expect0: [0, The next data packet received is expected to have the data toggle bit set to 0.]
+      Expect1: [1, The next data packet received is expected to have the data toggle bit set to 1.]
     _W1T:
       Toggle: [1, Flip bit]
   VTRX:


### PR DESCRIPTION
In some situations, it might be necessary to set the next data toggle bit to be transmitted, or the next data toggle bit to be expected on receive, to a specific value; since the bit can only be toggled, its current state must be read to decide whether to toggle it or not.

According to ST RM0481, the two fields are "read/write but [...] can only be toggled by writing 1", i.e. they do return a meaningful value when read.