### PR TITLE
rcc v3: add NoReset state to reset registers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Family-specific:
 
 * H5:
   * Update archive to v1.9
+  * RCC: Add NoReset variant to reset fields (#1292)
   * TIM: Add missing TIM12 peripheral to STM32H523
   * USB: CHEPnR.DTOGRX and DTOGTX are now also readable (#1291)
 

--- a/devices/fields/rcc/v3/common.yaml
+++ b/devices/fields/rcc/v3/common.yaml
@@ -70,6 +70,7 @@ BDCR:
     "On": [1, LSE oscillator On]
 "A?B?RSTR,A?B??RSTR":
   "*RST":
+    NoReset: [0, Stop resetting the selected module]
     Reset: [1, Reset the selected module]
 RSR,C1_RSR:
   "*RSTF":


### PR DESCRIPTION
According to RM0481 (STM32H523 and others), the reset registers are set and reset by software, which means programs need regular access to both values 1 (reset the peripheral) and 0 (do not reset/stop resetting the peripheral).

The current setup (only value 1 is easily accessible) makes sense for RCC variants where the reset bit is set to 0 by hardware once the reset is complete, but v3 appears not to be one of them.